### PR TITLE
Made notebook documentation links point to github over local files.

### DIFF
--- a/notebook/1_Deploy_Retail_Shopping_Assistant.ipynb
+++ b/notebook/1_Deploy_Retail_Shopping_Assistant.ipynb
@@ -814,7 +814,7 @@
    "metadata": {},
    "source": [
     "If you are deploying the solution on an NVIDIA Brev instance, return to the Brev documentation and resume from Step 14: Access the Web Interface.\n",
-    "- [Brev Guide](retail-shopping-assistant/docs/BREV.md#step-14-access-the-web-interface)\n"
+    "- [Brev Guide](https://github.com/NVIDIA-AI-Blueprints/retail-shopping-assistant/blob/main/docs/BREV.md)\n"
    ]
   },
   {
@@ -875,9 +875,9 @@
     "5. **Monitor Performance**: Use the built-in monitoring and analytics features\n",
     "\n",
     "For detailed customization and development guides, see:\n",
-    "- [User Guide](retail-shopping-assistant/docs/USER_GUIDE.md)\n",
-    "- [API Documentation](retail-shopping-assistant/docs/API.md)\n",
-    "- [Deployment Guide](retail-shopping-assistant/docs/DEPLOYMENT.md)"
+    "- [User Guide](https://github.com/NVIDIA-AI-Blueprints/retail-shopping-assistant/blob/main/docs/USER_GUIDE.md)\n",
+    "- [API Documentation](https://github.com/NVIDIA-AI-Blueprints/retail-shopping-assistant/blob/main/docs/API.md)\n",
+    "- [Deployment Guide](https://github.com/NVIDIA-AI-Blueprints/retail-shopping-assistant/blob/main/docs/DEPLOYMENT.md)"
    ]
   },
   {


### PR DESCRIPTION
Changed documentation links within the notebook to point to Github. This avoids issues with relative paths that were arising from the Launchable.