### PR TITLE
Add internal commerce contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The Brev deployment guide walks you through the entire process from creating a L
 
 - **[User Guide](docs/USER_GUIDE.md)**: How to use the application
 - **[API Documentation](docs/API.md)**: Complete API reference
+- **[Commerce Contracts](docs/COMMERCE_CONTRACTS.md)**: Internal product, cart, and commerce tool contracts
 - **[Deployment Guide](docs/DEPLOYMENT.md)**: Installation and setup instructions
 - **[Testing and Evaluation](tests/README.md)**: Unit, integration, and Challenger/Judge evaluation workflows
 - **[Documentation Hub](docs/README.md)**: Complete documentation index

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -1,0 +1,94 @@
+# Commerce Contracts
+
+This document defines the first internal contract layer for commerce tools. It
+is intentionally independent of ACP, UCP, and any future protocol plugin. Those
+protocols should map into these app-owned contracts through thin adapters later.
+
+## Goals
+
+- Give agents, tools, tests, and future protocol adapters one stable shape for
+  products, carts, and tool results.
+- Move commerce behavior toward deterministic tools instead of agent-specific
+  prose parsing.
+- Preserve the current runtime behavior while creating a safe path toward a
+  Deep Agents runtime.
+
+## Purpose Of This PR
+
+This PR establishes the internal commerce language that later tools will use. It
+does not make the current assistant more capable by itself; it gives the next
+PRs a small, reviewed target for product identity, cart identity, tool metadata,
+and structured errors.
+
+The main design decision is separation:
+
+- Product/catalog search is read-only and stateless.
+- Cart operations are stateful and mutating.
+- Store-policy lookup is read-only and controlled.
+- ACP/UCP mappings are future adapter concerns, not core model fields.
+
+## Current Phase
+
+Phase 1 is contract-only. The models live in `shared/commerce_contracts.py` and
+are not wired into the chain server runtime yet.
+
+This means:
+
+- No user-facing behavior changes.
+- No cart or catalog service schema changes yet.
+- Existing LangGraph agents continue to run as they do today.
+
+## Core Models
+
+| Model | Purpose |
+| --- | --- |
+| `Money` | Currency amount with a default `USD` currency. |
+| `ProductSummary` | Search-result-safe product identity and display fields. |
+| `ProductDetail` | Full product shape with variants and optional source URI. |
+| `ProductVariant` | Variant identity, options, price, and availability. |
+| `StorePolicy` | Controlled store-policy content such as returns or shipping. |
+| `CartLine` | Cart row keyed by `cart_line_id`, `product_id`, and optional `variant_id`. |
+| `Cart` | User cart with structured lines and optional subtotal. |
+| `CommerceError` | Structured tool error with code, message, retryability, and details. |
+| `ToolMeta` | Trace and idempotency metadata returned by tools. |
+
+## Tool Contracts
+
+The first tool contract set is:
+
+| Contract | Type | Purpose |
+| --- | --- | --- |
+| `SearchCatalogInput` / `SearchCatalogResult` | Read-only | Find products by query, category, filters, and `top_k`. |
+| `GetProductDetailsInput` / `GetProductDetailsResult` | Read-only | Fetch one product by stable `product_id`. |
+| `GetCartInput` / `GetCartResult` | Read-only | Read the authoritative cart for a user. |
+| `GetStorePolicyInput` / `GetStorePolicyResult` | Read-only | Fetch controlled store-policy text by topic. |
+| `AddCartItemInput` / `CartMutationResult` | Mutating | Add a product or variant to the cart. |
+| `UpdateCartItemInput` / `CartMutationResult` | Mutating | Change cart-line quantity. Quantity `0` means remove. |
+| `RemoveCartItemInput` / `CartMutationResult` | Mutating | Remove a cart line. |
+
+Mutating inputs require `idempotency_key` so future agent retries and protocol
+adapters can avoid duplicate cart changes.
+
+### Stateless Catalog Search
+
+`SearchCatalogInput` intentionally has no `user_id`, cart, memory, session, or
+conversation-history fields. The agent layer can use conversation context to
+decide what query, categories, and filters to send, but `search_catalog` itself
+should remain a pure read against the catalog for the supplied request.
+
+This keeps product search reusable by the current LangGraph retriever, future
+Deep Agents subagents, and later protocol adapters without coupling catalog
+results to shopper session state.
+
+## Migration Direction
+
+The next phases should wrap existing behavior behind these contracts without
+changing the public API first:
+
+1. Make `RetrieverAgent` call an internal `search_catalog` tool wrapper.
+2. Make `CartAgent` call internal cart tool wrappers.
+3. Preserve catalog IDs in chain-server state and cart memory rows.
+4. Add Deep Agents skills and subagents on top of the same tool layer.
+
+The important rule is that ACP/UCP compatibility should be added as adapters
+around these contracts, not as fields or naming choices inside the core models.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 
 ### 🔧 Technical Documentation
 - **[API Documentation](API.md)** - Complete API reference
