### PR TITLE
Reduce vLLM max concurrent sequences to prevent Mamba cache allocation failures on dual H100 80GB GPUs

### DIFF
--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -11,7 +11,7 @@ services:
       - "8000:8000"
     environment:
       - NGC_API_KEY=${NGC_API_KEY}
-      - NIM_PASSTHROUGH_ARGS=--enable-auto-tool-choice --tool-call-parser pythonic
+      - NIM_PASSTHROUGH_ARGS=--enable-auto-tool-choice --tool-call-parser pythonic --max-num-seqs 256
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
     user: "${UID:-1000}"


### PR DESCRIPTION
Reduce vLLM concurrent sequence allocation for Nemotron 120B deployment on dual H100 80GB GPUs.

The default vLLM configuration attempted to allocate:

max_num_seqs=1024

which exceeded the available Mamba cache blocks during engine initialization:

ValueError: max_num_seqs (1024) exceeds available Mamba cache blocks (524)

This caused the NIM/vLLM engine to fail startup on 2x H100 80GB HBM3 systems.