### PR TITLE
Add commerce tools for Deep Agents setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The Brev deployment guide walks you through the entire process from creating a L
 
 - **[User Guide](docs/USER_GUIDE.md)**: How to use the application
 - **[API Documentation](docs/API.md)**: Complete API reference
+- **[Commerce Contracts](docs/COMMERCE_CONTRACTS.md)**: Internal product, cart, and commerce tool contracts
 - **[Deployment Guide](docs/DEPLOYMENT.md)**: Installation and setup instructions
 - **[Testing and Evaluation](tests/README.md)**: Unit, integration, and Challenger/Judge evaluation workflows
 - **[Documentation Hub](docs/README.md)**: Complete documentation index

--- a/chain_server/src/cart.py
+++ b/chain_server/src/cart.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .agenttypes import Cart, State
+from .commerce_tools import add_cart_item, get_cart, remove_cart_item, search_catalog
 from .functions import (
     add_to_cart_function,
     bulk_add_to_cart_function,
@@ -11,6 +12,12 @@ from .functions import (
     view_cart_total_function,
     parse_tool_call_fallback,
 )
+from shared.commerce_contracts import (
+    AddCartItemInput,
+    GetCartInput,
+    RemoveCartItemInput,
+    SearchCatalogInput,
+)
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 import os
@@ -18,10 +25,9 @@ import json
 import logging
 import re
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 import sys
 import time
+import uuid
 from typing import Any, Optional
 from langgraph.config import get_stream_writer
 
@@ -170,20 +176,25 @@ class CartAgent():
         self.model = OpenAI(base_url=config.llm_port, api_key=self.llm_api_key)
         self.catalog_retriever_port = config.retriever_port
         self.categories = config.categories
-        self.retry_strategy = Retry(
-                total=3,                    
-                status_forcelist=[422, 429, 500, 502, 503, 504],  
-                allowed_methods=["POST"],   
-                backoff_factor=1            
-            )
         logging.info(f"CartAgent.__init__() | Initialization complete")
         
     def _get_cart(self, user_id: int) -> Cart:
-        response = requests.get(f"{self.memory_retriever_url}/user/{user_id}/cart")
-        logging.info(f"CartAgent._get_cart() | Response text: {response.text}.")
-        if response.status_code == 200:
-            cart_data = json.loads(response.text)["cart"]
+        result = get_cart(
+            GetCartInput(user_id=str(user_id)),
+            self.memory_retriever_url,
+        )
+        if result.ok and result.cart:
+            cart_data = [
+                {
+                    "item": line.display_name,
+                    "amount": line.quantity,
+                    "price": line.unit_price.amount if line.unit_price else None,
+                }
+                for line in result.cart.lines
+            ]
             return Cart(contents=cart_data)
+        if result.error:
+            logging.error(f"CartAgent._get_cart() | {result.error.message}")
         return Cart(contents=[])
 
     _CATALOG_LOOKUP_K = 5
@@ -196,25 +207,25 @@ class CartAgent():
         record is present even when embedding similarity ranks it below
         the top hit.
         """
-        adapter = HTTPAdapter(max_retries=self.retry_strategy)
-        session = requests.Session()
-        session.mount("https://", adapter)
-        session.mount("http://", adapter)
-        logging.info(f"CartAgent._lookup_in_catalog() | /query/text -- query: {item_name}")
-        ret_response = session.post(
-            f"{self.catalog_retriever_port}/query/text",
-            json={
-                "text": [item_name],
-                "categories": self.categories,
-                "k": self._CATALOG_LOOKUP_K,
-            },
+        logging.info(f"CartAgent._lookup_in_catalog() | search_catalog -- query: {item_name}")
+        result = search_catalog(
+            SearchCatalogInput(
+                query=item_name,
+                categories=self.categories,
+                top_k=self._CATALOG_LOOKUP_K,
+            ),
+            self.catalog_retriever_port,
         )
-        ret_response.raise_for_status()
-        res_json = ret_response.json()
-        names = res_json.get("names") or []
-        similarities = res_json.get("similarities") or []
-        texts = res_json.get("texts") or []
+        if not result.ok:
+            if result.error:
+                logging.error(f"CartAgent._lookup_in_catalog() | {result.error.message}")
+            return None
 
+        names = [product.display_name for product in result.products]
+        similarities = [
+            float(product.attributes.get("similarity") or 0.0)
+            for product in result.products
+        ]
         match_idx = _resolve_catalog_match(item_name, names, similarities)
         if match_idx is None:
             logging.info(
@@ -223,13 +234,19 @@ class CartAgent():
             )
             return None
 
+        product = result.products[match_idx]
         similarity = similarities[match_idx] if match_idx < len(similarities) else 0.0
-        text = texts[match_idx] if match_idx < len(texts) else None
+        text = product.attributes.get("catalog_text") or product.description
         logging.info(
             f"CartAgent._lookup_in_catalog() | query='{item_name}' -> "
-            f"matched='{names[match_idx]}' sim={similarity}"
+            f"matched='{product.display_name}' sim={similarity}"
         )
-        return {"name": names[match_idx], "text": text, "similarity": similarity}
+        return {
+            "name": product.display_name,
+            "product": product,
+            "text": text,
+            "similarity": similarity,
+        }
 
     def _add_to_cart(self, user_id: int, item_name: str, quantity: int) -> str:
         match = self._lookup_in_catalog(item_name)
@@ -237,16 +254,23 @@ class CartAgent():
             return f"No such item ({item_name}) could be found in the catalog."
 
         catalog_item_name = match["name"]
-        price = _extract_price(match.get("text"))
-        payload = {"item": catalog_item_name, "amount": quantity}
-        if price is not None:
-            payload["price"] = price
-        response = requests.post(
-            f"{self.memory_retriever_url}/user/{user_id}/cart/add",
-            json=payload,
+        product = match["product"]
+        result = add_cart_item(
+            AddCartItemInput(
+                user_id=str(user_id),
+                product_id=product.product_id,
+                display_name=catalog_item_name,
+                quantity=quantity,
+                idempotency_key=str(uuid.uuid4()),
+                unit_price=product.price,
+                image_url=product.image_url,
+            ),
+            self.memory_retriever_url,
         )
-        if response.status_code == 200:
-            return response.json()["message"]
+        if result.ok:
+            return result.message
+        if result.error:
+            return result.error.message
         return f"Failed to add {quantity} {catalog_item_name} to cart."
 
     def _view_cart_total(self, user_id: int) -> str:
@@ -293,12 +317,22 @@ class CartAgent():
             return f"No such item ({item_name}) could be found in the catalog."
 
         catalog_item_name = match["name"]
-        response = requests.post(
-            f"{self.memory_retriever_url}/user/{user_id}/cart/remove",
-            json={"item": catalog_item_name, "amount": quantity},
+        product = match["product"]
+        result = remove_cart_item(
+            RemoveCartItemInput(
+                user_id=str(user_id),
+                cart_line_id=catalog_item_name,
+                product_id=product.product_id,
+                display_name=catalog_item_name,
+                quantity=quantity,
+                idempotency_key=str(uuid.uuid4()),
+            ),
+            self.memory_retriever_url,
         )
-        if response.status_code == 200:
-            return response.json()["message"]
+        if result.ok:
+            return result.message
+        if result.error:
+            return result.error.message
         return f"Failed to remove {quantity} {catalog_item_name} from cart."
 
     @staticmethod

--- a/chain_server/src/cart.py
+++ b/chain_server/src/cart.py
@@ -175,6 +175,9 @@ class CartAgent():
         self.memory_retriever_url = config.memory_port
         self.model = OpenAI(base_url=config.llm_port, api_key=self.llm_api_key)
         self.catalog_retriever_port = config.retriever_port
+        self.catalog_search_timeout_seconds = getattr(
+            config, "catalog_search_timeout_seconds", None
+        )
         self.categories = config.categories
         logging.info(f"CartAgent.__init__() | Initialization complete")
         
@@ -215,6 +218,7 @@ class CartAgent():
                 top_k=self._CATALOG_LOOKUP_K,
             ),
             self.catalog_retriever_port,
+            timeout_seconds=self.catalog_search_timeout_seconds,
         )
         if not result.ok:
             if result.error:

--- a/chain_server/src/commerce_tools.py
+++ b/chain_server/src/commerce_tools.py
@@ -18,9 +18,16 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from shared.commerce_contracts import (
+    AddCartItemInput,
+    Cart,
+    CartLine,
+    CartMutationResult,
     CommerceError,
+    GetCartInput,
+    GetCartResult,
     Money,
     ProductSummary,
+    RemoveCartItemInput,
     SearchCatalogInput,
     SearchCatalogResult,
 )
@@ -96,6 +103,156 @@ def search_catalog(
     return SearchCatalogResult(ok=True, products=_products_from_catalog_response(data))
 
 
+def get_cart(
+    request: GetCartInput,
+    memory_retriever_url: str,
+    *,
+    timeout_seconds: float = 10,
+    session: Any | None = None,
+) -> GetCartResult:
+    """Read the authoritative cart for a shopper from the memory service."""
+
+    http = session or requests
+    try:
+        response = http.get(
+            f"{memory_retriever_url.rstrip('/')}/user/{request.user_id}/cart",
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as exc:
+        return GetCartResult(
+            ok=False,
+            error=CommerceError(
+                code="cart_read_failed",
+                message="Cart read request failed.",
+                retryable=True,
+                details={"error": str(exc)},
+            ),
+        )
+    except ValueError as exc:
+        return GetCartResult(
+            ok=False,
+            error=CommerceError(
+                code="cart_response_invalid",
+                message="Cart read returned an invalid response.",
+                details={"error": str(exc)},
+            ),
+        )
+
+    return GetCartResult(
+        ok=True,
+        cart=_cart_from_memory_items(str(request.user_id), data.get("cart") or []),
+    )
+
+
+def add_cart_item(
+    request: AddCartItemInput,
+    memory_retriever_url: str,
+    *,
+    timeout_seconds: float = 10,
+    session: Any | None = None,
+) -> CartMutationResult:
+    """Add one item to the shopper cart through the memory service adapter."""
+
+    display_name = request.display_name or request.product_id
+    payload: dict[str, Any] = {"item": display_name, "amount": request.quantity}
+    if request.unit_price is not None:
+        payload["price"] = request.unit_price.amount
+
+    http = session or requests
+    try:
+        response = http.post(
+            f"{memory_retriever_url.rstrip('/')}/user/{request.user_id}/cart/add",
+            json=payload,
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as exc:
+        return CartMutationResult(
+            ok=False,
+            error=CommerceError(
+                code="cart_add_failed",
+                message=f"Failed to add {request.quantity} {display_name} to cart.",
+                details={"error": str(exc)},
+            ),
+        )
+    except ValueError as exc:
+        return CartMutationResult(
+            ok=False,
+            error=CommerceError(
+                code="cart_response_invalid",
+                message="Cart add returned an invalid response.",
+                details={"error": str(exc)},
+            ),
+        )
+
+    return CartMutationResult(
+        ok=True,
+        changed_line=CartLine(
+            cart_line_id=display_name,
+            product_id=request.product_id,
+            display_name=display_name,
+            quantity=request.quantity,
+            variant_id=request.variant_id,
+            unit_price=request.unit_price,
+            image_url=request.image_url,
+        ),
+        message=str(data.get("message") or ""),
+    )
+
+
+def remove_cart_item(
+    request: RemoveCartItemInput,
+    memory_retriever_url: str,
+    *,
+    timeout_seconds: float = 10,
+    session: Any | None = None,
+) -> CartMutationResult:
+    """Remove quantity from a cart line through the memory service adapter."""
+
+    display_name = request.display_name or request.cart_line_id
+    http = session or requests
+    try:
+        response = http.post(
+            f"{memory_retriever_url.rstrip('/')}/user/{request.user_id}/cart/remove",
+            json={"item": display_name, "amount": request.quantity},
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as exc:
+        return CartMutationResult(
+            ok=False,
+            error=CommerceError(
+                code="cart_remove_failed",
+                message=f"Failed to remove {request.quantity} {display_name} from cart.",
+                details={"error": str(exc)},
+            ),
+        )
+    except ValueError as exc:
+        return CartMutationResult(
+            ok=False,
+            error=CommerceError(
+                code="cart_response_invalid",
+                message="Cart remove returned an invalid response.",
+                details={"error": str(exc)},
+            ),
+        )
+
+    return CartMutationResult(
+        ok=True,
+        changed_line=CartLine(
+            cart_line_id=request.cart_line_id,
+            product_id=request.product_id or display_name,
+            display_name=display_name,
+            quantity=request.quantity,
+        ),
+        message=str(data.get("message") or ""),
+    )
+
+
 def _query_terms(request: SearchCatalogInput) -> list[str]:
     if request.queries:
         return [query.strip() for query in request.queries if query.strip()]
@@ -125,9 +282,13 @@ def _products_from_catalog_response(data: dict[str, Any]) -> list[ProductSummary
     similarities = data.get("similarities") or []
 
     products: list[ProductSummary] = []
-    for text, product_id, name, image_url, similarity in zip(
-        texts, ids, names, images, similarities
-    ):
+    item_count = max(len(texts), len(ids), len(names), len(images), len(similarities))
+    for idx in range(item_count):
+        text = _list_get(texts, idx, "")
+        name = _list_get(names, idx, "")
+        product_id = _list_get(ids, idx, name)
+        image_url = _list_get(images, idx, None)
+        similarity = _float_or_default(_list_get(similarities, idx, 0.0), 0.0)
         if not product_id or not name:
             continue
         products.append(
@@ -140,11 +301,66 @@ def _products_from_catalog_response(data: dict[str, Any]) -> list[ProductSummary
                 image_url=str(image_url) if image_url else None,
                 attributes={
                     "catalog_text": str(text or ""),
-                    "similarity": float(similarity),
+                    "similarity": similarity,
                 },
             )
         )
     return products
+
+
+def _cart_from_memory_items(user_id: str, items: list[dict[str, Any]]) -> Cart:
+    lines = [_cart_line_from_memory_item(item) for item in items]
+    lines = [line for line in lines if line is not None]
+
+    subtotal: Money | None = None
+    if lines and all(line.unit_price is not None for line in lines):
+        subtotal = Money(
+            amount=sum(
+                line.unit_price.amount * line.quantity
+                for line in lines
+                if line.unit_price is not None
+            )
+        )
+
+    return Cart(user_id=user_id, lines=lines, subtotal=subtotal)
+
+
+def _cart_line_from_memory_item(item: dict[str, Any]) -> CartLine | None:
+    display_name = str(item.get("item") or "").strip()
+    if not display_name:
+        return None
+    quantity = _int_or_default(item.get("amount"), 0)
+    if quantity <= 0:
+        return None
+
+    price = _float_or_default(item.get("price"), None)
+    return CartLine(
+        cart_line_id=display_name,
+        product_id=str(item.get("product_id") or display_name),
+        display_name=display_name,
+        quantity=quantity,
+        unit_price=Money(amount=price) if price is not None else None,
+    )
+
+
+def _list_get(values: list[Any], idx: int, default: Any) -> Any:
+    return values[idx] if idx < len(values) else default
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_or_default(value: Any, default: float | None) -> float | None:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _price_from_text(text: str) -> Money | None:

--- a/chain_server/src/commerce_tools.py
+++ b/chain_server/src/commerce_tools.py
@@ -14,6 +14,8 @@ import re
 from typing import Any
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from shared.commerce_contracts import (
     CommerceError,
@@ -41,9 +43,9 @@ def search_catalog(
     does not accept ``user_id``, cart state, or memory context.
     """
 
-    query = request.query.strip()
+    query_terms = _query_terms(request)
     image = request.image_base64.strip()
-    if not query and not image:
+    if not query_terms and not image:
         return SearchCatalogResult(
             ok=False,
             error=CommerceError(
@@ -54,7 +56,7 @@ def search_catalog(
 
     endpoint = "query/image" if image else "query/text"
     payload: dict[str, Any] = {
-        "text": [query] if query else [],
+        "text": query_terms,
         "categories": request.categories,
         "filters": request.filters,
         "k": request.top_k,
@@ -62,7 +64,7 @@ def search_catalog(
     if image:
         payload["image_base64"] = image
 
-    http = session or requests.Session()
+    http = session or _catalog_session()
     try:
         response = http.post(
             f"{catalog_retriever_url.rstrip('/')}/{endpoint}",
@@ -94,6 +96,27 @@ def search_catalog(
     return SearchCatalogResult(ok=True, products=_products_from_catalog_response(data))
 
 
+def _query_terms(request: SearchCatalogInput) -> list[str]:
+    if request.queries:
+        return [query.strip() for query in request.queries if query.strip()]
+    query = request.query.strip()
+    return [query] if query else []
+
+
+def _catalog_session() -> requests.Session:
+    retry_strategy = Retry(
+        total=3,
+        status_forcelist=[422, 429, 500, 502, 503, 504],
+        allowed_methods=["POST"],
+        backoff_factor=1,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
 def _products_from_catalog_response(data: dict[str, Any]) -> list[ProductSummary]:
     texts = data.get("texts") or []
     ids = data.get("ids") or []
@@ -115,7 +138,10 @@ def _products_from_catalog_response(data: dict[str, Any]) -> list[ProductSummary
                 category=_category_from_text(str(text or "")),
                 price=_price_from_text(str(text or "")),
                 image_url=str(image_url) if image_url else None,
-                attributes={"similarity": float(similarity)},
+                attributes={
+                    "catalog_text": str(text or ""),
+                    "similarity": float(similarity),
+                },
             )
         )
     return products

--- a/chain_server/src/commerce_tools.py
+++ b/chain_server/src/commerce_tools.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal commerce tool wrappers used by agent runtimes.
+
+These functions are deliberately small adapters around existing services. They
+return shared commerce contracts so current LangGraph agents, future Deep
+Agents tools, and later protocol adapters can share the same typed boundary.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import requests
+
+from shared.commerce_contracts import (
+    CommerceError,
+    Money,
+    ProductSummary,
+    SearchCatalogInput,
+    SearchCatalogResult,
+)
+
+
+_PRICE_RE = re.compile(r"\bPRICE:\s*\$?([0-9][0-9,]*(?:\.[0-9]+)?)", re.IGNORECASE)
+
+
+def search_catalog(
+    request: SearchCatalogInput,
+    catalog_retriever_url: str,
+    *,
+    timeout_seconds: float = 10,
+    session: requests.Session | None = None,
+) -> SearchCatalogResult:
+    """Search the product catalog without using shopper session state.
+
+    The caller may use conversation context to build ``request``, but this tool
+    only reads the catalog for the supplied query/image/categories/filters. It
+    does not accept ``user_id``, cart state, or memory context.
+    """
+
+    query = request.query.strip()
+    image = request.image_base64.strip()
+    if not query and not image:
+        return SearchCatalogResult(
+            ok=False,
+            error=CommerceError(
+                code="invalid_search_request",
+                message="Catalog search requires a query or image.",
+            ),
+        )
+
+    endpoint = "query/image" if image else "query/text"
+    payload: dict[str, Any] = {
+        "text": [query] if query else [],
+        "categories": request.categories,
+        "filters": request.filters,
+        "k": request.top_k,
+    }
+    if image:
+        payload["image_base64"] = image
+
+    http = session or requests.Session()
+    try:
+        response = http.post(
+            f"{catalog_retriever_url.rstrip('/')}/{endpoint}",
+            json=payload,
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as exc:
+        return SearchCatalogResult(
+            ok=False,
+            error=CommerceError(
+                code="catalog_request_failed",
+                message="Catalog search request failed.",
+                retryable=True,
+                details={"error": str(exc)},
+            ),
+        )
+    except ValueError as exc:
+        return SearchCatalogResult(
+            ok=False,
+            error=CommerceError(
+                code="catalog_response_invalid",
+                message="Catalog search returned an invalid response.",
+                details={"error": str(exc)},
+            ),
+        )
+
+    return SearchCatalogResult(ok=True, products=_products_from_catalog_response(data))
+
+
+def _products_from_catalog_response(data: dict[str, Any]) -> list[ProductSummary]:
+    texts = data.get("texts") or []
+    ids = data.get("ids") or []
+    names = data.get("names") or []
+    images = data.get("images") or []
+    similarities = data.get("similarities") or []
+
+    products: list[ProductSummary] = []
+    for text, product_id, name, image_url, similarity in zip(
+        texts, ids, names, images, similarities
+    ):
+        if not product_id or not name:
+            continue
+        products.append(
+            ProductSummary(
+                product_id=str(product_id),
+                display_name=str(name),
+                description=_strip_price(str(text or "")),
+                category=_category_from_text(str(text or "")),
+                price=_price_from_text(str(text or "")),
+                image_url=str(image_url) if image_url else None,
+                attributes={"similarity": float(similarity)},
+            )
+        )
+    return products
+
+
+def _price_from_text(text: str) -> Money | None:
+    match = _PRICE_RE.search(text)
+    if not match:
+        return None
+    try:
+        return Money(amount=float(match.group(1).replace(",", "")))
+    except ValueError:
+        return None
+
+
+def _strip_price(text: str) -> str:
+    return _PRICE_RE.sub("", text).strip()
+
+
+def _category_from_text(text: str) -> str | None:
+    before_price = text.split("PRICE:", 1)[0]
+    parts = [part.strip() for part in before_price.split("|")]
+    if len(parts) < 3:
+        return None
+    category = parts[-1].split(",", 1)[0].strip()
+    return category or None

--- a/chain_server/src/commerce_tools.py
+++ b/chain_server/src/commerce_tools.py
@@ -30,6 +30,7 @@ from shared.commerce_contracts import (
     RemoveCartItemInput,
     SearchCatalogInput,
     SearchCatalogResult,
+    ToolMeta,
 )
 
 
@@ -40,7 +41,7 @@ def search_catalog(
     request: SearchCatalogInput,
     catalog_retriever_url: str,
     *,
-    timeout_seconds: float = 10,
+    timeout_seconds: float | None = None,
     session: requests.Session | None = None,
 ) -> SearchCatalogResult:
     """Search the product catalog without using shopper session state.
@@ -177,6 +178,7 @@ def add_cart_item(
                 message=f"Failed to add {request.quantity} {display_name} to cart.",
                 details={"error": str(exc)},
             ),
+            meta=ToolMeta(idempotency_key=request.idempotency_key),
         )
     except ValueError as exc:
         return CartMutationResult(
@@ -186,6 +188,7 @@ def add_cart_item(
                 message="Cart add returned an invalid response.",
                 details={"error": str(exc)},
             ),
+            meta=ToolMeta(idempotency_key=request.idempotency_key),
         )
 
     return CartMutationResult(
@@ -200,6 +203,7 @@ def add_cart_item(
             image_url=request.image_url,
         ),
         message=str(data.get("message") or ""),
+        meta=ToolMeta(idempotency_key=request.idempotency_key),
     )
 
 
@@ -230,6 +234,7 @@ def remove_cart_item(
                 message=f"Failed to remove {request.quantity} {display_name} from cart.",
                 details={"error": str(exc)},
             ),
+            meta=ToolMeta(idempotency_key=request.idempotency_key),
         )
     except ValueError as exc:
         return CartMutationResult(
@@ -239,6 +244,7 @@ def remove_cart_item(
                 message="Cart remove returned an invalid response.",
                 details={"error": str(exc)},
             ),
+            meta=ToolMeta(idempotency_key=request.idempotency_key),
         )
 
     return CartMutationResult(
@@ -250,6 +256,7 @@ def remove_cart_item(
             quantity=request.quantity,
         ),
         message=str(data.get("message") or ""),
+        meta=ToolMeta(idempotency_key=request.idempotency_key),
     )
 
 

--- a/chain_server/src/config.py
+++ b/chain_server/src/config.py
@@ -53,6 +53,13 @@ class ChainServerConfig(BaseModel):
     # Performance Configuration
     memory_length: int = Field(..., description="Maximum memory length for context")
     top_k_retrieve: int = Field(..., description="Number of top results to retrieve")
+    catalog_search_timeout_seconds: Optional[float] = Field(
+        default=None,
+        description=(
+            "Optional HTTP timeout for catalog search requests. None preserves "
+            "the previous no-timeout behavior for slower remote embedding calls."
+        ),
+    )
     multimodal: bool = Field(..., description="Whether multimodal features are enabled")
     
     # Safety Configuration
@@ -77,6 +84,13 @@ class ChainServerConfig(BaseModel):
         """Validate top_k_retrieve is positive."""
         if v <= 0:
             raise ValueError("top_k_retrieve must be positive")
+        return v
+
+    @validator('catalog_search_timeout_seconds')
+    def validate_catalog_search_timeout(cls, v):
+        """Validate optional catalog search timeout."""
+        if v is not None and v <= 0:
+            raise ValueError("catalog_search_timeout_seconds must be positive")
         return v
     
     @validator('categories', 'agent_choices')
@@ -115,6 +129,7 @@ def load_config(config_path: Optional[str] = None) -> ChainServerConfig:
         "retriever_port": os.environ.get("CATALOG_RETRIEVER_URL"),
         "memory_port": os.environ.get("MEMORY_RETRIEVER_URL"),
         "rails_port": os.environ.get("RAILS_URL"),
+        "catalog_search_timeout_seconds": os.environ.get("CATALOG_SEARCH_TIMEOUT_SECONDS"),
     }
     config_data.update({key: value for key, value in env_overrides.items() if value})
 

--- a/chain_server/src/retriever.py
+++ b/chain_server/src/retriever.py
@@ -45,6 +45,9 @@ class RetrieverAgent():
         
         # Store configuration
         self.catalog_retriever_url = config.retriever_port
+        self.catalog_search_timeout_seconds = getattr(
+            config, "catalog_search_timeout_seconds", None
+        )
         self.k_value = config.top_k_retrieve
         self.categories = config.categories
         
@@ -94,6 +97,7 @@ class RetrieverAgent():
                     top_k=k,
                 ),
                 self.catalog_retriever_url,
+                timeout_seconds=self.catalog_search_timeout_seconds,
             )
             fallback_used = False
 
@@ -116,6 +120,7 @@ class RetrieverAgent():
                             top_k=k,
                         ),
                         self.catalog_retriever_url,
+                        timeout_seconds=self.catalog_search_timeout_seconds,
                     )
                     if fallback_result.products:
                         result = fallback_result

--- a/chain_server/src/retriever.py
+++ b/chain_server/src/retriever.py
@@ -8,13 +8,12 @@ the catalog retriever service to find relevant products.
 """
 
 from .agenttypes import State
+from .commerce_tools import search_catalog
 from .functions import retrieval_extraction_function, parse_tool_call_fallback
+from shared.commerce_contracts import SearchCatalogInput
 from openai import OpenAI
 import os
 import json
-import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 import sys
 from typing import Tuple, List, Dict, Any
 import asyncio
@@ -74,61 +73,31 @@ class RetrieverAgent():
         end = time.monotonic()
         state.timings["retriever_categories"] = end - start
         
-        # Query the catalog retriever service
+        # Query the catalog through the internal commerce tool boundary.
         start = time.monotonic()
         try:
-
-            retry_strategy = Retry(
-                total=3,                    
-                status_forcelist=[422, 429, 500, 502, 503, 504],  
-                allowed_methods=["POST"],   
-                backoff_factor=1            
+            search_query = " ".join(entities)
+            logging.info(
+                "RetrieverAgent.invoke() | search_catalog -- getting response\n"
+                f"\t| query: {search_query}\n"
+                f"\t| image: {'yes' if image else 'no'}\n"
+                f"\t| categories: {categories}\n"
+                f"\t| filters: {filters}"
             )
-            
-            adapter = HTTPAdapter(max_retries=retry_strategy)
-            session = requests.Session()
-            session.mount("https://", adapter)
-            session.mount("http://", adapter)
-
-            if image:
-                logging.info(
-                    "RetrieverAgent.invoke() | /query/image -- getting response.\n"
-                    f"\t| entities: {entities}\n"
-                    f"\t| categories: {categories}\n"
-                    f"\t| filters: {filters}"
-                )
-                response = session.post(
-                    f"{self.catalog_retriever_url}/query/image",
-                    json={
-                        "text": entities,
-                        "image_base64": image,
-                        "categories": categories,
-                        "filters": filters,
-                        "k": k
-                    }
-                )
-            else:
-                logging.info(
-                    "RetrieverAgent.invoke() | /query/text -- getting response\n"
-                    f"\t| query: {entities}\n"
-                    f"\t| categories: {categories}\n"
-                    f"\t| filters: {filters}"
-                )
-                response = session.post(
-                    f"{self.catalog_retriever_url}/query/text",
-                    json={
-                        "text": entities,
-                        "categories": categories,
-                        "filters": filters,
-                        "k": k
-                    }
-                )
-
-            response.raise_for_status()
-            results = response.json()
+            result = search_catalog(
+                SearchCatalogInput(
+                    query=search_query,
+                    queries=entities,
+                    image_base64=image,
+                    categories=categories,
+                    filters=filters,
+                    top_k=k,
+                ),
+                self.catalog_retriever_url,
+            )
             fallback_used = False
 
-            if not image and not results.get("texts") and categories:
+            if not image and not result.products and categories:
                 fallback_entities = [
                     category for category in categories
                     if category in self.categories
@@ -138,28 +107,30 @@ class RetrieverAgent():
                         "RetrieverAgent.invoke() | No exact text results; "
                         f"retrying with category fallback: {fallback_entities}"
                     )
-                    fallback_response = session.post(
-                        f"{self.catalog_retriever_url}/query/text",
-                        json={
-                            "text": fallback_entities,
-                            "categories": categories,
-                            "filters": filters,
-                            "k": k
-                        }
+                    fallback_result = search_catalog(
+                        SearchCatalogInput(
+                            query=" ".join(fallback_entities),
+                            queries=fallback_entities,
+                            categories=categories,
+                            filters=filters,
+                            top_k=k,
+                        ),
+                        self.catalog_retriever_url,
                     )
-                    fallback_response.raise_for_status()
-                    fallback_results = fallback_response.json()
-                    if fallback_results.get("texts"):
-                        results = fallback_results
+                    if fallback_result.products:
+                        result = fallback_result
                         fallback_used = True
-            
-            # Format the response with product details
-            if results["texts"]:
-                products = []
+
+            if not result.ok:
+                state.response = "I encountered an error while searching for products. Please try again."
+            elif result.products:
+                # Format the response with product details
                 retrieved_dict = {}
-                for text, name, img, sim in zip(results["texts"], results["names"], results["images"], results["similarities"]):
-                    products.append(text)
-                    retrieved_dict[name] = img
+                products = []
+                for product in result.products:
+                    products.append(self._format_product_context(product))
+                    if product.image_url:
+                        retrieved_dict[product.display_name] = product.image_url
                 if fallback_used:
                     state.response = (
                         "No exact products closely matched the user's query. "
@@ -177,9 +148,9 @@ class RetrieverAgent():
             # Update context
             state.context = f"{state.context}\n{state.response}"
             
-        except requests.exceptions.RequestException as e:
+        except Exception as e:
             if verbose:
-                logging.error(f"RetrieverAgent.invoke() | Error querying catalog retriever service: {str(e)}")
+                logging.error(f"RetrieverAgent.invoke() | Error searching catalog: {str(e)}")
             state.response = "I encountered an error while searching for products. Please try again."
         end = time.monotonic()
         state.timings["retriever_retrieval"] = end - start
@@ -187,6 +158,17 @@ class RetrieverAgent():
         logging.info(f"RetrieverAgent.invoke() | Returning final state with response.")
 
         return state
+
+    @staticmethod
+    def _format_product_context(product) -> str:
+        catalog_text = product.attributes.get("catalog_text")
+        if isinstance(catalog_text, str) and catalog_text.strip():
+            return catalog_text
+
+        text = product.description or product.display_name
+        if product.price:
+            text = f"{text}\nPRICE: {product.price.amount}"
+        return text
 
     async def _extract_retrieval_inputs(self, state: State) -> Tuple[List[str], List[str], Dict[str, float]]:
         """

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -6,8 +6,8 @@ protocols should map into these app-owned contracts through thin adapters later.
 
 ## Goals
 
-- Give agents, tools, tests, and future protocol adapters one stable shape for
-  products, carts, and tool results.
+- Give agents, tools, tests, and future protocol adapters one consistent shape
+  for products, carts, and tool results.
 - Move commerce behavior toward deterministic tools instead of agent-specific
   prose parsing.
 - Preserve the current runtime behavior while creating a safe path toward a
@@ -38,6 +38,9 @@ path:
   removes.
 - Catalog search remains stateless: no user, cart, memory, session, or
   conversation-history fields are passed to `search_catalog`.
+- Catalog search timeout is configurable through
+  `catalog_search_timeout_seconds`. The default is `null`, preserving the
+  previous no-timeout catalog POST behavior for slower remote embedding calls.
 - Cart tools are stateful and adapt the current memory service API without
   changing the public service schema.
 
@@ -48,7 +51,7 @@ No ACP/UCP adapter layer has been added yet.
 | Model | Purpose |
 | --- | --- |
 | `Money` | Currency amount with a default `USD` currency. |
-| `ProductSummary` | Search-result-safe product identity and display fields. |
+| `ProductSummary` | Search-result-safe product display fields and current product identifier. |
 | `ProductDetail` | Full product shape with variants and optional source URI. |
 | `ProductVariant` | Variant identity, options, price, and availability. |
 | `StorePolicy` | Controlled store-policy content such as returns or shipping. |
@@ -64,7 +67,7 @@ The first tool contract set is:
 | Contract | Type | Purpose |
 | --- | --- | --- |
 | `SearchCatalogInput` / `SearchCatalogResult` | Read-only | Find products by query, category, filters, and `top_k`. |
-| `GetProductDetailsInput` / `GetProductDetailsResult` | Read-only | Fetch one product by stable `product_id`. |
+| `GetProductDetailsInput` / `GetProductDetailsResult` | Read-only | Reserved for fetching one product by durable `product_id` once the catalog exposes one. |
 | `GetCartInput` / `GetCartResult` | Read-only | Read the authoritative cart for a user. |
 | `GetStorePolicyInput` / `GetStorePolicyResult` | Read-only | Fetch controlled store-policy text by topic. |
 | `AddCartItemInput` / `CartMutationResult` | Mutating | Add a product or variant to the cart. |
@@ -72,7 +75,9 @@ The first tool contract set is:
 | `RemoveCartItemInput` / `CartMutationResult` | Mutating | Remove a cart line. |
 
 Mutating inputs require `idempotency_key` so future agent retries and protocol
-adapters can avoid duplicate cart changes.
+adapters have a stable key to enforce safe retries. In the current memory
+service adapter, the key is echoed in tool metadata but is not stored or used to
+deduplicate mutations yet.
 
 ### Stateless Catalog Search
 
@@ -86,6 +91,11 @@ This keeps product search reusable by the current LangGraph retriever, future
 Deep Agents subagents, and later protocol adapters without coupling catalog
 results to shopper session state.
 
+Current catalog search results map the retriever's returned `ids` field into
+`ProductSummary.product_id`. Those IDs are Milvus retriever primary keys and can
+change after reindexing. Treat them as transient catalog result IDs until the
+catalog import provides a durable product ID or SKU.
+
 ## Migration Direction
 
 The migration wraps existing behavior behind these contracts without changing
@@ -93,7 +103,8 @@ the public API first:
 
 1. `RetrieverAgent` calls an internal `search_catalog` tool wrapper.
 2. `CartAgent` calls internal cart tool wrappers.
-3. Preserve catalog IDs in chain-server state and cart memory rows.
+3. Preserve current catalog result IDs in chain-server state and cart memory
+   rows, while treating them as transient until durable catalog IDs are added.
 4. Add Deep Agents skills and subagents on top of the same tool layer.
 
 The important rule is that ACP/UCP compatibility should be added as adapters

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -103,8 +103,9 @@ the public API first:
 
 1. `RetrieverAgent` calls an internal `search_catalog` tool wrapper.
 2. `CartAgent` calls internal cart tool wrappers.
-3. Preserve current catalog result IDs in chain-server state and cart memory
-   rows, while treating them as transient until durable catalog IDs are added.
+3. Treat current catalog result IDs as transient `ProductSummary` and mutation
+   result fields only; durable ID persistence in chain-server state and cart
+   memory rows is future work.
 4. Add Deep Agents skills and subagents on top of the same tool layer.
 
 The important rule is that ACP/UCP compatibility should be added as adapters

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -73,8 +73,9 @@ adapters can avoid duplicate cart changes.
 
 `SearchCatalogInput` intentionally has no `user_id`, cart, memory, session, or
 conversation-history fields. The agent layer can use conversation context to
-decide what query, categories, and filters to send, but `search_catalog` itself
-should remain a pure read against the catalog for the supplied request.
+decide what query, optional image, categories, and filters to send, but
+`search_catalog` itself should remain a pure read against the catalog for the
+supplied request.
 
 This keeps product search reusable by the current LangGraph retriever, future
 Deep Agents subagents, and later protocol adapters without coupling catalog

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -73,9 +73,9 @@ adapters can avoid duplicate cart changes.
 
 `SearchCatalogInput` intentionally has no `user_id`, cart, memory, session, or
 conversation-history fields. The agent layer can use conversation context to
-decide what query, optional image, categories, and filters to send, but
-`search_catalog` itself should remain a pure read against the catalog for the
-supplied request.
+decide what query or query terms, optional image, categories, and filters to
+send, but `search_catalog` itself should remain a pure read against the catalog
+for the supplied request.
 
 This keeps product search reusable by the current LangGraph retriever, future
 Deep Agents subagents, and later protocol adapters without coupling catalog

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -1,0 +1,94 @@
+# Commerce Contracts
+
+This document defines the first internal contract layer for commerce tools. It
+is intentionally independent of ACP, UCP, and any future protocol plugin. Those
+protocols should map into these app-owned contracts through thin adapters later.
+
+## Goals
+
+- Give agents, tools, tests, and future protocol adapters one stable shape for
+  products, carts, and tool results.
+- Move commerce behavior toward deterministic tools instead of agent-specific
+  prose parsing.
+- Preserve the current runtime behavior while creating a safe path toward a
+  Deep Agents runtime.
+
+## Purpose Of This PR
+
+This PR establishes the internal commerce language that later tools will use. It
+does not make the current assistant more capable by itself; it gives the next
+PRs a small, reviewed target for product identity, cart identity, tool metadata,
+and structured errors.
+
+The main design decision is separation:
+
+- Product/catalog search is read-only and stateless.
+- Cart operations are stateful and mutating.
+- Store-policy lookup is read-only and controlled.
+- ACP/UCP mappings are future adapter concerns, not core model fields.
+
+## Current Phase
+
+Phase 1 is contract-only. The models live in `shared/commerce_contracts.py` and
+are not wired into the chain server runtime yet.
+
+This means:
+
+- No user-facing behavior changes.
+- No cart or catalog service schema changes yet.
+- Existing LangGraph agents continue to run as they do today.
+
+## Core Models
+
+| Model | Purpose |
+| --- | --- |
+| `Money` | Currency amount with a default `USD` currency. |
+| `ProductSummary` | Search-result-safe product identity and display fields. |
+| `ProductDetail` | Full product shape with variants and optional source URI. |
+| `ProductVariant` | Variant identity, options, price, and availability. |
+| `StorePolicy` | Controlled store-policy content such as returns or shipping. |
+| `CartLine` | Cart row keyed by `cart_line_id`, `product_id`, and optional `variant_id`. |
+| `Cart` | User cart with structured lines and optional subtotal. |
+| `CommerceError` | Structured tool error with code, message, retryability, and details. |
+| `ToolMeta` | Trace and idempotency metadata returned by tools. |
+
+## Tool Contracts
+
+The first tool contract set is:
+
+| Contract | Type | Purpose |
+| --- | --- | --- |
+| `SearchCatalogInput` / `SearchCatalogResult` | Read-only | Find products by query, category, filters, and `top_k`. |
+| `GetProductDetailsInput` / `GetProductDetailsResult` | Read-only | Fetch one product by stable `product_id`. |
+| `GetCartInput` / `GetCartResult` | Read-only | Read the authoritative cart for a user. |
+| `GetStorePolicyInput` / `GetStorePolicyResult` | Read-only | Fetch controlled store-policy text by topic. |
+| `AddCartItemInput` / `CartMutationResult` | Mutating | Add a product or variant to the cart. |
+| `UpdateCartItemInput` / `CartMutationResult` | Mutating | Change cart-line quantity. Quantity `0` means remove. |
+| `RemoveCartItemInput` / `CartMutationResult` | Mutating | Remove a cart line. |
+
+Mutating inputs require `idempotency_key` so future agent retries and protocol
+adapters can avoid duplicate cart changes.
+
+### Stateless Catalog Search
+
+`SearchCatalogInput` intentionally has no `user_id`, cart, memory, session, or
+conversation-history fields. The agent layer can use conversation context to
+decide what query, categories, and filters to send, but `search_catalog` itself
+should remain a pure read against the catalog for the supplied request.
+
+This keeps product search reusable by the current LangGraph retriever, future
+Deep Agents subagents, and later protocol adapters without coupling catalog
+results to shopper session state.
+
+## Migration Direction
+
+The next phases should wrap existing behavior behind these contracts without
+changing the public API first:
+
+1. Make `RetrieverAgent` call an internal `search_catalog` tool wrapper.
+2. Make `CartAgent` call internal cart tool wrappers.
+3. Preserve catalog IDs in chain-server state and cart memory rows.
+4. Add Deep Agents skills and subagents on top of the same tool layer.
+
+The important rule is that ACP/UCP compatibility should be added as adapters
+around these contracts, not as fields or naming choices inside the core models.

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -15,10 +15,10 @@ protocols should map into these app-owned contracts through thin adapters later.
 
 ## Purpose Of This PR
 
-This PR establishes the internal commerce language that later tools will use. It
-does not make the current assistant more capable by itself; it gives the next
-PRs a small, reviewed target for product identity, cart identity, tool metadata,
-and structured errors.
+This PR establishes the internal commerce language and starts routing current
+runtime behavior through it. It gives product search and cart operations a small,
+reviewed target for product identity, cart identity, tool metadata, and
+structured errors while preserving the existing public API.
 
 The main design decision is separation:
 
@@ -29,14 +29,19 @@ The main design decision is separation:
 
 ## Current Phase
 
-Phase 1 is contract-only. The models live in `shared/commerce_contracts.py` and
-are not wired into the chain server runtime yet.
+The stacked commerce-tool work now has runtime wiring for the current LangGraph
+path:
 
-This means:
+- `RetrieverAgent` calls the internal `search_catalog` tool wrapper for product
+  discovery.
+- `CartAgent` calls internal cart tool wrappers for cart reads, adds, and
+  removes.
+- Catalog search remains stateless: no user, cart, memory, session, or
+  conversation-history fields are passed to `search_catalog`.
+- Cart tools are stateful and adapt the current memory service API without
+  changing the public service schema.
 
-- No user-facing behavior changes.
-- No cart or catalog service schema changes yet.
-- Existing LangGraph agents continue to run as they do today.
+No ACP/UCP adapter layer has been added yet.
 
 ## Core Models
 
@@ -83,11 +88,11 @@ results to shopper session state.
 
 ## Migration Direction
 
-The next phases should wrap existing behavior behind these contracts without
-changing the public API first:
+The migration wraps existing behavior behind these contracts without changing
+the public API first:
 
-1. Make `RetrieverAgent` call an internal `search_catalog` tool wrapper.
-2. Make `CartAgent` call internal cart tool wrappers.
+1. `RetrieverAgent` calls an internal `search_catalog` tool wrapper.
+2. `CartAgent` calls internal cart tool wrappers.
 3. Preserve catalog IDs in chain-server state and cart memory rows.
 4. Add Deep Agents skills and subagents on top of the same tool layer.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -321,6 +321,7 @@ docker stack deploy -c docker-compose.prod.yaml retail-assistant
 | `LLM_API_KEY` | Language model API key | Yes | - |
 | `EMBED_API_KEY` | Embedding model API key | Yes | - |
 | `RAIL_API_KEY` | Guardrails API key | Yes | - |
+| `CATALOG_SEARCH_TIMEOUT_SECONDS` | Optional chain-server timeout for catalog search requests | No | no timeout |
 | `LOCAL_NIM_CACHE` | NIM cache directory | Local only | `~/.cache/nim` |
 | `LOG_LEVEL` | Logging level | No | `INFO` |
 | `NODE_ENV` | Node environment | No | `production` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 
 ### 🔧 Technical Documentation
 - **[API Documentation](API.md)** - Complete API reference
+- **[Commerce Contracts](COMMERCE_CONTRACTS.md)** - Internal product, cart, and commerce tool contracts
 - **[Architecture Overview](../README.md#architecture)** - System design and components
 - **[Configuration Guide](../README.md#configuration)** - Settings and customization
 
@@ -34,6 +35,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 | Document | Description | Audience |
 |----------|-------------|----------|
 | [API Documentation](API.md) | Complete API reference with examples | Developers, integrators |
+| [Commerce Contracts](COMMERCE_CONTRACTS.md) | Internal product, cart, and commerce tool contracts | Developers, architects |
 | [Deployment Guide](DEPLOYMENT.md) | Installation and deployment instructions | DevOps, system administrators |
 | [Architecture Overview](../README.md#architecture) | System design and component details | Architects, developers |
 | [Configuration Guide](../README.md#configuration) | Settings and customization options | Developers, administrators |

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -3,9 +3,11 @@
 
 """Internal commerce contracts for agent-facing tools.
 
-These models define the app's stable product, cart, and tool result shapes.
-They intentionally avoid protocol-specific ACP/UCP fields so those protocols
-can be added later as adapter layers instead of driving the core design.
+These models define the app's product, cart, and tool result shapes. The
+contracts are stable, but current adapters may still map legacy service fields
+such as transient catalog retriever IDs until durable product IDs are available.
+They intentionally avoid protocol-specific ACP/UCP fields so those protocols can
+be added later as adapter layers instead of driving the core design.
 """
 
 from __future__ import annotations
@@ -39,7 +41,14 @@ class ProductVariant(CommerceModel):
 
 
 class ProductSummary(CommerceModel):
-    product_id: str = Field(..., min_length=1)
+    product_id: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Product identifier. Current catalog search results may use a "
+            "transient retriever ID until the catalog supplies durable IDs."
+        ),
+    )
     display_name: str = Field(..., min_length=1)
     description: str = ""
     category: str | None = None

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -101,6 +101,7 @@ class SearchCatalogInput(CommerceModel):
     """
 
     query: str = ""
+    image_base64: str = ""
     categories: list[str] = Field(default_factory=list)
     filters: dict[str, Any] = Field(default_factory=dict)
     top_k: int = Field(default=4, ge=1, le=50)

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -154,6 +154,9 @@ class AddCartItemInput(CommerceModel):
     quantity: int = Field(..., ge=1)
     idempotency_key: str = Field(..., min_length=1)
     variant_id: str | None = None
+    display_name: str | None = None
+    unit_price: Money | None = None
+    image_url: str | None = None
 
 
 class UpdateCartItemInput(CommerceModel):
@@ -167,6 +170,9 @@ class RemoveCartItemInput(CommerceModel):
     user_id: str = Field(..., min_length=1)
     cart_line_id: str = Field(..., min_length=1)
     idempotency_key: str = Field(..., min_length=1)
+    quantity: int = Field(default=1, ge=1)
+    product_id: str | None = None
+    display_name: str | None = None
 
 
 class CartMutationResult(CommerceModel):
@@ -174,4 +180,5 @@ class CartMutationResult(CommerceModel):
     cart: Cart | None = None
     changed_line: CartLine | None = None
     error: CommerceError | None = None
+    message: str = ""
     meta: ToolMeta = Field(default_factory=ToolMeta)

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal commerce contracts for agent-facing tools.
+
+These models define the app's stable product, cart, and tool result shapes.
+They intentionally avoid protocol-specific ACP/UCP fields so those protocols
+can be added later as adapter layers instead of driving the core design.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+Availability = Literal["in_stock", "out_of_stock", "preorder", "backorder", "unknown"]
+
+
+class CommerceModel(BaseModel):
+    """Base model for commerce contracts."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class Money(CommerceModel):
+    amount: float = Field(..., ge=0, description="Decimal currency amount.")
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+
+
+class ProductVariant(CommerceModel):
+    variant_id: str = Field(..., min_length=1)
+    product_id: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1)
+    options: dict[str, str] = Field(default_factory=dict)
+    availability: Availability = "unknown"
+    price: Money | None = None
+
+
+class ProductSummary(CommerceModel):
+    product_id: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1)
+    description: str = ""
+    category: str | None = None
+    brand: str | None = None
+    price: Money | None = None
+    image_url: str | None = None
+    availability: Availability = "unknown"
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProductDetail(ProductSummary):
+    variants: list[ProductVariant] = Field(default_factory=list)
+    source_uri: str | None = None
+
+
+class StorePolicy(CommerceModel):
+    policy_id: str = Field(..., min_length=1)
+    topic: str = Field(..., min_length=1)
+    title: str = Field(..., min_length=1)
+    body: str = Field(..., min_length=1)
+    source_uri: str | None = None
+
+
+class CartLine(CommerceModel):
+    cart_line_id: str = Field(..., min_length=1)
+    product_id: str = Field(..., min_length=1)
+    display_name: str = Field(..., min_length=1)
+    quantity: int = Field(..., ge=1)
+    variant_id: str | None = None
+    unit_price: Money | None = None
+    image_url: str | None = None
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class Cart(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    lines: list[CartLine] = Field(default_factory=list)
+    subtotal: Money | None = None
+
+
+class CommerceError(CommerceModel):
+    code: str = Field(..., min_length=1)
+    message: str = Field(..., min_length=1)
+    retryable: bool = False
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolMeta(CommerceModel):
+    trace_id: str | None = None
+    idempotency_key: str | None = None
+
+
+class SearchCatalogInput(CommerceModel):
+    """Stateless catalog search input.
+
+    This contract intentionally excludes user, cart, and conversation context.
+    Agents may use context to decide what query to send, but the catalog search
+    tool itself should behave as a pure read for the supplied request fields.
+    """
+
+    query: str = ""
+    categories: list[str] = Field(default_factory=list)
+    filters: dict[str, Any] = Field(default_factory=dict)
+    top_k: int = Field(default=4, ge=1, le=50)
+
+
+class SearchCatalogResult(CommerceModel):
+    ok: bool
+    products: list[ProductSummary] = Field(default_factory=list)
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class GetProductDetailsInput(CommerceModel):
+    product_id: str = Field(..., min_length=1)
+
+
+class GetProductDetailsResult(CommerceModel):
+    ok: bool
+    product: ProductDetail | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class GetCartInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+
+
+class GetCartResult(CommerceModel):
+    ok: bool
+    cart: Cart | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class GetStorePolicyInput(CommerceModel):
+    topic: str = Field(..., min_length=1)
+
+
+class GetStorePolicyResult(CommerceModel):
+    ok: bool
+    policy: StorePolicy | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class AddCartItemInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    product_id: str = Field(..., min_length=1)
+    quantity: int = Field(..., ge=1)
+    idempotency_key: str = Field(..., min_length=1)
+    variant_id: str | None = None
+
+
+class UpdateCartItemInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    cart_line_id: str = Field(..., min_length=1)
+    quantity: int = Field(..., ge=0)
+    idempotency_key: str = Field(..., min_length=1)
+
+
+class RemoveCartItemInput(CommerceModel):
+    user_id: str = Field(..., min_length=1)
+    cart_line_id: str = Field(..., min_length=1)
+    idempotency_key: str = Field(..., min_length=1)
+
+
+class CartMutationResult(CommerceModel):
+    ok: bool
+    cart: Cart | None = None
+    changed_line: CartLine | None = None
+    error: CommerceError | None = None
+    meta: ToolMeta = Field(default_factory=ToolMeta)

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -101,6 +101,7 @@ class SearchCatalogInput(CommerceModel):
     """
 
     query: str = ""
+    queries: list[str] = Field(default_factory=list)
     image_base64: str = ""
     categories: list[str] = Field(default_factory=list)
     filters: dict[str, Any] = Field(default_factory=dict)

--- a/shared/configs/chain_server/config.yaml
+++ b/shared/configs/chain_server/config.yaml
@@ -102,5 +102,6 @@ agent_choices: [
         ]
 memory_length: 16384
 top_k_retrieve: 4
+catalog_search_timeout_seconds: null
 multimodal: True
 unsafe_message: "Sorry, I am a shopping assistant that specializes in apparel. Do you have any questions that align better with my expertise?"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def base_config() -> SimpleNamespace:
         agent_choices=["cart", "retriever", "chatter"],
         memory_length=16384,
         top_k_retrieve=4,
+        catalog_search_timeout_seconds=None,
         multimodal=True,
         unsafe_message="Sorry, I can only help with shopping questions.",
     )
@@ -88,6 +89,7 @@ def valid_config_dict() -> Dict[str, Any]:
         "agent_choices": ["cart", "retriever", "chatter"],
         "memory_length": 16384,
         "top_k_retrieve": 4,
+        "catalog_search_timeout_seconds": None,
         "multimodal": True,
         "unsafe_message": "Sorry, I can only help with shopping questions.",
     }

--- a/tests/unit/chain_server/test_cart.py
+++ b/tests/unit/chain_server/test_cart.py
@@ -395,7 +395,7 @@ def _install_http_stubs(
         def mount(self, prefix: str, _adapter: Any) -> None:
             self.mounts.append(prefix)
 
-        def post(self, url: str, json: Dict[str, Any]):
+        def post(self, url: str, json: Dict[str, Any], timeout: int = 10):  # noqa: ARG002
             recorder.calls.append(("POST", url, json))
             return cart_mod.requests.Response  # unused; replaced below
 
@@ -420,7 +420,9 @@ def _install_http_stubs(
     def _fake_session_ctor() -> _FakeSession:
         return _FakeSession()
 
-    def _fake_session_post(self: _FakeSession, url: str, json: Dict[str, Any]):
+    def _fake_session_post(
+        self: _FakeSession, url: str, json: Dict[str, Any], timeout: int = 10  # noqa: ARG002
+    ):
         recorder.calls.append(("POST", url, json))
         # The catalog retriever's /query/text is the only session.post target.
         return _FakeResponse(catalog_response)
@@ -804,7 +806,7 @@ def _install_bulk_http_stubs(
         def mount(self, prefix: str, _adapter: Any) -> None:
             pass
 
-        def post(self, url: str, json: Dict[str, Any]):
+        def post(self, url: str, json: Dict[str, Any], timeout: int = 10):  # noqa: ARG002
             recorder.calls.append(("POST", url, json))
             query_list = json.get("text") or []
             query = query_list[0] if query_list else ""

--- a/tests/unit/chain_server/test_commerce_tools.py
+++ b/tests/unit/chain_server/test_commerce_tools.py
@@ -7,8 +7,19 @@ from pathlib import Path
 
 import requests
 
-from chain_server.src.commerce_tools import search_catalog
-from shared.commerce_contracts import SearchCatalogInput
+from chain_server.src.commerce_tools import (
+    add_cart_item,
+    get_cart,
+    remove_cart_item,
+    search_catalog,
+)
+from shared.commerce_contracts import (
+    AddCartItemInput,
+    GetCartInput,
+    Money,
+    RemoveCartItemInput,
+    SearchCatalogInput,
+)
 
 
 class FakeSession:
@@ -19,6 +30,12 @@ class FakeSession:
 
     def post(self, url, json, timeout):
         self.calls.append({"url": url, "json": json, "timeout": timeout})
+        if self.exc:
+            raise self.exc
+        return self.response
+
+    def get(self, url, timeout):
+        self.calls.append({"url": url, "timeout": timeout})
         if self.exc:
             raise self.exc
         return self.response
@@ -157,6 +174,83 @@ def test_search_catalog_returns_structured_request_error() -> None:
     assert result.error.retryable is True
 
 
+def test_get_cart_maps_memory_rows_to_contract_cart() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "user_id": 42,
+                "cart": [
+                    {"item": "Silk Dress", "amount": 2, "price": 49.99},
+                    {"item": "Leather Bag", "amount": 1, "price": 199.0},
+                ],
+            }
+        )
+    )
+
+    result = get_cart(
+        GetCartInput(user_id="42"),
+        "http://memory-retriever:8011",
+        session=session,
+    )
+
+    assert result.ok is True
+    assert session.calls[0]["url"] == "http://memory-retriever:8011/user/42/cart"
+    assert result.cart.user_id == "42"
+    assert result.cart.lines[0].display_name == "Silk Dress"
+    assert result.cart.lines[0].unit_price.amount == 49.99
+    assert result.cart.subtotal.amount == 298.98
+
+
+def test_add_cart_item_posts_memory_payload_and_returns_message() -> None:
+    session = FakeSession(FakeResponse({"message": "added 2 Silk Dress"}))
+
+    result = add_cart_item(
+        AddCartItemInput(
+            user_id="42",
+            product_id="prod_123",
+            display_name="Silk Dress",
+            quantity=2,
+            unit_price=Money(amount=49.99),
+            idempotency_key="cart-add-1",
+        ),
+        "http://memory-retriever:8011",
+        session=session,
+    )
+
+    assert result.ok is True
+    assert session.calls[0]["url"] == "http://memory-retriever:8011/user/42/cart/add"
+    assert session.calls[0]["json"] == {
+        "item": "Silk Dress",
+        "amount": 2,
+        "price": 49.99,
+    }
+    assert result.changed_line.product_id == "prod_123"
+    assert result.message == "added 2 Silk Dress"
+
+
+def test_remove_cart_item_posts_memory_payload_and_returns_message() -> None:
+    session = FakeSession(FakeResponse({"message": "removed 1 Silk Dress"}))
+
+    result = remove_cart_item(
+        RemoveCartItemInput(
+            user_id="42",
+            cart_line_id="Silk Dress",
+            product_id="prod_123",
+            display_name="Silk Dress",
+            quantity=1,
+            idempotency_key="cart-remove-1",
+        ),
+        "http://memory-retriever:8011",
+        session=session,
+    )
+
+    assert result.ok is True
+    assert session.calls[0]["url"] == "http://memory-retriever:8011/user/42/cart/remove"
+    assert session.calls[0]["json"] == {"item": "Silk Dress", "amount": 1}
+    assert result.changed_line.product_id == "prod_123"
+    assert result.message == "removed 1 Silk Dress"
+
+
 def test_commerce_tools_do_not_import_current_agents() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     source = (repo_root / "chain_server/src/commerce_tools.py").read_text()
@@ -168,12 +262,12 @@ def test_commerce_tools_do_not_import_current_agents() -> None:
         "ChatterAgent",
         "SummaryAgent",
         "create_graph",
-        ".planner",
-        ".retriever",
-        ".cart",
-        ".chatter",
-        ".summarizer",
-        ".graph",
+        "from .planner",
+        "from .retriever",
+        "from .cart",
+        "from .chatter",
+        "from .summarizer",
+        "from .graph",
     ]
 
     for reference in forbidden_references:

--- a/tests/unit/chain_server/test_commerce_tools.py
+++ b/tests/unit/chain_server/test_commerce_tools.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import requests
+
+from chain_server.src.commerce_tools import search_catalog
+from shared.commerce_contracts import SearchCatalogInput
+
+
+class FakeSession:
+    def __init__(self, response=None, exc: Exception | None = None) -> None:
+        self.response = response
+        self.exc = exc
+        self.calls = []
+
+    def post(self, url, json, timeout):
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        if self.exc:
+            raise self.exc
+        return self.response
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code: int = 200) -> None:
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+def test_search_catalog_posts_stateless_text_payload() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "texts": [
+                    "Classic Black Patent Leather Purse | Formal bag | bag,purse\nPRICE: 89.99"
+                ],
+                "ids": ["prod_123"],
+                "similarities": [0.91],
+                "names": ["Classic Black Patent Leather Purse"],
+                "images": ["/images/purse.jpg"],
+            }
+        )
+    )
+
+    result = search_catalog(
+        SearchCatalogInput(
+            query="black purse",
+            categories=["bag"],
+            filters={"max_price": 100},
+            top_k=3,
+        ),
+        "http://catalog-retriever:8010",
+        session=session,
+    )
+
+    assert result.ok is True
+    assert session.calls[0]["url"] == "http://catalog-retriever:8010/query/text"
+    assert session.calls[0]["json"] == {
+        "text": ["black purse"],
+        "categories": ["bag"],
+        "filters": {"max_price": 100},
+        "k": 3,
+    }
+    assert "user_id" not in session.calls[0]["json"]
+    assert "cart" not in session.calls[0]["json"]
+    assert "context" not in session.calls[0]["json"]
+    assert result.products[0].product_id == "prod_123"
+    assert result.products[0].price.amount == 89.99
+    assert result.products[0].category == "bag"
+
+
+def test_search_catalog_posts_image_payload_when_image_is_present() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "texts": ["Red sunglasses | Oval frames | sunglasses,accessory\nPRICE: 49"],
+                "ids": ["prod_456"],
+                "similarities": [0.88],
+                "names": ["Red Oval Sunglasses"],
+                "images": ["/images/sunglasses.jpg"],
+            }
+        )
+    )
+
+    result = search_catalog(
+        SearchCatalogInput(
+            query="similar under $60",
+            image_base64="data:image/jpeg;base64,abc",
+            categories=["sunglasses"],
+            filters={"max_price": 60},
+        ),
+        "http://catalog-retriever:8010/",
+        session=session,
+    )
+
+    assert result.ok is True
+    assert session.calls[0]["url"] == "http://catalog-retriever:8010/query/image"
+    assert session.calls[0]["json"]["image_base64"] == "data:image/jpeg;base64,abc"
+    assert result.products[0].product_id == "prod_456"
+
+
+def test_search_catalog_rejects_empty_query_without_image() -> None:
+    session = FakeSession(FakeResponse({}))
+
+    result = search_catalog(
+        SearchCatalogInput(query=""),
+        "http://catalog-retriever:8010",
+        session=session,
+    )
+
+    assert result.ok is False
+    assert result.error.code == "invalid_search_request"
+    assert session.calls == []
+
+
+def test_search_catalog_returns_structured_request_error() -> None:
+    result = search_catalog(
+        SearchCatalogInput(query="black purse"),
+        "http://catalog-retriever:8010",
+        session=FakeSession(exc=requests.Timeout("timed out")),
+    )
+
+    assert result.ok is False
+    assert result.error.code == "catalog_request_failed"
+    assert result.error.retryable is True
+
+
+def test_commerce_tools_do_not_import_current_agents() -> None:
+    source = Path("chain_server/src/commerce_tools.py").read_text()
+
+    forbidden_references = [
+        "PlannerAgent",
+        "RetrieverAgent",
+        "CartAgent",
+        "ChatterAgent",
+        "SummaryAgent",
+        "create_graph",
+        ".planner",
+        ".retriever",
+        ".cart",
+        ".chatter",
+        ".summarizer",
+        ".graph",
+    ]
+
+    for reference in forbidden_references:
+        assert reference not in source

--- a/tests/unit/chain_server/test_commerce_tools.py
+++ b/tests/unit/chain_server/test_commerce_tools.py
@@ -91,9 +91,33 @@ def test_search_catalog_posts_stateless_text_payload() -> None:
     assert "user_id" not in session.calls[0]["json"]
     assert "cart" not in session.calls[0]["json"]
     assert "context" not in session.calls[0]["json"]
+    assert session.calls[0]["timeout"] is None
     assert result.products[0].product_id == "prod_123"
     assert result.products[0].price.amount == 89.99
     assert result.products[0].category == "bag"
+
+
+def test_search_catalog_uses_configured_timeout_when_provided() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "texts": [],
+                "ids": [],
+                "similarities": [],
+                "names": [],
+                "images": [],
+            }
+        )
+    )
+
+    search_catalog(
+        SearchCatalogInput(query="black purse"),
+        "http://catalog-retriever:8010",
+        timeout_seconds=120,
+        session=session,
+    )
+
+    assert session.calls[0]["timeout"] == 120
 
 
 def test_search_catalog_posts_image_payload_when_image_is_present() -> None:
