### PR TITLE
refact: Replace langchain with OpenAI library in ChatterAgent for consistency

### DIFF
--- a/chain_server/requirements.txt
+++ b/chain_server/requirements.txt
@@ -20,7 +20,6 @@ jsonpatch==1.33
 jsonpointer==3.0.0
 langchain==0.3.27
 langchain-core==0.3.74
-langchain-nvidia-ai-endpoints==0.3.16
 langchain-text-splitters==0.3.9
 langgraph==0.5.3
 langgraph-checkpoint==2.1.0


### PR DESCRIPTION
- Replaced langchain_nvidia_ai_endpoints.ChatNVIDIA with openai.AsyncOpenAI in the chatter agent to maintain consistency across all agents while preserving async streaming functionality. All agents now use the same OpenAI library.