+- **[Commerce Contracts](COMMERCE_CONTRACTS.md)** - Internal product, cart, and commerce tool contracts
 - **[Architecture Overview](../README.md#architecture)** - System design and components
 - **[Configuration Guide](../README.md#configuration)** - Settings and customization
 
@@ -34,6 +35,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 | Document | Description | Audience |
 |----------|-------------|----------|
 | [API Documentation](API.md) | Complete API reference with examples | Developers, integrators |
+| [Commerce Contracts](COMMERCE_CONTRACTS.md) | Internal product, cart, and commerce tool contracts | Developers, architects |
 | [Deployment Guide](DEPLOYMENT.md) | Installation and deployment instructions | DevOps, system administrators |
 | [Architecture Overview](../README.md#architecture) | System design and component details | Architects, developers |
 | [Configuration Guide](../README.md#configuration) | Settings and customization options | Developers, administrators |

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal commerce contracts for agent-facing tools.
+
+These models define the app's stable product, cart, and tool result shapes.
+They intentionally avoid protocol-specific ACP/UCP fields so those protocols
+can be added later as adapter layers instead of driving the core design.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+Availability = Literal["in_stock", "out_of_stock", "preorder", "backorder", "unknown"]
+
+
+class CommerceModel(BaseModel):
+    """Base model for commerce contracts."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class Money(CommerceModel):
+    amount: float = Field(..., ge=0, description="Decimal currency amount.")
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+
+
+class ProductVariant(CommerceModel):
+    variant_id: str = Field(..., min_length=1)
+    product_id: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1)
+    options: dict[str, str] = Field(default_factory=dict)
+    availability: Availability = "unknown"
+    price: Money | None = None
+
+
+class ProductSummary(CommerceModel):
+    product_id: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1)
+    description: str = ""
+    category: str | None = None
+    brand: str | None = None
+    price: Money | None = None
+    image_url: str | None = None
+    availability: Availability = "unknown"
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProductDetail(ProductSummary):
+    variants: list[ProductVariant] = Field(default_factory=list)
+    source_uri: str | None = None
+
+
+class StorePolicy(CommerceModel):
+    policy_id: str = Field(..., min_length=1)
+    topic: str = Field(..., min_length=1)
+    title: str = Field(..., min_length=1)
+    body: str = Field(..., min_length=1)
+    source_uri: str | None = None
+
+
+class CartLine(CommerceModel):
+    cart_line_id: str = Field(..., min_length=1)
+    product_id: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1)
+    quantity: int = Field(..., ge=1)
+    variant_id: str | None = None
+    unit_price: Money | None = None
+    image_url: str | None = None
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class Cart(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    lines: list[CartLine] = Field(default_factory=list)
+    subtotal: Money | None = None
+
+
+class CommerceError(CommerceModel):
+    code: str = Field(..., min_length=1)
+    message: str = Field(..., min_length=1)
+    retryable: bool = False
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolMeta(CommerceModel):
+    trace_id: str | None = None
+    idempotency_key: str | None = None
+
+
+class SearchCatalogInput(CommerceModel):
+    """Stateless catalog search input.
+
+    This contract intentionally excludes user, cart, and conversation context.
+    Agents may use context to decide what query to send, but the catalog search
+    tool itself should behave as a pure read for the supplied request fields.
+    """
+
+    query: str = ""
+    categories: list[str] = Field(default_factory=list)
+    filters: dict[str, Any] = Field(default_factory=dict)
+    top_k: int = Field(default=4, ge=1, le=50)
+
+
+class SearchCatalogResult(CommerceModel):
+    ok: bool
+    products: list[ProductSummary] = Field(default_factory=list)
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class GetProductDetailsInput(CommerceModel):
+    product_id: str = Field(..., min_length=1)
+
+
+class GetProductDetailsResult(CommerceModel):
+    ok: bool
+    product: ProductDetail | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class GetCartInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+
+
+class GetCartResult(CommerceModel):
+    ok: bool
+    cart: Cart | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class GetStorePolicyInput(CommerceModel):
+    topic: str = Field(..., min_length=1)
+
+
+class GetStorePolicyResult(CommerceModel):
+    ok: bool
+    policy: StorePolicy | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class AddCartItemInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    product_id: str = Field(..., min_length=1)
+    quantity: int = Field(..., ge=1)
+    idempotency_key: str = Field(..., min_length=1)
+    variant_id: str | None = None
+
+
+class UpdateCartItemInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    cart_line_id: str = Field(..., min_length=1)
+    quantity: int = Field(..., ge=0)
+    idempotency_key: str = Field(..., min_length=1)
+
+
+class RemoveCartItemInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    cart_line_id: str = Field(..., min_length=1)
+    idempotency_key: str = Field(..., min_length=1)
+
+
+class CartMutationResult(CommerceModel):
+    ok: bool
+    cart: Cart | None = None
+    changed_line: CartLine | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)

--- a/tests/unit/shared/test_commerce_contracts.py
+++ b/tests/unit/shared/test_commerce_contracts.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from shared.commerce_contracts import (
+    AddCartItemInput,
+    Cart,
+    CartLine,
+    Money,
+    ProductSummary,
+    SearchCatalogResult,
+)
+
+
+def test_product_summary_requires_stable_product_id() -> None:
+    product = ProductSummary(
+        product_id="prod_123",
+        display_name="Classic Black Patent Leather Purse",
+        price=Money(amount=89.99),
+        availability="in_stock",
+    )
+
+    assert product.product_id == "prod_123"
+    assert product.model_dump()["price"]["currency"] == "USD"
+
+
+def test_cart_line_quantity_must_be_positive() -> None:
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        CartLine(
+            cart_line_id="line_1",
+            product_id="prod_123",
+            display_name="Classic Black Patent Leather Purse",
+            quantity=0,
+        )
+
+
+def test_mutating_cart_input_requires_idempotency_key() -> None:
+    with pytest.raises(ValidationError, match="idempotency_key"):
+        AddCartItemInput(
+            user_id="user_1",
+            product_id="prod_123",
+            quantity=1,
+        )
+
+
+def test_contracts_reject_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ProductSummary(
+            product_id="prod_123",
+            display_name="Classic Black Patent Leather Purse",
+            unsupported_field=True,
+        )
+
+
+def test_search_result_serializes_structured_products() -> None:
+    cart = Cart(
+        user_id="user_1",
+        lines=[
+            CartLine(
+                cart_line_id="line_1",
+                product_id="prod_123",
+                display_name="Classic Black Patent Leather Purse",
+                quantity=1,
+                unit_price=Money(amount=89.99),
+            )
+        ],
+        subtotal=Money(amount=89.99),
+    )
+    result = SearchCatalogResult(
+        ok=True,
+        products=[
+            ProductSummary(
+                product_id=cart.lines[0].product_id,
+                display_name=cart.lines[0].display_name,
+            )
+        ],
+    )
+
+    dumped = result.model_dump()
+    assert dumped["products"][0]["product_id"] == "prod_123"
+    assert dumped["products"][0]["display_name"] == cart.lines[0].display_name


### PR DESCRIPTION
# PR: Add internal commerce contracts

Base: `staging`

Head: `commerce-contracts-phase-1`

## Title

Add internal commerce contracts

## Description

### Summary

Adds a contract-only foundation for future commerce tools and Deep Agents
migration work. The new contracts define stable internal product, cart, policy,
tool-result, and error shapes without changing runtime behavior.

The purpose is to agree on the internal commerce language before moving current
cart/search behavior into tools. This keeps later ACP/UCP support as optional
adapter layers rather than protocol-specific core design.

### What Changed

- `shared/commerce_contracts.py`
  - Adds Pydantic models for `Money`, products, variants, cart lines, carts,
    store policies, structured commerce errors, tool metadata, catalog search
    results, product-detail results, cart-read results, policy results, and
    cart mutation inputs/results.
  - Defines `SearchCatalogInput` as stateless: no user, cart, session, memory,
    or conversation-history fields.
  - Requires `idempotency_key` on mutating cart inputs.
  - Forbids unknown fields so future tool inputs fail fast instead of silently
    accepting drift.

- `tests/unit/shared/test_commerce_contracts.py`
  - Adds focused unit tests for stable product identity, positive cart-line
    quantities, required idempotency keys, unknown-field rejection, and
    structured serialization.

- `docs/COMMERCE_CONTRACTS.md`
  - Documents the internal contract layer, current contract-only phase, tool
    contract set, and migration path toward deterministic tools and future
    Deep Agents support.

- `README.md`
  - Links to the new commerce contracts documentation.

- `docs/README.md`
  - Adds the commerce contracts doc to the documentation hub and developer
    documentation table.

### Validation

- `pytest -q tests/unit/shared`
- `python -m py_compile shared/commerce_contracts.py`
- `git diff --check`

### Notes

- No runtime behavior changes.
- No cart, catalog, or API wiring changes.
- ACP/UCP are intentionally not modeled in these core contracts; future
  protocol support should be added as adapter layers.