@@ -226,6 +250,7 @@ def test_add_cart_item_posts_memory_payload_and_returns_message() -> None:
     }
     assert result.changed_line.product_id == "prod_123"
     assert result.message == "added 2 Silk Dress"
+    assert result.meta.idempotency_key == "cart-add-1"
 
 
 def test_remove_cart_item_posts_memory_payload_and_returns_message() -> None:
@@ -249,6 +274,7 @@ def test_remove_cart_item_posts_memory_payload_and_returns_message() -> None:
     assert session.calls[0]["json"] == {"item": "Silk Dress", "amount": 1}
     assert result.changed_line.product_id == "prod_123"
     assert result.message == "removed 1 Silk Dress"
+    assert result.meta.idempotency_key == "cart-remove-1"
 
 
 def test_commerce_tools_do_not_import_current_agents() -> None:

--- a/tests/unit/chain_server/test_commerce_tools.py
+++ b/tests/unit/chain_server/test_commerce_tools.py
@@ -109,6 +109,28 @@ def test_search_catalog_posts_image_payload_when_image_is_present() -> None:
     assert result.products[0].product_id == "prod_456"
 
 
+def test_search_catalog_preserves_multiple_query_terms() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "texts": [],
+                "ids": [],
+                "similarities": [],
+                "names": [],
+                "images": [],
+            }
+        )
+    )
+
+    search_catalog(
+        SearchCatalogInput(queries=["earrings", "necklace"]),
+        "http://catalog-retriever:8010",
+        session=session,
+    )
+
+    assert session.calls[0]["json"]["text"] == ["earrings", "necklace"]
+
+
 def test_search_catalog_rejects_empty_query_without_image() -> None:
     session = FakeSession(FakeResponse({}))
 
