### PR TITLE
Add Deep Agents cart reference harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The Brev deployment guide walks you through the entire process from creating a L
 - **[API Documentation](docs/API.md)**: Complete API reference
 - **[Commerce Contracts](docs/COMMERCE_CONTRACTS.md)**: Internal product, cart, and commerce tool contracts
 - **[Deep Agents Migration Plan](docs/DEEP_AGENTS_MIGRATION_PLAN.md)**: SDK migration, session isolation, tools, skills, and scaling notes
+- **[Deep Agents Cart Tool Goal](docs/DEEP_AGENTS_CART_TOOL_GOAL.md)**: Minimal cart-tool smoke gate and constraints
 - **[Deployment Guide](docs/DEPLOYMENT.md)**: Installation and setup instructions
 - **[Testing and Evaluation](tests/README.md)**: Unit, integration, and Challenger/Judge evaluation workflows
 - **[Documentation Hub](docs/README.md)**: Complete documentation index

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -10,7 +10,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import time
 from typing import Any, AsyncIterator
 import uuid
@@ -28,6 +27,7 @@ from .commerce_tools import (
 from shared.commerce_contracts import (
     AddCartItemInput,
     GetCartInput,
+    ProductSummary,
     RemoveCartItemInput,
     SearchCatalogInput,
 )
@@ -68,6 +68,7 @@ class DeepAgentsRuntime:
         self.config = config
         self._checkpointer = MemorySaver()
         self._profile_registered = False
+        self._product_refs: dict[str, dict[str, ProductSummary]] = {}
 
     async def astream(
         self, state: State, identity: RequestIdentity
@@ -149,7 +150,7 @@ class DeepAgentsRuntime:
         retrieved: dict[str, str] = {}
         state.retrieved = retrieved
 
-        @tool(return_direct=True)
+        @tool(return_direct=False)
         def search_catalog_tool(
             query: str,
             category: str = "",
@@ -180,6 +181,7 @@ class DeepAgentsRuntime:
             if not result.products:
                 return "No matching catalog products were found."
 
+            self._remember_products(identity, result.products)
             lines = []
             for product in result.products:
                 if product.image_url:
@@ -187,7 +189,7 @@ class DeepAgentsRuntime:
                 lines.append(_format_product(product))
             return "\n\n".join(lines)
 
-        @tool(return_direct=True)
+        @tool(return_direct=False)
         def get_cart_tool() -> str:
             """Read the current cart contents."""
 
@@ -196,13 +198,16 @@ class DeepAgentsRuntime:
             return _format_cart(cart)
 
         @tool(return_direct=True)
-        def add_cart_item_tool(item_name: str, quantity: int = 1) -> str:
-            """Add a catalog item to the current cart after validating the product name."""
+        def add_cart_item_tool(product_ref: str, quantity: int = 1) -> str:
+            """Add a catalog item by PRODUCT_REF from a prior search_catalog_tool result."""
 
             quantity = max(1, int(quantity or 1))
-            product = self._lookup_product(item_name)
+            product = self._product_from_ref(identity, product_ref)
             if product is None:
-                return f"No catalog product named '{item_name}' could be found."
+                return (
+                    f"No product with PRODUCT_REF '{product_ref}' is available. "
+                    "Search the catalog first and use the PRODUCT_REF from the result."
+                )
             result = add_cart_item(
                 AddCartItemInput(
                     user_id=str(identity.cart_user_id),
@@ -221,21 +226,22 @@ class DeepAgentsRuntime:
             return result.error.message if result.error else "Cart add failed."
 
         @tool(return_direct=True)
-        def remove_cart_item_tool(item_name: str, quantity: int = 1) -> str:
-            """Remove an item from the current cart by matching against cart contents."""
+        def remove_cart_item_tool(cart_line_id: str, quantity: int = 1) -> str:
+            """Remove a cart item by CART_LINE_ID from get_cart_tool/current-cart output."""
 
             quantity = max(1, int(quantity or 1))
             cart = self._read_cart(identity.cart_user_id)
-            line = _find_cart_line(item_name, cart)
+            line = _cart_line_by_id(cart_line_id, cart)
             if line is None:
-                return f"No cart item named '{item_name}' could be found."
+                return f"No cart line with CART_LINE_ID '{cart_line_id}' could be found."
             result = remove_cart_item(
                 RemoveCartItemInput(
                     user_id=str(identity.cart_user_id),
-                    cart_line_id=line["item"],
+                    cart_line_id=line["cart_line_id"],
+                    product_id=line.get("product_id"),
                     display_name=line["item"],
                     quantity=quantity,
-                    idempotency_key=f"{identity.request_id}:remove:{line['item']}:{quantity}",
+                    idempotency_key=f"{identity.request_id}:remove:{line['cart_line_id']}:{quantity}",
                 ),
                 self.config.memory_port,
             )
@@ -291,6 +297,9 @@ Rules:
   answer from the results you have or ask one concise clarifying question.
 - A tool result is enough to produce a final answer. Do not keep searching for
   alternatives unless the shopper explicitly rejects the current result.
+- When the shopper asks to add an item that has not already been searched in
+  this conversation, call search_catalog_tool first, then call
+  add_cart_item_tool with the selected PRODUCT_REF.
 - If an image is attached, the current image is already available to
   search_catalog_tool. Use that tool for "this", "similar", and image-price
   refinement requests.
@@ -298,6 +307,10 @@ Rules:
 - Cart mutations require explicit shopper intent and must use add_cart_item_tool
   or remove_cart_item_tool. Never claim a cart mutation unless the tool reports
   success.
+- Use PRODUCT_REF from search_catalog_tool when adding an item. Do not pass
+  display names to add_cart_item_tool.
+- Use CART_LINE_ID from CURRENT CART or get_cart_tool when removing an item. Do
+  not guess cart line IDs from product names.
 - If the shopper asks for anything under a budget without a product type,
   category, occasion, style, outfit goal, or image, ask one concise clarifying
   question instead of guessing.
@@ -324,21 +337,21 @@ Rules:
             return [cleaned]
         return list(self.config.categories)
 
-    def _lookup_product(self, item_name: str):
-        result = search_catalog(
-            SearchCatalogInput(
-                query=item_name,
-                categories=self.config.categories,
-                top_k=max(5, self.config.top_k_retrieve),
-            ),
-            self.config.retriever_port,
-            timeout_seconds=self.config.catalog_search_timeout_seconds,
+    def _remember_products(
+        self, identity: RequestIdentity, products: list[ProductSummary]
+    ) -> None:
+        refs = self._product_refs.setdefault(identity.conversation_id, {})
+        for product in products:
+            refs[product.product_id] = product
+        while len(refs) > 50:
+            refs.pop(next(iter(refs)))
+
+    def _product_from_ref(
+        self, identity: RequestIdentity, product_ref: str
+    ) -> ProductSummary | None:
+        return self._product_refs.get(identity.conversation_id, {}).get(
+            (product_ref or "").strip()
         )
-        if not result.ok or not result.products:
-            return None
-        names = [product.display_name for product in result.products]
-        match_idx = _resolve_name_match(item_name, names)
-        return result.products[match_idx] if match_idx is not None else None
 
     def _read_cart(self, user_id: int) -> Cart:
         result = get_cart(GetCartInput(user_id=str(user_id)), self.config.memory_port)
@@ -347,6 +360,8 @@ Rules:
         return Cart(
             contents=[
                 {
+                    "cart_line_id": line.cart_line_id,
+                    "product_id": line.product_id,
                     "item": line.display_name,
                     "amount": line.quantity,
                     "price": line.unit_price.amount if line.unit_price else None,
@@ -470,9 +485,12 @@ def _content_to_text(content: Any) -> str:
 def _format_product(product: Any) -> str:
     text = product.attributes.get("catalog_text") if product.attributes else None
     if isinstance(text, str) and text.strip():
-        return text
+        return f"PRODUCT_REF: {product.product_id}\n{text.strip()}"
     price = f"\nPRICE: ${product.price.amount:.2f}" if product.price else ""
-    return f"{product.display_name} | {product.description}{price}".strip()
+    return (
+        f"PRODUCT_REF: {product.product_id}\n"
+        f"{product.display_name} | {product.description}{price}"
+    ).strip()
 
 
 def _format_cart(cart: Cart) -> str:
@@ -487,7 +505,11 @@ def _format_cart(cart: Cart) -> str:
                 suffix = f" @ ${float(price):.2f}"
             except (TypeError, ValueError):
                 suffix = ""
-        lines.append(f"- {item.get('amount', 1)} x {item.get('item', '')}{suffix}")
+        cart_line_id = item.get("cart_line_id") or item.get("item", "")
+        lines.append(
+            f"- CART_LINE_ID: {cart_line_id} | "
+            f"{item.get('amount', 1)} x {item.get('item', '')}{suffix}"
+        )
     return "\n".join(lines)
 
 
@@ -514,37 +536,13 @@ def _format_cart_total(cart: Cart) -> str:
     return "\n".join(lines + [total])
 
 
-def _find_cart_line(item_name: str, cart: Cart) -> dict[str, Any] | None:
+def _cart_line_by_id(cart_line_id: str, cart: Cart) -> dict[str, Any] | None:
     if not cart.contents:
         return None
-    names = [str(item.get("item") or "") for item in cart.contents]
-    idx = _resolve_name_match(item_name, names)
-    return cart.contents[idx] if idx is not None else None
-
-
-def _resolve_name_match(query_name: str, candidates: list[str]) -> int | None:
-    query_norm = _normalize_name(query_name)
-    if not query_norm:
-        return 0 if candidates else None
-    query_tokens = set(query_norm.split())
-    best_idx = None
-    best_score = 0.0
-    for idx, candidate in enumerate(candidates):
-        candidate_norm = _normalize_name(candidate)
-        if not candidate_norm:
-            continue
-        if query_norm == candidate_norm or query_norm in candidate_norm or candidate_norm in query_norm:
-            return idx
-        candidate_tokens = set(candidate_norm.split())
-        if not candidate_tokens:
-            continue
-        score = len(query_tokens & candidate_tokens) / len(query_tokens | candidate_tokens)
-        if score > best_score:
-            best_score = score
-            best_idx = idx
-    return best_idx if best_idx is not None and best_score >= 0.5 else None
-
-
-def _normalize_name(name: str) -> str:
-    cleaned = re.sub(r"[^a-z0-9 ]+", " ", (name or "").lower())
-    return re.sub(r"\s+", " ", cleaned).strip()
+    target = (cart_line_id or "").strip()
+    if not target:
+        return None
+    for item in cart.contents:
+        if str(item.get("cart_line_id") or "").strip() == target:
+            return item
+    return None

--- a/docs/API.md
+++ b/docs/API.md
@@ -85,10 +85,11 @@ interface QueryRequest {
 
 `session_id`, `conversation_id`, and `cart_id` are optional for backward
 compatibility. When they are omitted, the server maps the legacy `user_id` to
-internal compatibility identifiers. When supplied, `conversation_id` scopes the
-Deep Agents thread and conversation memory, while `cart_id` scopes cart
-reads/writes. Production website integrations should use server-created session,
-conversation, and cart identifiers before broad rollout so customer context and
+internal compatibility identifiers. The bundled UI creates browser-session
+identifiers and sends them on every turn. When supplied, `conversation_id`
+scopes the Deep Agents thread and conversation memory, while `cart_id` scopes
+cart reads/writes. Production website integrations should move these IDs to a
+server-owned session/thread service before broad rollout so customer context and
 cart state cannot bleed across sessions.
 
 ### QueryResponse

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -35,6 +35,13 @@ SDK adapter:
 - `DeepAgentsRuntime` exposes request-scoped wrapper tools over the internal
   `search_catalog`, `get_cart`, `add_cart_item`, and `remove_cart_item`
   wrappers.
+- Deep Agents cart mutation tools use explicit refs: `PRODUCT_REF` values
+  returned by catalog search for add operations, and `CART_LINE_ID` values
+  returned by cart reads for remove operations. They do not perform hidden
+  product-name lookup or fuzzy cart-line matching.
+- Catalog search and cart-read wrapper tools return results to the agent loop
+  so explicit cart-mutation requests can search/read and then mutate in one
+  turn. Mutation tools still return the authoritative cart result directly.
 - The legacy `RetrieverAgent` and `CartAgent` files still exist in the repo for
   reference and tests, but they are not the chain-server entrypoint.
 - Catalog search remains stateless: no user, cart, memory, session, or
@@ -71,9 +78,9 @@ The first tool contract set is:
 | `GetProductDetailsInput` / `GetProductDetailsResult` | Read-only | Reserved for fetching one product by durable `product_id` once the catalog exposes one. |
 | `GetCartInput` / `GetCartResult` | Read-only | Read the authoritative cart for a user. |
 | `GetStorePolicyInput` / `GetStorePolicyResult` | Read-only | Fetch controlled store-policy text by topic. |
-| `AddCartItemInput` / `CartMutationResult` | Mutating | Add a product or variant to the cart. |
+| `AddCartItemInput` / `CartMutationResult` | Mutating | Add a product or variant to the cart from an explicit product ref. |
 | `UpdateCartItemInput` / `CartMutationResult` | Mutating | Change cart-line quantity. Quantity `0` means remove. |
-| `RemoveCartItemInput` / `CartMutationResult` | Mutating | Remove a cart line. |
+| `RemoveCartItemInput` / `CartMutationResult` | Mutating | Remove an explicit cart line by `cart_line_id`. |
 
 Mutating inputs require `idempotency_key` so future agent retries and protocol
 adapters have a stable key to enforce safe retries. In the current memory
@@ -107,7 +114,8 @@ the public API first:
 3. Treat current catalog result IDs as transient `ProductSummary` and mutation
    result fields only; durable ID persistence in chain-server state and cart
    memory rows is future work.
-4. Deep Agents SDK wrapper tools now reuse the same internal commerce wrappers.
+4. Deep Agents SDK wrapper tools now reuse the same internal commerce wrappers
+   and require explicit product/cart-line refs for cart mutations.
 5. Add Deep Agents skills and subagents on top of the same tool layer.
 
 The important rule is that ACP/UCP compatibility should be added as adapters

--- a/docs/DEEP_AGENTS_CART_TOOL_GOAL.md
+++ b/docs/DEEP_AGENTS_CART_TOOL_GOAL.md
@@ -1,0 +1,38 @@
+# Deep Agents Cart Tool Goal
+
+This branch first proves the minimal cart-tool loop before adding broader
+features.
+
+## Commit Gate
+
+The ref-based cart tool changes should pass this live four-step shopper flow
+before commit:
+
+1. Find a black bag under $100 and add it to my cart.
+2. What is in my cart?
+3. Remove that bag from my cart.
+4. What is my total?
+
+## Intended Shape
+
+- Use Deep Agents as the only shopper-language interpreter.
+- Keep cart mutations as deterministic tools.
+- Add by explicit `PRODUCT_REF` returned from catalog search.
+- Remove by explicit `CART_LINE_ID` returned from cart reads.
+- Keep discovery and cart-read tools chainable inside the agent loop.
+- Keep mutation tools authoritative and idempotent.
+
+## Constraints
+
+- Do not reintroduce hidden product-name lookup inside add-cart mutation.
+- Do not reintroduce fuzzy cart-line matching inside remove-cart mutation.
+- Do not add a standalone cart agent or planner.
+- Do not add broad keyword taxonomies for shopper intent.
+
+## Next Work
+
+1. Keep this smoke green while changing the cart harness.
+2. If search-then-add fails, fix the Deep Agents tool contract or prompt first.
+3. If remove-by-reference fails, improve cart-read output or tool naming first.
+4. Only then consider richer features such as durable SKU lookup, product-detail
+   tools, multi-item cart operations, or cart confirmation policy.

--- a/docs/DEEP_AGENTS_MIGRATION_PLAN.md
+++ b/docs/DEEP_AGENTS_MIGRATION_PLAN.md
@@ -38,9 +38,9 @@ Current constraints:
   use one catalog search per user turn unless the shopper explicitly asks for
   alternatives. This keeps broad shopping prompts from turning into unbounded
   exploratory search loops.
-- Commerce wrapper tools return directly to the caller in this slice. That
-  trades some conversational polish for predictable latency, simpler control
-  flow, and fewer repeated model calls.
+- Catalog search and cart-read tools return to the Deep Agents loop so a single
+  shopper turn can discover products or read the cart before mutating it.
+  Mutating cart tools return directly with the authoritative cart result.
 
 Filesystem and built-in Deep Agents tools:
 
@@ -169,8 +169,10 @@ Initial tools should be small, typed, and deterministic:
 - `search_catalog`: read-only, stateless product discovery.
 - `get_product_details`: read-only product facts for one product.
 - `get_cart`: read-only cart state for a `cart_id`.
-- `add_cart_item`: mutating cart write with idempotency.
-- `remove_cart_item`: mutating cart write with idempotency.
+- `add_cart_item`: mutating cart write with idempotency, using a `PRODUCT_REF`
+  previously returned by product search.
+- `remove_cart_item`: mutating cart write with idempotency, using a
+  `CART_LINE_ID` returned by cart reads.
 - `view_cart_total`: deterministic arithmetic over cart line prices.
 - `get_store_policy`: read-only controlled policy content.
 - `load_customer_persona`: read-only persona/profile snapshot.
@@ -269,6 +271,12 @@ Implications:
 - Expose current catalog and cart capabilities as typed tools.
 - Keep product search stateless.
 - Keep cart operations deterministic and idempotent.
+- Make cart mutations ref-based: add by `PRODUCT_REF`, remove by
+  `CART_LINE_ID`; do not hide product lookup or fuzzy cart-line matching inside
+  mutation tools.
+- Keep discovery/read tools chainable inside the agent loop so same-turn
+  requests like "find a black bag and add it" can search first, then mutate by
+  ref.
 - Do not create standalone planner or cart-agent classes.
 
 ### Slice 4: Skills

--- a/docs/DEEP_AGENTS_MIGRATION_PLAN.md
+++ b/docs/DEEP_AGENTS_MIGRATION_PLAN.md
@@ -29,11 +29,12 @@ Current constraints:
 - No skills are added yet; the first goal is a readable SDK harness.
 - The public request body remains backward compatible.
 - Optional `session_id`, `conversation_id`, and `cart_id` fields are accepted,
-  but legacy callers that send only `user_id` are mapped to deterministic
+  and the bundled UI now sends browser-session identifiers on every turn.
+  Legacy callers that send only `user_id` are still mapped to deterministic
   compatibility identifiers.
 - The compatibility mapping is not the final production identity design. A
-  high-scale website should move to server-created session and conversation
-  identifiers before broad rollout.
+  high-scale website should move to server-created session, conversation, and
+  cart identifiers before broad rollout.
 - The runtime caps Deep Agents recursion per turn and instructs the model to
   use one catalog search per user turn unless the shopper explicitly asks for
   alternatives. This keeps broad shopping prompts from turning into unbounded
@@ -106,9 +107,10 @@ POST /query/stream
   -> persist conversation summary and tool results under the correct scope
 ```
 
-The first migration should preserve the existing endpoint shape. The server can
-derive internal `session_id`, `conversation_id`, `cart_id`, and `request_id`
-without requiring the frontend to send them yet.
+The first migration preserves the existing endpoint shape. The bundled UI sends
+explicit browser-session identifiers, and the server can still derive internal
+`session_id`, `conversation_id`, `cart_id`, and `request_id` for legacy callers
+that do not send them.
 
 ## Identity Model
 
@@ -258,12 +260,14 @@ Implications:
   token-level model chunks. Token-level Deep Agents streaming is a follow-up
   after the harness migration is stable.
 
-### Slice 2: Server-Owned Identity
+### Slice 2: Stable Conversation Identity
 
-- Resolve internal `session_id`, `conversation_id`, `cart_id`, and `request_id`
-  server-side.
+- Accept explicit `session_id`, `conversation_id`, and `cart_id` from clients
+  that have a stable browser/session identity.
+- Keep deriving `request_id` server-side per turn.
 - Map `conversation_id` to the Deep Agents `thread_id`.
-- Keep the current request body compatible while the UI is unchanged.
+- Keep the current request body compatible for legacy callers.
+- The bundled UI now creates session-scoped IDs and sends them on every turn.
 - Add isolation tests before relying on this in production.
 
 ### Slice 3: Shopping Tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 - **[API Documentation](API.md)** - Complete API reference
 - **[Commerce Contracts](COMMERCE_CONTRACTS.md)** - Internal product, cart, and commerce tool contracts
 - **[Deep Agents Migration Plan](DEEP_AGENTS_MIGRATION_PLAN.md)** - SDK migration, session isolation, tools, skills, and scaling notes
+- **[Deep Agents Cart Tool Goal](DEEP_AGENTS_CART_TOOL_GOAL.md)** - Minimal cart-tool smoke gate and constraints
 - **[Architecture Overview](../README.md#architecture)** - System design and components
 - **[Configuration Guide](../README.md#configuration)** - Settings and customization
 
@@ -38,6 +39,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 | [API Documentation](API.md) | Complete API reference with examples | Developers, integrators |
 | [Commerce Contracts](COMMERCE_CONTRACTS.md) | Internal product, cart, and commerce tool contracts | Developers, architects |
 | [Deep Agents Migration Plan](DEEP_AGENTS_MIGRATION_PLAN.md) | SDK migration, session isolation, tools, skills, and scaling notes | Developers, architects |
+| [Deep Agents Cart Tool Goal](DEEP_AGENTS_CART_TOOL_GOAL.md) | Minimal cart-tool smoke gate and constraints | Developers, evaluators |
 | [Deployment Guide](DEPLOYMENT.md) | Installation and deployment instructions | DevOps, system administrators |
 | [Architecture Overview](../README.md#architecture) | System design and component details | Architects, developers |
 | [Configuration Guide](../README.md#configuration) | Settings and customization options | Developers, administrators |
@@ -170,6 +172,9 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 docs/
 ├── README.md           # This documentation hub
 ├── API.md             # API reference
+├── COMMERCE_CONTRACTS.md
+├── DEEP_AGENTS_MIGRATION_PLAN.md
+├── DEEP_AGENTS_CART_TOOL_GOAL.md
 ├── DEPLOYMENT.md      # Deployment guide
 ├── USER_GUIDE.md      # User guide
 └── assets/            # Images and diagrams

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -12,13 +12,15 @@ from __future__ import annotations
 
 import importlib
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Any, Dict, Iterator, List
 
 import pytest
 from fastapi.testclient import TestClient
 
 from chain_server.src.agenttypes import Cart, State
+from shared.commerce_contracts import Cart as CommerceCart
+from shared.commerce_contracts import CartLine, Money, ProductSummary
 
 
 class _StubRuntime:
@@ -304,6 +306,190 @@ class TestDeepAgentsRuntimeScopes:
         assert cart_user_ids == [222]
         assert state.context == "prior context"
         assert state.cart.contents == [{"item": "Bag", "amount": 1, "price": 20.0}]
+
+
+class TestDeepAgentsRuntimeRefs:
+    def test_search_and_cart_read_tools_are_chainable(
+        self,
+        base_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        captured: Dict[str, Any] = {}
+        deepagents_mod = ModuleType("deepagents")
+        tools_mod = ModuleType("langchain_core.tools")
+        openai_mod = ModuleType("langchain_openai")
+
+        class FakeProfile:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        class FakeChatOpenAI:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        def fake_tool(*, return_direct: bool = False):
+            def decorate(fn):
+                fn.return_direct = return_direct
+                return fn
+
+            return decorate
+
+        def fake_create_deep_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace()
+
+        deepagents_mod.GeneralPurposeSubagentProfile = FakeProfile
+        deepagents_mod.HarnessProfile = FakeProfile
+        deepagents_mod.create_deep_agent = fake_create_deep_agent
+        deepagents_mod.register_harness_profile = lambda *args, **kwargs: None
+        tools_mod.tool = fake_tool
+        openai_mod.ChatOpenAI = FakeChatOpenAI
+
+        monkeypatch.setitem(sys.modules, "deepagents", deepagents_mod)
+        monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
+        monkeypatch.setitem(sys.modules, "langchain_openai", openai_mod)
+
+        runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        identity = runtime_mod.RequestIdentity(
+            session_id="session-a",
+            conversation_id="conversation-a",
+            cart_id="cart-a",
+            context_user_id=111,
+            cart_user_id=222,
+            request_id="request-a",
+        )
+
+        runtime._create_agent(State(user_id=111, query="hello"), identity)
+
+        tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
+        assert tools_by_name["search_catalog_tool"].return_direct is False
+        assert tools_by_name["get_cart_tool"].return_direct is False
+        assert tools_by_name["add_cart_item_tool"].return_direct is True
+        assert tools_by_name["remove_cart_item_tool"].return_direct is True
+        assert tools_by_name["view_cart_total_tool"].return_direct is True
+
+    def test_product_refs_are_cached_by_conversation(
+        self,
+        base_config,
+    ) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        identity_a = runtime_mod.RequestIdentity(
+            session_id="session-a",
+            conversation_id="conversation-a",
+            cart_id="cart-a",
+            context_user_id=111,
+            cart_user_id=222,
+            request_id="request-a",
+        )
+        identity_b = runtime_mod.RequestIdentity(
+            session_id="session-b",
+            conversation_id="conversation-b",
+            cart_id="cart-b",
+            context_user_id=333,
+            cart_user_id=444,
+            request_id="request-b",
+        )
+        product = ProductSummary(
+            product_id="prod_123",
+            display_name="Silk Dress",
+            price=Money(amount=49.99),
+        )
+
+        runtime._remember_products(identity_a, [product])
+
+        assert runtime._product_from_ref(identity_a, "prod_123") == product
+        assert runtime._product_from_ref(identity_b, "prod_123") is None
+
+    def test_format_product_exposes_product_ref(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        product = ProductSummary(
+            product_id="prod_456",
+            display_name="Leather Bag",
+            description="structured tote",
+            price=Money(amount=129.0),
+        )
+
+        formatted = runtime_mod._format_product(product)
+
+        assert "PRODUCT_REF: prod_456" in formatted
+        assert "Leather Bag" in formatted
+
+    def test_format_cart_exposes_cart_line_id(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        cart = Cart(
+            contents=[
+                {
+                    "cart_line_id": "line_1",
+                    "product_id": "prod_123",
+                    "item": "Silk Dress",
+                    "amount": 2,
+                    "price": 49.99,
+                }
+            ]
+        )
+
+        formatted = runtime_mod._format_cart(cart)
+
+        assert "CART_LINE_ID: line_1" in formatted
+        assert "2 x Silk Dress" in formatted
+
+    def test_read_cart_preserves_cart_line_and_product_refs(
+        self,
+        base_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        contract_cart = CommerceCart(
+            user_id="222",
+            lines=[
+                CartLine(
+                    cart_line_id="line_1",
+                    product_id="prod_123",
+                    display_name="Silk Dress",
+                    quantity=2,
+                    unit_price=Money(amount=49.99),
+                )
+            ],
+        )
+
+        monkeypatch.setattr(
+            runtime_mod,
+            "get_cart",
+            lambda request, memory_port: SimpleNamespace(ok=True, cart=contract_cart),
+        )
+
+        cart = runtime._read_cart(222)
+
+        assert cart.contents == [
+            {
+                "cart_line_id": "line_1",
+                "product_id": "prod_123",
+                "item": "Silk Dress",
+                "amount": 2,
+                "price": 49.99,
+            }
+        ]
+
+    def test_cart_line_lookup_uses_exact_cart_line_id(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        cart = Cart(
+            contents=[
+                {"cart_line_id": "line_1", "item": "Silk Dress", "amount": 1},
+                {"cart_line_id": "line_2", "item": "Silk Dress", "amount": 1},
+            ]
+        )
+
+        assert runtime_mod._cart_line_by_id("line_2", cart) == cart.contents[1]
+        assert runtime_mod._cart_line_by_id("Silk Dress", cart) is None
 
 
 class TestValidation:

--- a/ui/src/components/chatbox/chatbox.tsx
+++ b/ui/src/components/chatbox/chatbox.tsx
@@ -30,7 +30,12 @@ import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import ChatMessage from "./ChatMessage";
 import { ChatboxProps } from "../../types";
 import { config } from "../../config/config";
-import { showCartNotification } from "../../utils";
+import {
+  clearUserSession,
+  createApiRequest,
+  getOrCreateUserSession,
+  showCartNotification,
+} from "../../utils";
 import logo from "../../assets/nvidia-logo.png";
 
 /**
@@ -66,15 +71,6 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
 
   // Utility functions
   const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-  const getOrCreateUserId = () => {
-    const storedId = sessionStorage.getItem('shopping_user_id');
-    if (storedId) return parseInt(storedId, 10);
-    
-    const newId = Date.now() * 1000 + Math.floor(Math.random() * 1000);
-    sessionStorage.setItem('shopping_user_id', String(newId));
-    return newId;
-  };
 
   const convertToBase64 = (file: File): Promise<string> => {
     return new Promise((resolve, reject) => {
@@ -193,7 +189,7 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
     // Clear previous cart operation notifications for new message
     shownCartOperations.current.clear();
 
-    const userId = getOrCreateUserId();
+    const userSession = getOrCreateUserSession();
     setIsLoading(true);
 
     // Will be used to enable submit shortly after the last token
@@ -224,13 +220,12 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
       setNewMessage("");
 
       // Prepare API request
-      const payload = {
-        user_id: userId,
-        query: newMessage,
-        guardrails: isGuardrailsOn,
-        image: image || "",
-        image_bool: !!image
-      };
+      const payload = createApiRequest(
+        userSession,
+        newMessage,
+        image || "",
+        isGuardrailsOn
+      );
       
       // Clear image immediately after preparing payload
       setImage("");
@@ -352,7 +347,7 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
     setImage("");
     setPreviewImage("");
     setNewRenderImage("");
-    sessionStorage.removeItem('shopping_user_id');
+    clearUserSession();
 
     // Add welcome messages
     addMessage(

--- a/ui/src/hooks/useChat.ts
+++ b/ui/src/hooks/useChat.ts
@@ -10,7 +10,7 @@ import { toast } from 'react-toastify';
 import { MessageData, ApiRequest, StreamingChunk, MessageRole } from '../types';
 import { config } from '../config/config';
 import { 
-  getOrCreateUserId, 
+  getOrCreateUserSession,
   createApiRequest, 
   parseStreamingChunk,
   sleep,
@@ -37,7 +37,8 @@ interface UseChatReturn {
 }
 
 export const useChat = (setNewRenderImage: (value: string) => void): UseChatReturn => {
-  const [userId, setUserId] = useState(getOrCreateUserId());
+  const [userSession, setUserSession] = useState(getOrCreateUserSession());
+  const [userId, setUserId] = useState(userSession.userId);
   const [messages, setMessages] = useState<MessageData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isGuardrailsOn, setIsGuardrailsOn] = useState(config.features.guardrails.defaultState);
@@ -127,7 +128,7 @@ export const useChat = (setNewRenderImage: (value: string) => void): UseChatRetu
       addMessage("assistant" as MessageRole, "loader", "");
 
       // Prepare API request
-      const payload = createApiRequest(userId, query, imageData || image, isGuardrailsOn);
+      const payload = createApiRequest(userSession, query, imageData || image, isGuardrailsOn);
       const url = `${config.api.baseUrl}${config.api.endpoints.stream}`;
 
       // Send request
@@ -239,7 +240,7 @@ export const useChat = (setNewRenderImage: (value: string) => void): UseChatRetu
     } finally {
       setIsLoading(false);
     }
-  }, [userId, isGuardrailsOn, image, previewImage, addMessage]);
+  }, [userSession, isGuardrailsOn, image, previewImage, addMessage]);
 
   const resetChat = useCallback(async () => {
     setMessages([]);
@@ -247,7 +248,9 @@ export const useChat = (setNewRenderImage: (value: string) => void): UseChatRetu
     setPreviewImage("");
     setNewRenderImage("");
     clearUserSession();
-    setUserId(getOrCreateUserId());
+    const nextSession = getOrCreateUserSession();
+    setUserId(nextSession.userId);
+    setUserSession(nextSession);
 
     // Add welcome messages
     addMessage(
@@ -289,4 +292,4 @@ export const useChat = (setNewRenderImage: (value: string) => void): UseChatRetu
     resetChat,
     downloadMessages,
   };
-}; 
+};

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -50,6 +50,9 @@ export interface ApiRequest {
   guardrails: boolean;
   image: string;
   image_bool: boolean;
+  session_id?: string;
+  conversation_id?: string;
+  cart_id?: string;
   context?: string;
   cart?: CartData;
   retrieved?: Record<string, string>;
@@ -78,6 +81,9 @@ export interface StreamingChunk {
 
 export interface UserSession {
   userId: number;
+  sessionId: string;
+  conversationId: string;
+  cartId: string;
   isActive: boolean;
   createdAt: Date;
 }
@@ -92,4 +98,4 @@ export interface ErrorState {
   hasError: boolean;
   message: string;
   code?: string;
-} 
+}

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -8,6 +8,9 @@
 import { FileUploadResult, UserSession, StreamingChunk, ApiRequest } from '../types';
 import { config } from '../config/config';
 
+const SESSION_STORAGE_KEY = 'shopping_session_identity';
+const LEGACY_USER_ID_KEY = 'shopping_user_id';
+
 /**
  * Convert a file to base64 string
  */
@@ -36,23 +39,38 @@ export const base64ToBlob = (base64: string): Blob => {
 };
 
 /**
- * Get or create a user ID from session storage
+ * Get or create a user ID from session storage.
  */
 export const getOrCreateUserId = (): number => {
-  const storedId = sessionStorage.getItem('shopping_user_id');
-  if (storedId) return parseInt(storedId, 10);
-  
-  // Use timestamp + random component to avoid collisions
-  const newId = Date.now() * 1000 + Math.floor(Math.random() * 1000);
-  sessionStorage.setItem('shopping_user_id', String(newId));
-  return newId;
+  return getOrCreateUserSession().userId;
+};
+
+/**
+ * Get or create the browser-scoped assistant identity sent to the API.
+ */
+export const getOrCreateUserSession = (): UserSession => {
+  const storedSession = readStoredUserSession();
+  if (storedSession) return storedSession;
+
+  const userId = getStoredUserId() || createUserId();
+  const session = {
+    userId,
+    sessionId: createScopedId('session'),
+    conversationId: createScopedId('conversation'),
+    cartId: createScopedId('cart'),
+    isActive: true,
+    createdAt: new Date(),
+  };
+  storeUserSession(session);
+  return session;
 };
 
 /**
  * Clear user session data
  */
 export const clearUserSession = (): void => {
-  sessionStorage.removeItem('shopping_user_id');
+  sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  sessionStorage.removeItem(LEGACY_USER_ID_KEY);
 };
 
 /**
@@ -104,18 +122,89 @@ export const parseStreamingChunk = (rawData: string): StreamingChunk | null => {
  * Create API request payload
  */
 export const createApiRequest = (
-  userId: number,
+  userSession: UserSession,
   query: string,
   image: string = '',
   guardrails: boolean = true
 ): ApiRequest => {
   return {
-    user_id: userId,
+    user_id: userSession.userId,
+    session_id: userSession.sessionId,
+    conversation_id: userSession.conversationId,
+    cart_id: userSession.cartId,
     query,
     guardrails,
     image,
     image_bool: !!image,
   };
+};
+
+const getStoredUserId = (): number | null => {
+  const storedId = sessionStorage.getItem(LEGACY_USER_ID_KEY);
+  if (!storedId) return null;
+
+  const parsed = parseInt(storedId, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const createUserId = (): number => {
+  const userId = Date.now() * 1000 + Math.floor(Math.random() * 1000);
+  sessionStorage.setItem(LEGACY_USER_ID_KEY, String(userId));
+  return userId;
+};
+
+const createScopedId = (prefix: string): string => {
+  const browserCrypto =
+    typeof crypto !== 'undefined'
+      ? (crypto as Crypto & { randomUUID?: () => string })
+      : undefined;
+  const randomId =
+    browserCrypto && typeof browserCrypto.randomUUID === 'function'
+      ? browserCrypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  return `${prefix}-${randomId}`;
+};
+
+const readStoredUserSession = (): UserSession | null => {
+  const storedSession = sessionStorage.getItem(SESSION_STORAGE_KEY);
+  if (!storedSession) return null;
+
+  try {
+    const parsed = JSON.parse(storedSession);
+    if (
+      typeof parsed.userId === 'number' &&
+      typeof parsed.sessionId === 'string' &&
+      typeof parsed.conversationId === 'string' &&
+      typeof parsed.cartId === 'string'
+    ) {
+      return {
+        userId: parsed.userId,
+        sessionId: parsed.sessionId,
+        conversationId: parsed.conversationId,
+        cartId: parsed.cartId,
+        isActive: true,
+        createdAt: parsed.createdAt ? new Date(parsed.createdAt) : new Date(),
+      };
+    }
+  } catch (error) {
+    sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  }
+
+  return null;
+};
+
+const storeUserSession = (session: UserSession): void => {
+  sessionStorage.setItem(LEGACY_USER_ID_KEY, String(session.userId));
+  sessionStorage.setItem(
+    SESSION_STORAGE_KEY,
+    JSON.stringify({
+      userId: session.userId,
+      sessionId: session.sessionId,
+      conversationId: session.conversationId,
+      cartId: session.cartId,
+      createdAt: session.createdAt.toISOString(),
+    })
+  );
 };
 
 /**
@@ -133,7 +222,7 @@ export const downloadMessages = (messages: any[], filename?: string): void => {
   const blob = new Blob([jsonStr], { type: 'application/json' });
   
   const date = new Date();
-  const timestamp = date.toISOString().replace(/[:\-]|\.\d{3}/g, '');
+  const timestamp = date.toISOString().replace(/[:-]|\.\d{3}/g, '');
   const defaultFilename = `messages_${timestamp}.json`;
   
   const url = URL.createObjectURL(blob);
@@ -278,4 +367,4 @@ export const showCartNotification = (
       }
     }
   }
-}; 
+};


### PR DESCRIPTION

### Summary

This PR adds the next minimum Deep Agents harness pieces for cart-safe shopping
turns:

- Refactors Deep Agents cart tools to use explicit `PRODUCT_REF` and
  `CART_LINE_ID` values instead of hidden product lookup or fuzzy cart matching.
- Sends stable browser-session `session_id`, `conversation_id`, and `cart_id`
  values from the UI on every turn.
- Maps `conversation_id` to the Deep Agents thread and keeps `cart_id` separate
  for cart state.
- Updates docs for the Level 1/Level 2 harness path and the remaining production
  follow-ups.

### Validation

- `python scripts/model_config.py deploy --build`
- Live cart smoke: `cart-smoke-20260704T050338Z` passed
- `.local-run/dev-venv/bin/python -m pytest -q unit/chain_server`
- `npm ci --no-audit --no-fund && npm run build`
- `git diff --check`