### PR TITLE
Stabilize local NIM deploy on shared GPU 2

### DIFF
--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -6,12 +6,12 @@ version: '3.8'
 services:
 
   nemotron:
-    image: nvcr.io/nim/nvidia/nemotron-3-super-120b-a12b:latest
+    image: nvcr.io/nim/nvidia/nemotron-3-super-120b-a12b:2.0.4
     ports:
       - "8000:8000"
     environment:
       - NGC_API_KEY=${NGC_API_KEY}
-      - NIM_PASSTHROUGH_ARGS=--enable-auto-tool-choice --tool-call-parser llama3_json
+      - NIM_PASSTHROUGH_ARGS=--enable-auto-tool-choice --tool-call-parser pythonic
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
     user: "${UID:-1000}"
@@ -45,6 +45,12 @@ services:
     restart: "no"
     networks:
       - shopping-network
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/v1/health/ready').read()"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 60s
 
   embedqa:
     image: nvcr.io/nim/nvidia/nv-embedqa-e5-v5:1.6
@@ -65,6 +71,9 @@ services:
     restart: "no"
     networks:
       - shopping-network
+    depends_on:
+      nvclip:
+        condition: service_healthy
 
   content:
     image: nvcr.io/nim/nvidia/llama-3.1-nemoguard-8b-content-safety:1.10.1


### PR DESCRIPTION
- Pin nemotron-3-super-120b-a12b to 2.0.4. Floating :latest pulled in a newer vLLM that eagerly validates Llama-3 special tokens against the Nemotron tokenizer at request time, causing every chat-completion call with tools to 500.
- Switch the vLLM tool-call parser from llama3_json to pythonic. The chain-server already extracts Nemotron tool calls from message.content via parse_tool_call_fallback, so the vLLM parser only needs to satisfy --enable-auto-tool-choice without binding to model-specific tokens.
- Add a python3-based readiness healthcheck on nvclip and have embedqa depends_on: condition: service_healthy. nvclip and embedqa share GPU 2; starting them concurrently caused embedqa's TensorRT engine deserialization to drop to CPU and exit with "TensorRT model requested for CPU". Sequencing them removes the CUDA-init race. (curl is not present in the nvclip image, hence the urllib check.)