### PR TITLE
Harden vulnerability scan inputs

### DIFF
--- a/.bdignore
+++ b/.bdignore
@@ -1,0 +1,14 @@
+/chain_server/venv/
+/catalog_retriever/venv/
+/guardrails/venv/
+/memory_retriever/venv/
+/ui/node_modules/
+/ui/build/
+/catalog_retriever/volumes/
+/.local-run/
+/tests/.pytest_cache/
+/tests/htmlcov/
+/tests/integration/conversations/shopping/results/
+/tests/integration/conversations/shopping/judge/
+/tests/integration/conversations/rails/results/
+/tests/integration/conversations/rails/judge/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ wheels/
 
 # Virtual environments
 venv/
+**/venv/
+.venv/
+**/.venv/
 env/
 ENV/
 

--- a/LICENSE-3rd-party.txt
+++ b/LICENSE-3rd-party.txt
@@ -102,7 +102,7 @@ below.
    langgraph-checkpoint 4.1.1
    Copyright (c) 2022 Harrison Chase
 
-   langgraph-prebuilt 1.0.13
+   langgraph-prebuilt 1.0.12
    Copyright (c) 2022 Harrison Chase
 
    langgraph-sdk 0.3.15

--- a/LICENSE-3rd-party.txt
+++ b/LICENSE-3rd-party.txt
@@ -90,7 +90,7 @@ below.
    langchain-core 1.3.3
    Copyright (c) 2022 Harrison Chase
 
-   langchain-nvidia-ai-endpoints 1.3.0
+   langchain-nvidia-ai-endpoints 1.4.0
    Copyright (c) 2022 Harrison Chase
 
    langchain-text-splitters 1.1.2

--- a/catalog_retriever/requirements.txt
+++ b/catalog_retriever/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.4.7
 click==8.2.1
 distro==1.9.0
 fastapi==0.136.3
-fonttools>=4.61.1
+fonttools==4.63.0
 greenlet==3.2.3
 grpcio==1.67.1
 h11==0.16.0

--- a/catalog_retriever/requirements.txt
+++ b/catalog_retriever/requirements.txt
@@ -4,7 +4,7 @@ certifi==2026.5.20
 charset-normalizer==3.4.7
 click==8.2.1
 distro==1.9.0
-fastapi==0.136.3
+fastapi==0.136.1
 fonttools==4.63.0
 greenlet==3.2.3
 grpcio==1.67.1

--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -89,7 +89,7 @@ class Milvus:
     """
     Minimal Milvus adapter for the catalog retriever.
 
-    This keeps the small langchain-milvus API surface used by the retriever
+    This keeps the small vector-store API surface used by the retriever
     while relying directly on pymilvus so the vulnerable wrapper dependency is
     not required at runtime.
     """

--- a/chain_server/requirements.txt
+++ b/chain_server/requirements.txt
@@ -22,7 +22,7 @@ jsonpointer==3.1.1
 langchain-core==1.3.3
 langchain-text-splitters==1.1.2
 langgraph==1.1.10
-langgraph-prebuilt==1.0.13
+langgraph-prebuilt==1.0.12
 langgraph-sdk==0.3.15
 langsmith==0.8.8
 multidict==6.7.1

--- a/chain_server/requirements.txt
+++ b/chain_server/requirements.txt
@@ -9,7 +9,7 @@ click==8.2.1
 distro==1.9.0
 fastapi==0.136.3
 filetype==1.2.0
-fonttools>=4.61.1
+fonttools==4.63.0
 frozenlist==1.7.0
 greenlet==3.2.3
 h11==0.16.0

--- a/chain_server/requirements.txt
+++ b/chain_server/requirements.txt
@@ -7,7 +7,7 @@ certifi==2026.5.20
 charset-normalizer==3.4.7
 click==8.2.1
 distro==1.9.0
-fastapi==0.136.3
+fastapi==0.136.1
 filetype==1.2.0
 fonttools==4.63.0
 frozenlist==1.7.0

--- a/guardrails/src/requirements.txt
+++ b/guardrails/src/requirements.txt
@@ -3,7 +3,7 @@ uvicorn==0.35.0
 nemoguardrails==0.22.0
 pydantic==2.13.4
 langchain-core==1.3.3
-langchain-nvidia-ai-endpoints==1.3.0
+langchain-nvidia-ai-endpoints==1.4.0
 aiofiles==24.1.0
 openai==1.97.0
 starlette==1.0.1