@@ -136,7 +158,8 @@ def test_search_catalog_returns_structured_request_error() -> None:
 
 
 def test_commerce_tools_do_not_import_current_agents() -> None:
-    source = Path("chain_server/src/commerce_tools.py").read_text()
+    repo_root = Path(__file__).resolve().parents[3]
+    source = (repo_root / "chain_server/src/commerce_tools.py").read_text()
 
     forbidden_references = [
         "PlannerAgent",

--- a/tests/unit/chain_server/test_config.py
+++ b/tests/unit/chain_server/test_config.py
@@ -124,6 +124,24 @@ class TestChainServerConfigValidation:
         with pytest.raises(ValidationError):
             ChainServerConfig(**{**valid_config_dict, "top_k_retrieve": value})
 
+    @pytest.mark.parametrize("value", [None, 30, 120.5])
+    def test_catalog_search_timeout_accepts_none_or_positive_values(
+        self, valid_config_dict: dict, value: float | None
+    ) -> None:
+        cfg = ChainServerConfig(
+            **{**valid_config_dict, "catalog_search_timeout_seconds": value}
+        )
+        assert cfg.catalog_search_timeout_seconds == value
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_catalog_search_timeout_rejects_non_positive_values(
+        self, valid_config_dict: dict, value: float
+    ) -> None:
+        with pytest.raises(ValidationError):
+            ChainServerConfig(
+                **{**valid_config_dict, "catalog_search_timeout_seconds": value}
+            )
+
     @pytest.mark.parametrize("field", ["categories", "agent_choices"])
     def test_empty_list_fields_are_rejected(
         self, valid_config_dict: dict, field: str

--- a/tests/unit/chain_server/test_retriever.py
+++ b/tests/unit/chain_server/test_retriever.py
@@ -311,9 +311,10 @@ def _install_search_catalog(
     """Stub the commerce search tool used inside RetrieverAgent.invoke."""
     captured: Dict[str, Any] = {}
 
-    def _search_catalog(request, catalog_retriever_url):
+    def _search_catalog(request, catalog_retriever_url, *, timeout_seconds=None):
         captured["request"] = request
         captured["catalog_retriever_url"] = catalog_retriever_url
+        captured["timeout_seconds"] = timeout_seconds
         if raise_exc is not None:
             raise raise_exc
         return result or SearchCatalogResult(ok=True)
@@ -363,6 +364,7 @@ class TestRetrieverInvoke:
         assert captured["request"].queries == ["summer dress"]
         assert captured["request"].image_base64 == ""
         assert captured["request"].top_k == retriever_agent.k_value
+        assert captured["timeout_seconds"] is None
         assert "Summer Dress" in out.response
         assert "Summer Dress" in out.retrieved
         assert out.retrieved["Summer Dress"] == "img1.jpg"

--- a/tests/unit/chain_server/test_retriever.py
+++ b/tests/unit/chain_server/test_retriever.py
@@ -18,11 +18,11 @@ from types import SimpleNamespace
 from typing import Any, Dict
 
 import pytest
-import requests
 
 from chain_server.src import retriever as retriever_mod
 from chain_server.src.agenttypes import State
 from chain_server.src.retriever import RetrieverAgent
+from shared.commerce_contracts import ProductSummary, SearchCatalogResult
 
 
 @pytest.fixture
@@ -302,40 +302,23 @@ class TestExtractRetrievalInputs:
 # ---------------------------------------------------------------------------
 
 
-class _FakeCatalogResponse:
-    def __init__(self, payload: Dict[str, Any], status: int = 200) -> None:
-        self._payload = payload
-        self.status_code = status
-
-    def json(self) -> Dict[str, Any]:
-        return self._payload
-
-    def raise_for_status(self) -> None:
-        if self.status_code >= 400:
-            raise requests.exceptions.HTTPError(f"HTTP {self.status_code}")
-
-
-def _install_session_post(
+def _install_search_catalog(
     monkeypatch: pytest.MonkeyPatch,
-    payload: Dict[str, Any] | None = None,
+    result: SearchCatalogResult | None = None,
     *,
     raise_exc: Exception | None = None,
 ):
-    """Stub ``requests.Session.post`` used inside RetrieverAgent.invoke."""
+    """Stub the commerce search tool used inside RetrieverAgent.invoke."""
     captured: Dict[str, Any] = {}
 
-    class _FakeSession:
-        def mount(self, *_args, **_kwargs) -> None:
-            return None
+    def _search_catalog(request, catalog_retriever_url):
+        captured["request"] = request
+        captured["catalog_retriever_url"] = catalog_retriever_url
+        if raise_exc is not None:
+            raise raise_exc
+        return result or SearchCatalogResult(ok=True)
 
-        def post(self, url: str, json: Dict[str, Any]):
-            captured["url"] = url
-            captured["json"] = json
-            if raise_exc is not None:
-                raise raise_exc
-            return _FakeCatalogResponse(payload or {})
-
-    monkeypatch.setattr(retriever_mod.requests, "Session", lambda: _FakeSession())
+    monkeypatch.setattr(retriever_mod, "search_catalog", _search_catalog)
     return captured
 
 
@@ -354,23 +337,32 @@ class TestRetrieverInvoke:
                 "category_three": "dress",
             },
         )
-        captured = _install_session_post(
+        captured = _install_search_catalog(
             monkeypatch,
-            payload={
-                "texts": ["Summer Dress | breezy | dress"],
-                "names": ["Summer Dress"],
-                "images": ["img1.jpg"],
-                "similarities": [0.9],
-            },
+            result=SearchCatalogResult(
+                ok=True,
+                products=[
+                    ProductSummary(
+                        product_id="prod_1",
+                        display_name="Summer Dress",
+                        image_url="img1.jpg",
+                        attributes={
+                            "catalog_text": "Summer Dress | breezy | dress",
+                            "similarity": 0.9,
+                        },
+                    )
+                ],
+            ),
         )
 
         state = State(user_id=1, query="show me a summer dress")
         out = await retriever_agent.invoke(state, verbose=False)
 
-        assert captured["url"].endswith("/query/text")
-        # Filters omitted when none are requested.
-        assert captured["json"]["text"] == ["summer dress"]
-        assert captured["json"]["k"] == retriever_agent.k_value
+        assert captured["catalog_retriever_url"] == retriever_agent.catalog_retriever_url
+        assert captured["request"].query == "summer dress"
+        assert captured["request"].queries == ["summer dress"]
+        assert captured["request"].image_base64 == ""
+        assert captured["request"].top_k == retriever_agent.k_value
         assert "Summer Dress" in out.response
         assert "Summer Dress" in out.retrieved
         assert out.retrieved["Summer Dress"] == "img1.jpg"
@@ -391,14 +383,22 @@ class TestRetrieverInvoke:
                 "category_three": "bag",
             },
         )
-        captured = _install_session_post(
+        captured = _install_search_catalog(
             monkeypatch,
-            payload={
-                "texts": ["Leather Bag | elegant | bag"],
-                "names": ["Leather Bag"],
-                "images": ["bag.jpg"],
-                "similarities": [0.7],
-            },
+            result=SearchCatalogResult(
+                ok=True,
+                products=[
+                    ProductSummary(
+                        product_id="prod_2",
+                        display_name="Leather Bag",
+                        image_url="bag.jpg",
+                        attributes={
+                            "catalog_text": "Leather Bag | elegant | bag",
+                            "similarity": 0.7,
+                        },
+                    )
+                ],
+            ),
         )
 
         state = State(
@@ -408,8 +408,7 @@ class TestRetrieverInvoke:
         )
         out = await retriever_agent.invoke(state, verbose=False)
 
-        assert captured["url"].endswith("/query/image")
-        assert captured["json"]["image_base64"] == "data:image/jpeg;base64,AAAA"
+        assert captured["request"].image_base64 == "data:image/jpeg;base64,AAAA"
         assert "Leather Bag" in out.response
 
     async def test_no_results_produces_polite_message(
@@ -426,14 +425,9 @@ class TestRetrieverInvoke:
                 "category_three": "bag",
             },
         )
-        _install_session_post(
+        _install_search_catalog(
             monkeypatch,
-            payload={
-                "texts": [],
-                "names": [],
-                "images": [],
-                "similarities": [],
-            },
+            result=SearchCatalogResult(ok=True, products=[]),
         )
 
         state = State(user_id=1, query="looking for a watch")
@@ -455,9 +449,9 @@ class TestRetrieverInvoke:
                 "category_three": "bag",
             },
         )
