### PR TITLE
docs: mark nvclip as deprecated for cloud deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ For detailed architecture information, see [Architecture Overview](docs/README.m
    docker compose -f docker-compose.yaml up -d --build
    ```
 
+   > **⚠️ `nvclip` is deprecated.** Its hosted endpoint on the NVIDIA API Catalog (`api.build.nvidia.com`) is no longer available, so image (visual) search does **not** work under Option B as-is. **Workaround:** deploy `nvclip` as a local NIM (from `docker-compose-nim-local.yaml`) and point `image_embed_port` at it — see the [Deployment Guide](docs/DEPLOYMENT.md).
+
 5. **Access the application**: Open your browser to `http://localhost:3000`
 
 6. **Stop the containers**:
@@ -179,7 +181,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ### Related Projects
 - [NVIDIA Retrieval QA](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nv-embedqa-e5-v5): Embedding model for semantic search
-- [NV-CLIP](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nvclip): Visual understanding model
+- [NV-CLIP](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nvclip): Visual understanding model _(deprecated — hosted/cloud endpoint no longer available; run as a local NIM)_
 - [Nemotron 3 Super](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-3-super-120b-a12b): Large language model
 
 ## License

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -97,6 +97,8 @@ This guide covers deploying the Retail Shopping Assistant in various environment
 - Data privacy considerations
 - API rate limits
 
+> **⚠️ `nvclip` is deprecated.** Its hosted endpoint on the NVIDIA API Catalog (`api.build.nvidia.com`) is no longer available, so image (visual) search does **not** work under Cloud NIM Deployment as-is. **Workaround:** run `nvclip` as a local NIM (from `docker-compose-nim-local.yaml`) and point `image_embed_port` at the local container, even when other endpoints stay on the cloud.
+
 ### Option 3: Hybrid Deployment
 
 **Best for**: Production with mixed requirements
@@ -478,6 +480,8 @@ text_model_name: "nvidia/nv-embedqa-e5-v5"
 image_embed_port: "https://api.build.nvidia.com/v1"
 image_model_name: "nvidia/nvclip"
 ```
+
+> **⚠️ `nvclip` is deprecated.** The hosted `api.build.nvidia.com` endpoint for `nvclip` is no longer available, so the cloud image-embedding config above will not work as-is. **Workaround:** deploy `nvclip` as a local NIM (from `docker-compose-nim-local.yaml`) and set `image_embed_port` to the local container (e.g. `http://nvclip:8000/v1`).
 
 **Guardrails Override** (`guardrails/config/config-build.yml`):
 ```yaml


### PR DESCRIPTION
nvclip's hosted endpoint on the NVIDIA API Catalog (api.build.nvidia.com) is no longer available, so image/visual search does not work under the Cloud Deployment path (README "Option B" / DEPLOYMENT.md Cloud NIM, config-build.yaml) as-is.

Add deprecation callouts to README.md and docs/DEPLOYMENT.md, each with a one-line workaround pointer: run nvclip as a local NIM (from docker-compose-nim-local.yaml) and point image_embed_port at the local container.