--- a/guardrails/src/requirements.txt
+++ b/guardrails/src/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.136.3
+fastapi==0.136.1
 uvicorn==0.35.0
 nemoguardrails==0.22.0
 pydantic==2.13.4

--- a/memory_retriever/requirements.txt
+++ b/memory_retriever/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.7.0
 anyio==4.13.0
 click==8.2.1
-fastapi==0.136.3
+fastapi==0.136.1
 greenlet==3.2.3
 h11==0.16.0
 idna==3.17

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -14,7 +14,7 @@ pytest-cov>=5.0
 pydantic>=2.13
 
 # FastAPI TestClient is used for memory_retriever HTTP tests.
-fastapi>=0.136
+fastapi==0.136.1
 httpx>=0.27
 
 # HTTP client mocked in chain_server tests.

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -33,7 +33,7 @@ Pillow>=12.2
 
 # Needed by chain_server.graph / chain_server.chatter on import.
 langgraph==1.1.10
-langgraph-prebuilt==1.0.13
+langgraph-prebuilt==1.0.12
 langgraph-sdk==0.3.15
 langchain-core==1.3.3
 


### PR DESCRIPTION
## Summary
- Add `.bdignore` so Black Duck signature scans skip generated local artifacts (`venv/`, `node_modules/`, build output, Milvus volumes, and test outputs) that can retain stale vulnerable dependency metadata outside the committed dependency manifests.
- Avoid the scanner-flagged `fastapi==0.136.3` release by pinning runtime services and test dev requirements to `fastapi==0.136.1`. Keep `starlette==1.0.1` pinned for the BadHost fix.
- Avoid the scanner-flagged `langgraph-prebuilt==1.0.13` release by pinning `langgraph-prebuilt==1.0.12` in chain-server and unit-test requirements while keeping `langgraph==1.1.10` and `langchain-core==1.3.3`.
- Pin backend `fonttools` requirements to `4.63.0` for deterministic package-audit resolution.
- Remove the leftover source comment reference to the removed LangChain Milvus wrapper package.

## FastAPI scanner note
- OSV entry `MAL-2026-4750` documents the Amazon Inspector finding against exactly `fastapi 0.136.3`, citing the undocumented `fastar>=0.9.0` optional dependency added to that release. The OSV entry is now withdrawn, but because scanners can still surface the version-specific component finding, this PR moves the repo off `0.136.3` entirely.
- Current service manifests now use `fastapi==0.136.1` and `starlette==1.0.1`.

## LangGraph scanner note
- The repo did not have `langgraph==1.0.13`; the `1.0.13` component was `langgraph-prebuilt==1.0.13`.
- `langgraph-prebuilt==1.1.0` conflicts with the current `langgraph==1.1.10` and would require `langgraph==1.2.2` plus `langchain-core==1.4.0`, so this PR removes the flagged `1.0.13` version with the compatible `langgraph-prebuilt==1.0.12` pin instead.

## Validation
- `pip-audit --no-deps --disable-pip -r chain_server/requirements.txt -f json`: no known vulnerabilities found; reports `fastapi==0.136.1`, `langgraph==1.1.10`, `langgraph-prebuilt==1.0.12`, and `langchain-core==1.3.3`.
- `pip-audit --no-deps --disable-pip -r catalog_retriever/requirements.txt -f json`: no known vulnerabilities found; reports `fastapi==0.136.1`.
- `pip-audit --no-deps --disable-pip -r guardrails/src/requirements.txt -f json`: no known vulnerabilities found; reports `fastapi==0.136.1`.
- `pip-audit --no-deps --disable-pip -r memory_retriever/requirements.txt -f json`: no known vulnerabilities found; reports `fastapi==0.136.1`.
- `npm audit --audit-level=high`: passed; remaining npm audit findings are moderate React tooling issues.
- `python skills/retail-test-runner/scripts/run_retail_tests.py unit`: 404 passed.
- `docker compose -f docker-compose.yaml build chain-server catalog-retriever rails memory-retriever`: passed.
- `docker compose -f docker-compose.yaml build chain-server`: passed after the LangGraph-prebuilt pin.
- Built images report `fastapi==0.136.1` and `starlette==1.0.1` for chain-server, catalog-retriever, rails, and memory-retriever.
- Built chain-server image reports `langgraph==1.1.10`, `langgraph-prebuilt==1.0.12`, `langgraph-sdk==0.3.15`, and `langchain-core==1.3.3`.
- Built images report `fonttools==4.63.0`, `langchain-core==1.3.3`, and catalog `pymilvus==2.6.0`.