-        _install_session_post(
+        _install_search_catalog(
             monkeypatch,
-            raise_exc=requests.exceptions.ConnectionError("boom"),
+            raise_exc=RuntimeError("boom"),
         )
 
         state = State(user_id=1, query="any bag")

--- a/tests/unit/shared/test_commerce_contracts.py
+++ b/tests/unit/shared/test_commerce_contracts.py
@@ -16,7 +16,7 @@ from shared.commerce_contracts import (
 )
 
 
-def test_product_summary_requires_stable_product_id() -> None:
+def test_product_summary_requires_product_id() -> None:
     product = ProductSummary(
         product_id="prod_123",
         display_name="Classic Black Patent Leather Purse",

--- a/tests/unit/shared/test_commerce_contracts.py
+++ b/tests/unit/shared/test_commerce_contracts.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from shared.commerce_contracts import (
+    AddCartItemInput,
+    Cart,
+    CartLine,
+    Money,
+    ProductSummary,
+    SearchCatalogResult,
+)
+
+
+def test_product_summary_requires_stable_product_id() -> None:
+    product = ProductSummary(
+        product_id="prod_123",
+        display_name="Classic Black Patent Leather Purse",
+        price=Money(amount=89.99),
+        availability="in_stock",
+    )
+
+    assert product.product_id == "prod_123"
+    assert product.model_dump()["price"]["currency"] == "USD"
+
+
+def test_cart_line_quantity_must_be_positive() -> None:
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        CartLine(
+            cart_line_id="line_1",
+            product_id="prod_123",
+            display_name="Classic Black Patent Leather Purse",
+            quantity=0,
+        )
+
+
+def test_mutating_cart_input_requires_idempotency_key() -> None:
+    with pytest.raises(ValidationError, match="idempotency_key"):
+        AddCartItemInput(
+            user_id="user_1",
+            product_id="prod_123",
+            quantity=1,
+        )
+
+
+def test_contracts_reject_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ProductSummary(
+            product_id="prod_123",
+            display_name="Classic Black Patent Leather Purse",
+            unsupported_field=True,
+        )
+
+
+def test_search_result_serializes_structured_products() -> None:
+    cart = Cart(
+        user_id="user_1",
+        lines=[
+            CartLine(
+                cart_line_id="line_1",
+                product_id="prod_123",
+                display_name="Classic Black Patent Leather Purse",
+                quantity=1,
+                unit_price=Money(amount=89.99),
+            )
+        ],
+        subtotal=Money(amount=89.99),
+    )
+    result = SearchCatalogResult(
+        ok=True,
+        products=[
+            ProductSummary(
+                product_id=cart.lines[0].product_id,
+                display_name=cart.lines[0].display_name,
+            )
+        ],
+    )
+
+    dumped = result.model_dump()
+    assert dumped["products"][0]["product_id"] == "prod_123"
+    assert dumped["products"][0]["display_name"] == cart.lines[0].display_name


### PR DESCRIPTION
## Summary

Routes the current LangGraph catalog and cart paths through reusable commerce tool wrappers, giving future Deep Agents tools a typed boundary while preserving current behavior.

## What Changed

- `shared/commerce_contracts.py`
  - Adds typed models for money, products, carts, cart lines, errors, tool metadata, catalog search, cart reads, and cart mutations.
  - Keeps catalog search stateless: no user, cart, memory, session, or conversation context in `SearchCatalogInput`.
  - Documents that current catalog search IDs are transient retriever IDs until durable product IDs or SKUs are available.
  - Keeps cart mutation idempotency keys in the contract for future retry safety.

- `chain_server/src/commerce_tools.py`
  - Adds `search_catalog`, a stateless catalog-search wrapper over the catalog retriever service.
  - Adds `get_cart`, `add_cart_item`, and `remove_cart_item` wrappers over the memory retriever service.
  - Preserves catalog retry behavior for catalog POSTs.
  - Defaults catalog-search timeout to no timeout, matching the previous direct catalog POST behavior.
  - Echoes cart mutation idempotency keys in tool metadata, without claiming memory-service deduplication.
  - Does not import or call existing agents, graph, planner, retriever, cart, chatter, or summarizer.

- `chain_server/src/config.py`
  - Adds optional `catalog_search_timeout_seconds` config and `CATALOG_SEARCH_TIMEOUT_SECONDS` environment override.
  - Validates that configured timeout values are positive when provided.

- `shared/configs/chain_server/config.yaml`
  - Sets `catalog_search_timeout_seconds: null` so slower remote embedding or image catalog searches are not newly capped.

- `chain_server/src/retriever.py`
  - Routes `RetrieverAgent.invoke()` catalog reads through `search_catalog`.
  - Passes configured catalog-search timeout through the tool wrapper.
  - Preserves current retrieval extraction, fallback behavior, timings, response text, and image map output.
  - Keeps catalog/product search independent from shopper session state.

- `chain_server/src/cart.py`
  - Routes catalog item lookup through `search_catalog` with the configured catalog-search timeout.
  - Routes cart reads through `get_cart`.
  - Routes add/remove operations through `add_cart_item` and `remove_cart_item`.
  - Keeps existing cart intent selection, pronoun resolution, bulk dispatch, and user-facing response behavior.

- `docs/COMMERCE_CONTRACTS.md`
  - Documents the typed tool boundary, stateless catalog search rule, runtime wiring status, and migration direction.
  - Clarifies that current catalog result IDs are transient Milvus retriever IDs until the catalog exposes durable product IDs.
  - Clarifies that durable ID persistence in chain-server state and cart memory rows is future work.
  - Clarifies that idempotency keys are present in the contract and metadata but are not enforced by the current memory service yet.

- `docs/DEPLOYMENT.md`
  - Documents the `CATALOG_SEARCH_TIMEOUT_SECONDS` runtime environment override alongside the other deployment environment variables.

- `README.md`
  - Links the commerce tools documentation.

- `docs/README.md`
  - Adds the commerce tools doc to the docs index.

- `tests/conftest.py`
  - Adds the new catalog timeout config field to shared test fixtures.

- `tests/unit/shared/test_commerce_contracts.py`
  - Covers typed model validation, unknown field rejection, idempotency-key requirements, and structured serialization.

- `tests/unit/chain_server/test_commerce_tools.py`
  - Covers stateless search payloads, image payload selection, multiple query terms, configurable timeout behavior, structured catalog errors, cart read mapping, cart add/remove payloads, idempotency metadata, and the no-agent-import boundary.

- `tests/unit/chain_server/test_config.py`
  - Covers optional catalog-search timeout validation.

- `tests/unit/chain_server/test_retriever.py`
  - Updates retriever invoke tests to stub `search_catalog` instead of direct HTTP.
  - Verifies text/image requests are converted into `SearchCatalogInput` and timeout config is forwarded.

- `tests/unit/chain_server/test_cart.py`
  - Updates HTTP stubs to match the commerce tool wrappers' timeout-aware request surface.

## Validation

- `python -m py_compile chain_server/src/commerce_tools.py chain_server/src/config.py chain_server/src/retriever.py chain_server/src/cart.py shared/commerce_contracts.py`
  - Passed

- Focused unit suite:
  - `tests/unit/chain_server/test_commerce_tools.py`
  - `tests/unit/chain_server/test_config.py`
  - `tests/unit/chain_server/test_retriever.py`
  - `tests/unit/shared/test_commerce_contracts.py`
  - Passed: `81 passed`

- `tests/unit/chain_server/test_cart.py`
  - Passed: `83 passed`

- `python skills/retail-test-runner/scripts/run_retail_tests.py unit`
  - Passed: `446 passed, 1 warning`

- `git diff --check`
  - Passed

- Earlier text-only live shopping integration, rails disabled:
  - Command: `python skills/retail-test-runner/scripts/run_retail_tests.py integration --test-path shopping --disable-guardrails --skip-quality --request-timeout 120`
  - Passed with exit code `0`
  - 9 shopping conversation files processed
  - 48 live responses collected
  - 0 captured request errors
  - Generated `tests/integration/conversations/shopping/results/timing_summary.png`

## Notes

- Rails, image scenarios, and new live tests were not run for the latest review-feedback commits.