### PR TITLE
Add VLM media perception for uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,14 @@ export LLM_BASE_URL="${LLM_BASE_URL:-}"
 export LLM_MODEL="${LLM_MODEL:-}"
 
 # ---------------------------------------------------------------------------
+# Optional VLM media perception
+# ---------------------------------------------------------------------------
+
+export VLM_API_KEY="${VLM_API_KEY:-$NVIDIA_API_KEY}"
+export VLM_BASE_URL="${VLM_BASE_URL:-}"
+export VLM_MODEL="${VLM_MODEL:-}"
+
+# ---------------------------------------------------------------------------
 # Text embedding
 # ---------------------------------------------------------------------------
 
@@ -72,6 +80,7 @@ export LOCAL_NIM_CACHE="${LOCAL_NIM_CACHE:-$HOME/.cache/nim}"
 # export LLM_BASE_URL="http://HOST:8000/v1"
 # export TEXT_EMBED_BASE_URL="http://HOST:8001/v1"
 # export IMAGE_EMBED_BASE_URL="http://HOST:8002/v1"
+# export VLM_BASE_URL="http://HOST:8005/v1"
 # export RAILS_CONTENT_BASE_URL="http://HOST:8003/v1"
 # export RAILS_TOPIC_BASE_URL="http://HOST:8004/v1"
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@
 
 ## Overview
 
-The Retail Shopping Assistant is an AI-powered blueprint that provides a comprehensive interface for an intelligent retail shopping advisor. The chain server uses the Deep Agents SDK as the assistant harness over deterministic shopping tools, with SSE-framed responses, image-based search, and intelligent shopping cart management.
+The Retail Shopping Assistant is an AI-powered blueprint that provides a comprehensive interface for an intelligent retail shopping advisor. The chain server uses the Deep Agents SDK as the assistant harness over deterministic shopping tools, with SSE-framed responses, image-based search, optional VLM media perception, and intelligent shopping cart management.
 
 ### Key Features
 
 - 🤖 **Intelligent Product Search**: Find products using natural language or images
 - 🛒 **Smart Cart Management**: Add, remove, and manage shopping cart items
 - 🖼️ **Visual Search**: Upload images to find similar products
+- 🎥 **Optional VLM Media Perception**: Enable a VLM role to analyze image and video uploads in shopping context
 - 💬 **Conversational AI**: Natural language interactions
 - 🔒 **Content Safety**: Built-in moderation and safety checks
 - ⚡ **SSE Response Stream**: Event-stream response framing for chat clients; token-level Deep Agents streaming is a follow-up after the harness migration
@@ -110,7 +111,9 @@ For detailed architecture information, see [Architecture Overview](docs/README.m
    The helper prints resolved endpoints without printing API keys. By default,
    `shared/configs/models.yaml` uses NVIDIA Build hosted endpoints for the
    app LLM, text embeddings, image embeddings, and guardrails, and starts no
-   local NIM containers.
+   local NIM containers. The `vlm` role uses a hosted endpoint by default for
+   image/video media understanding in addition to image embedding search; set it
+   to `disabled` in `models.yaml` when that capability should be off.
 
    For local NIMs, edit the desired model roles in
    `shared/configs/models.yaml` to `source: local_nim`, then run:

--- a/chain_server/src/agenttypes.py
+++ b/chain_server/src/agenttypes.py
@@ -62,6 +62,14 @@ class State(BaseModel):
     cart: Cart = Field(default_factory=Cart, description="User's shopping cart")
     response: str = Field(default="", description="Generated response from agents")
     image: str = Field(default="", description="Base64 encoded image data")
+    media: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="Normalized media attachments for the current turn"
+    )
+    media_analysis: str = Field(
+        default="",
+        description="Structured VLM analysis for the current turn's media"
+    )
     retrieved: Dict[str, str] = Field(
         default_factory=dict,
         description="Dictionary of retrieved product information"

--- a/chain_server/src/config.py
+++ b/chain_server/src/config.py
@@ -28,6 +28,42 @@ def load_config_data(base_config_path: str) -> Dict[str, Any]:
     return config
 
 
+class MediaInputConfig(BaseModel):
+    """Configuration for user-attached media accepted by the chain server."""
+
+    enabled: bool = True
+    allow_mixed_media: bool = True
+    max_images_per_turn: int = 1
+    max_videos_per_turn: int = 1
+    image_mime_types: List[str] = Field(default_factory=lambda: ["image/jpeg", "image/png"])
+    video_mime_types: List[str] = Field(default_factory=lambda: ["video/mp4"])
+    max_image_bytes: int = 10 * 1024 * 1024
+    max_video_bytes: int = 50 * 1024 * 1024
+    max_video_duration_seconds: int = 120
+
+    @validator("max_images_per_turn", "max_videos_per_turn")
+    def validate_media_counts(cls, v):
+        if v < 0:
+            raise ValueError("media limits cannot be negative")
+        return v
+
+    @validator("max_image_bytes", "max_video_bytes", "max_video_duration_seconds")
+    def validate_positive_media_limits(cls, v):
+        if v <= 0:
+            raise ValueError("media size and duration limits must be positive")
+        return v
+
+    @validator("image_mime_types", "video_mime_types")
+    def validate_mime_types(cls, v):
+        if not v:
+            raise ValueError("media MIME type lists cannot be empty")
+        return v
+
+    class Config:
+        extra = "forbid"
+        validate_assignment = True
+
+
 class ChainServerConfig(BaseModel):
     """Configuration class for the chain server application."""
     
@@ -36,6 +72,11 @@ class ChainServerConfig(BaseModel):
     llm_name: str = Field(..., description="LLM model name")
     llm_api_key_env: Optional[str] = Field(default="LLM_API_KEY", description="LLM API key environment variable")
     llm_api_key_required: bool = Field(default=True, description="Whether the LLM key must be present")
+    vlm_port: Optional[str] = Field(default=None, description="Optional VLM service endpoint URL")
+    vlm_name: Optional[str] = Field(default=None, description="Optional VLM model name")
+    vlm_api_key_env: Optional[str] = Field(default=None, description="VLM API key environment variable")
+    vlm_api_key_required: bool = Field(default=False, description="Whether the VLM key must be present")
+    vlm_enabled: bool = Field(default=False, description="Whether VLM media perception is enabled")
     
     # Service Endpoints
     retriever_port: str = Field(..., description="Catalog retriever service endpoint")
@@ -61,6 +102,7 @@ class ChainServerConfig(BaseModel):
         ),
     )
     multimodal: bool = Field(..., description="Whether multimodal features are enabled")
+    media_input: MediaInputConfig = Field(default_factory=MediaInputConfig)
     
     # Safety Configuration
     unsafe_message: str = Field(..., description="Message to display for unsafe content")
@@ -69,6 +111,12 @@ class ChainServerConfig(BaseModel):
     def validate_urls(cls, v):
         """Validate that URLs are properly formatted."""
         if not v.startswith(('http://', 'https://')):
+            raise ValueError(f"URL must start with http:// or https://: {v}")
+        return v
+
+    @validator("vlm_port")
+    def validate_optional_vlm_url(cls, v):
+        if v is not None and not v.startswith(("http://", "https://")):
             raise ValueError(f"URL must start with http:// or https://: {v}")
         return v
     
@@ -137,12 +185,24 @@ def load_config(config_path: Optional[str] = None) -> ChainServerConfig:
     model_config = resolve_model_config(config_root=config_root)
     validate_model_config(model_config, roles=("app_llm",))
     app_llm = model_config.require("app_llm")
+    vlm = model_config.get("vlm")
+    if vlm is not None and not vlm.disabled:
+        validate_model_config(model_config, roles=("vlm",))
     config_data.update(
         {
             "llm_port": app_llm.base_url,
             "llm_name": app_llm.model,
             "llm_api_key_env": app_llm.api_key_env,
             "llm_api_key_required": app_llm.api_key_required,
+            "vlm_enabled": bool(vlm is not None and not vlm.disabled),
+            "vlm_port": vlm.base_url if vlm is not None and not vlm.disabled else None,
+            "vlm_name": vlm.model if vlm is not None and not vlm.disabled else None,
+            "vlm_api_key_env": (
+                vlm.api_key_env if vlm is not None and not vlm.disabled else None
+            ),
+            "vlm_api_key_required": (
+                vlm.api_key_required if vlm is not None and not vlm.disabled else False
+            ),
         }
     )
     

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 from typing import Any, AsyncIterator
 import uuid
@@ -24,6 +25,7 @@ from .commerce_tools import (
     remove_cart_item,
     search_catalog,
 )
+from .media_perception import MEDIA_ONLY_QUERY, MediaPerceptionClient
 from shared.commerce_contracts import (
     AddCartItemInput,
     GetCartInput,
@@ -69,6 +71,7 @@ class DeepAgentsRuntime:
         self._checkpointer = MemorySaver()
         self._profile_registered = False
         self._product_refs: dict[str, dict[str, ProductSummary]] = {}
+        self._media_perception = MediaPerceptionClient(config)
 
     async def astream(
         self, state: State, identity: RequestIdentity
@@ -99,6 +102,11 @@ class DeepAgentsRuntime:
             state.timings["deepagents"] = time.monotonic() - start
             return state
 
+        media_start = time.monotonic()
+        state.media_analysis = await self._media_perception.analyze(state)
+        if state.media:
+            state.timings["media_perception"] = time.monotonic() - media_start
+
         agent = self._create_agent(state, identity)
         input_message = self._build_user_message(state, identity)
         try:
@@ -122,7 +130,12 @@ class DeepAgentsRuntime:
         if state.guardrails and not self._check_safety("output", identity.context_user_id, state.response):
             state.response = self.config.unsafe_message
 
-        state.context = self._updated_context(state.context, state.query, state.response)
+        state.context = self._updated_context(
+            state.context,
+            state.query,
+            state.response,
+            media_analysis=state.media_analysis,
+        )
         self._persist_context(state, identity)
         state.timings["deepagents"] = time.monotonic() - start
         return state
@@ -159,6 +172,14 @@ class DeepAgentsRuntime:
         ) -> str:
             """Search available catalog products. Use for product discovery and image-similar shopping."""
 
+            if state.media and not _media_query_allows_catalog_search(state.query):
+                return (
+                    "Catalog search skipped: the shopper asked for visual/style "
+                    "analysis, not product retrieval. Answer from MEDIA ANALYSIS "
+                    "only and do not discuss catalog availability, prices, or "
+                    "specific products."
+                )
+
             categories = self._tool_categories(category)
             filters = {
                 key: value
@@ -176,6 +197,19 @@ class DeepAgentsRuntime:
                 self.config.retriever_port,
                 timeout_seconds=self.config.catalog_search_timeout_seconds,
             )
+            fallback_used = False
+            if state.image and state.media_analysis and not result.products and query.strip():
+                result = search_catalog(
+                    SearchCatalogInput(
+                        query=query,
+                        categories=categories,
+                        filters=filters,
+                        top_k=self.config.top_k_retrieve,
+                    ),
+                    self.config.retriever_port,
+                    timeout_seconds=self.config.catalog_search_timeout_seconds,
+                )
+                fallback_used = bool(result.products)
             if not result.ok:
                 return result.error.message if result.error else "Catalog search failed."
             if not result.products:
@@ -187,7 +221,12 @@ class DeepAgentsRuntime:
                 if product.image_url:
                     retrieved[product.display_name] = product.image_url
                 lines.append(_format_product(product))
-            return "\n\n".join(lines)
+            prefix = (
+                "Image similarity returned no matches; text fallback results:\n\n"
+                if fallback_used
+                else ""
+            )
+            return prefix + "\n\n".join(lines)
 
         @tool(return_direct=False)
         def get_cart_tool() -> str:
@@ -292,6 +331,11 @@ Available catalog categories: {categories}
 Rules:
 - Product discovery, product recommendations, budget filters, and image-similar
   shopping require search_catalog_tool.
+- Media-only or descriptive media requests such as "what's in this look",
+  "describe this outfit", "what am I wearing", or "what colors are here" must
+  be answered from MEDIA ANALYSIS. Do not call search_catalog_tool and do not
+  show catalog products unless the shopper explicitly asks to find, shop,
+  recommend, compare, price-check, check availability, or add an item.
 - Use at most one catalog search per user turn. Search with the complete user
   request rather than running many keyword probes. If one search is not enough,
   answer from the results you have or ask one concise clarifying question.
@@ -303,6 +347,12 @@ Rules:
 - If an image is attached, the current image is already available to
   search_catalog_tool. Use that tool for "this", "similar", and image-price
   refinement requests.
+- If MEDIA ANALYSIS is present, use it as the visual/video understanding of
+  the attached media. It can guide search_catalog_tool queries and follow-up
+  pronoun resolution, but catalog tool results remain the source of truth for
+  product names, prices, and availability.
+- If video understanding is unavailable, say so plainly or ask the shopper for
+  a text description. Do not invent visual details.
 - Cart reads require get_cart_tool. Cart totals require view_cart_total_tool.
 - Cart mutations require explicit shopper intent and must use add_cart_item_tool
   or remove_cart_item_tool. Never claim a cart mutation unless the tool reports
@@ -327,6 +377,8 @@ Rules:
             f"CART ID: {identity.cart_id}\n\n"
             f"USER QUERY: {state.query}\n"
             f"IMAGE ATTACHED: {'yes' if state.image else 'no'}\n\n"
+            f"MEDIA ATTACHED:\n{_format_media_summary(state.media)}\n\n"
+            f"MEDIA ANALYSIS:\n{state.media_analysis or '(none)'}\n\n"
             f"CURRENT CART:\n{_format_cart(state.cart)}\n\n"
             f"RECENT DISCUSSION:\n{state.context or '(none)'}"
         )
@@ -416,8 +468,18 @@ Rules:
             return True
         return responses[0].get("content") == text
 
-    def _updated_context(self, old_context: str, query: str, response: str) -> str:
-        new_context = f"{old_context}\nUser: {query}\nAssistant: {response}".strip()
+    def _updated_context(
+        self,
+        old_context: str,
+        query: str,
+        response: str,
+        *,
+        media_analysis: str = "",
+    ) -> str:
+        media_line = f"\nMedia analysis: {media_analysis}" if media_analysis else ""
+        new_context = (
+            f"{old_context}\nUser: {query}{media_line}\nAssistant: {response}"
+        ).strip()
         max_chars = max(1000, int(self.config.memory_length))
         return new_context[-max_chars:]
 
@@ -451,6 +513,64 @@ def create_request_identity(
 def _stable_numeric_id(namespace: str, value: str) -> int:
     digest = hashlib.sha256(f"{namespace}:{value}".encode("utf-8")).hexdigest()
     return int(digest[:15], 16)
+
+
+_EXPLICIT_MEDIA_CATALOG_PATTERNS = (
+    "do you have",
+    "do you carry",
+    "do you sell",
+    "in stock",
+    "available",
+    "availability",
+    "find",
+    "search",
+    "shop",
+    "buy",
+    "purchase",
+    "browse",
+    "show me",
+    "recommend",
+    "suggest",
+    "options",
+    "something like this",
+    "anything like this",
+    "like these",
+    "like this under",
+    "under $",
+    "less than",
+    "cheaper",
+    "budget",
+    "price",
+    "cost",
+    "sale",
+    "add",
+    "cart",
+    "catalog",
+    "product",
+    "products",
+)
+
+_DESCRIPTIVE_MEDIA_QUERY_RE = re.compile(
+    r"^\s*(what(?:'s| is| are)?|describe|break down|analy[sz]e|tell me about|"
+    r"identify|explain|rate)\b",
+    re.IGNORECASE,
+)
+
+
+def _media_query_allows_catalog_search(query: str) -> bool:
+    """Return whether a media-attached turn has explicit shopping intent."""
+
+    normalized = " ".join((query or "").strip().lower().split())
+    if not normalized or normalized == MEDIA_ONLY_QUERY.lower():
+        return False
+
+    if any(pattern in normalized for pattern in _EXPLICIT_MEDIA_CATALOG_PATTERNS):
+        return True
+
+    if _DESCRIPTIVE_MEDIA_QUERY_RE.search(normalized):
+        return False
+
+    return False
 
 
 def _extract_final_text(result: Any) -> str:
@@ -534,6 +654,16 @@ def _format_cart_total(cart: Cart) -> str:
     if missing:
         total += f" excluding items without cached prices: {', '.join(missing)}"
     return "\n".join(lines + [total])
+
+
+def _format_media_summary(media: list[dict[str, Any]]) -> str:
+    if not media:
+        return "(none)"
+    counts: dict[str, int] = {}
+    for item in media:
+        media_type = str(item.get("type") or "unknown")
+        counts[media_type] = counts.get(media_type, 0) + 1
+    return ", ".join(f"{count} {media_type}(s)" for media_type, count in sorted(counts.items()))
 
 
 def _cart_line_by_id(cart_line_id: str, cart: Cart) -> dict[str, Any] | None:

--- a/chain_server/src/main.py
+++ b/chain_server/src/main.py
@@ -10,16 +10,19 @@ including query processing and streaming responses.
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-from typing import Optional, Dict
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, List, Literal, Any
+import base64
 import logging
 import sys
 import time
 import json
+import re
 
 from .agenttypes import State, Cart
 from .config import load_config
 from .deepagents_runtime import DeepAgentsRuntime, create_request_identity
+from .media_perception import MEDIA_ONLY_QUERY
 
 # Configure logging
 logging.basicConfig(
@@ -55,11 +58,21 @@ app.add_middleware(
 
 
 # Request/Response models
+class MediaItem(BaseModel):
+    """Request model for attached visual media."""
+
+    type: Literal["image", "video"]
+    data: str
+    mime_type: str = ""
+    filename: Optional[str] = None
+
+
 class QueryRequest(BaseModel):
     """Request model for shopping queries."""
     user_id: int
     query: str
     image: str = ""
+    media: List[MediaItem] = Field(default_factory=list)
     session_id: Optional[str] = None
     conversation_id: Optional[str] = None
     cart_id: Optional[str] = None
@@ -79,10 +92,16 @@ class QueryResponse(BaseModel):
 
 def create_initial_state(request: QueryRequest) -> State:
     """Create initial state from request."""
+    media = _normalized_media(request)
+    first_image = next(
+        (item["data"] for item in media if item.get("type") == "image"),
+        request.image,
+    )
     return State(
         user_id=request.user_id,
         query=request.query,
-        image=request.image,
+        image=first_image,
+        media=media,
         context=request.context or "",
         cart=request.cart or Cart(),
         guardrails=request.guardrails,
@@ -99,9 +118,12 @@ async def process_query_stream(request: QueryRequest):
     try:
         logger.info(f"chain-server | /query/stream | Processing streaming query for user {request.user_id}: {request.query}")
         
-        # Handle image-only queries
-        if request.image and not request.query:
-            request.query = "The user has submitted an image, and is looking for items from the catalog that appear similar."
+        media = _normalized_media(request)
+        _validate_media(media)
+
+        # Handle media-only queries
+        if media and not request.query:
+            request.query = MEDIA_ONLY_QUERY
         
         # Create initial state
         state = create_initial_state(request)
@@ -124,6 +146,8 @@ async def process_query_stream(request: QueryRequest):
 
         return StreamingResponse(send_updates(), media_type="text/event-stream")
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error processing streaming query: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -138,6 +162,11 @@ async def process_query_timing(request: QueryRequest):
     try:
         logger.info(f"chain-server | /query/timing | Processing timing query for user {request.user_id}: {request.query}")
         
+        media = _normalized_media(request)
+        _validate_media(media)
+        if media and not request.query:
+            request.query = MEDIA_ONLY_QUERY
+
         # Create initial state
         state = create_initial_state(request)
         identity = create_request_identity(
@@ -167,6 +196,8 @@ async def process_query_timing(request: QueryRequest):
         logger.info(f"chain-server | /query | Successfully processed timing query in {total_time:.2f}s")
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error processing timing query: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -181,6 +212,26 @@ async def health_check():
     }
 
 
+@app.get("/capabilities")
+async def capabilities():
+    """Return runtime capabilities that the UI should enforce."""
+    media_config = config.media_input
+    return {
+        "media_input": {
+            "enabled": media_config.enabled,
+            "allow_mixed_media": media_config.allow_mixed_media,
+            "max_images_per_turn": media_config.max_images_per_turn,
+            "max_videos_per_turn": media_config.max_videos_per_turn,
+            "image_mime_types": media_config.image_mime_types,
+            "video_mime_types": media_config.video_mime_types,
+            "max_image_bytes": media_config.max_image_bytes,
+            "max_video_bytes": media_config.max_video_bytes,
+            "max_video_duration_seconds": media_config.max_video_duration_seconds,
+            "vlm_enabled": config.vlm_enabled,
+        }
+    }
+
+
 @app.get("/")
 async def root():
     """Root endpoint with API information."""
@@ -191,7 +242,142 @@ async def root():
             "query": "/query",
             "stream": "/query/stream",
             "timing": "/query/timing",
+            "capabilities": "/capabilities",
             "health": "/health",
             "docs": "/docs"
         }
     }
+
+
+_DATA_URL_RE = re.compile(r"^data:([^;]+);base64,(.*)$", re.IGNORECASE | re.DOTALL)
+
+
+def _normalized_media(request: QueryRequest) -> List[Dict[str, str]]:
+    """Normalize legacy image and media[] into one internal media list."""
+    normalized: List[Dict[str, str]] = []
+    if request.image.strip():
+        image_data = request.image.strip()
+        image_mime_type = _mime_from_data_url(image_data) or "image/jpeg"
+        if not _mime_from_data_url(image_data):
+            image_data = f"data:{image_mime_type};base64,{image_data}"
+        normalized.append(
+            {
+                "type": "image",
+                "data": image_data,
+                "mime_type": image_mime_type,
+            }
+        )
+
+    seen_data = {item["data"] for item in normalized}
+    for item in request.media:
+        data = item.data.strip()
+        if not data:
+            continue
+        mime_type = (item.mime_type or _mime_from_data_url(data) or "").strip()
+        if mime_type and not _mime_from_data_url(data):
+            data = f"data:{mime_type};base64,{data}"
+        if data in seen_data:
+            continue
+        normalized.append(
+            {
+                "type": item.type,
+                "data": data,
+                "mime_type": mime_type,
+                "filename": item.filename or "",
+            }
+        )
+        seen_data.add(data)
+    return normalized
+
+
+def _validate_media(media: List[Dict[str, str]]) -> None:
+    if not media:
+        return
+
+    media_config = config.media_input
+    if not media_config.enabled:
+        raise HTTPException(status_code=400, detail="Media uploads are disabled.")
+
+    images = [item for item in media if item.get("type") == "image"]
+    videos = [item for item in media if item.get("type") == "video"]
+    if len(images) > media_config.max_images_per_turn:
+        raise HTTPException(
+            status_code=400,
+            detail=f"At most {media_config.max_images_per_turn} image(s) are allowed per turn.",
+        )
+    if len(videos) > media_config.max_videos_per_turn:
+        raise HTTPException(
+            status_code=400,
+            detail=f"At most {media_config.max_videos_per_turn} video(s) are allowed per turn.",
+        )
+    if not media_config.allow_mixed_media and images and videos:
+        raise HTTPException(
+            status_code=400,
+            detail="Mixed image and video uploads are not enabled.",
+        )
+
+    for item in media:
+        mime_type = item.get("mime_type") or _mime_from_data_url(item.get("data", ""))
+        if item.get("type") == "image":
+            _validate_media_item(
+                item,
+                allowed_mime_types=media_config.image_mime_types,
+                max_bytes=media_config.max_image_bytes,
+                fallback_label="image",
+            )
+        elif item.get("type") == "video":
+            _validate_media_item(
+                item,
+                allowed_mime_types=media_config.video_mime_types,
+                max_bytes=media_config.max_video_bytes,
+                fallback_label="video",
+            )
+        elif mime_type:
+            raise HTTPException(status_code=400, detail="Unsupported media type.")
+
+
+def _validate_media_item(
+    item: Dict[str, str],
+    *,
+    allowed_mime_types: List[str],
+    max_bytes: int,
+    fallback_label: str,
+) -> None:
+    data = item.get("data", "")
+    mime_type = item.get("mime_type") or _mime_from_data_url(data)
+    if mime_type not in allowed_mime_types:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported {fallback_label} MIME type. Allowed: "
+                f"{', '.join(allowed_mime_types)}."
+            ),
+        )
+
+    try:
+        byte_count = _data_url_byte_count(data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if byte_count > max_bytes:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{fallback_label.title()} upload exceeds the configured size limit.",
+        )
+
+
+def _mime_from_data_url(data: str) -> str:
+    match = _DATA_URL_RE.match((data or "").strip())
+    return match.group(1).lower() if match else ""
+
+
+def _data_url_byte_count(data: str) -> int:
+    match = _DATA_URL_RE.match((data or "").strip())
+    if not match:
+        encoded = (data or "").strip()
+    else:
+        encoded = match.group(2).strip()
+    encoded += "=" * (-len(encoded) % 4)
+    try:
+        return len(base64.b64decode(encoded, validate=True))
+    except Exception as exc:  # noqa: BLE001 - normalize validation errors.
+        raise ValueError("Media is not valid base64.") from exc

--- a/chain_server/src/media_perception.py
+++ b/chain_server/src/media_perception.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""VLM-backed media perception for user-attached shopping media."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any
+
+from openai import OpenAI
+
+from .agenttypes import State
+
+
+logger = logging.getLogger(__name__)
+
+MEDIA_ONLY_QUERY = "The user submitted visual media without additional text."
+
+
+class MediaPerceptionClient:
+    """Small adapter around the configured VLM endpoint."""
+
+    def __init__(self, config: Any) -> None:
+        self.config = config
+        self.enabled = bool(
+            getattr(config, "vlm_enabled", False)
+            and getattr(config, "vlm_port", None)
+            and getattr(config, "vlm_name", None)
+        )
+        self.model_name = getattr(config, "vlm_name", None)
+        api_key_env = getattr(config, "vlm_api_key_env", None)
+        api_key = os.environ.get(api_key_env, "") if api_key_env else "not-needed"
+        self.client = (
+            OpenAI(base_url=getattr(config, "vlm_port"), api_key=api_key or "not-needed")
+            if self.enabled
+            else None
+        )
+
+    async def analyze(self, state: State) -> str:
+        """Return compact structured media analysis for the current turn."""
+
+        media = state.media or []
+        if not media:
+            return ""
+
+        if not self.enabled or self.client is None or not self.model_name:
+            return _disabled_analysis(media)
+
+        try:
+            response = await asyncio.to_thread(
+                self.client.chat.completions.create,
+                model=self.model_name,
+                messages=self._messages(state),
+                temperature=0,
+                max_tokens=1200,
+                extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+            )
+            content = response.choices[0].message.content or ""
+        except Exception as exc:  # noqa: BLE001 - media perception is optional.
+            logger.warning("VLM media perception failed: %s", exc)
+            return json.dumps(
+                {
+                    "summary": "Media was attached, but VLM media analysis failed.",
+                    "fashion_items": [],
+                    "style_terms": [],
+                    "colors": [],
+                    "materials_or_textures": [],
+                    "occasion": [],
+                    "search_queries": [],
+                    "constraints_detected": {},
+                    "uncertainties": ["VLM media analysis failed."],
+                    "safety_notes": [],
+                },
+                sort_keys=True,
+            )
+
+        return _normalize_vlm_content(content)
+
+    def _messages(self, state: State) -> list[dict[str, Any]]:
+        prompt = _perception_prompt(state.query, state.context)
+        content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+        for item in state.media:
+            media_type = str(item.get("type") or "").strip().lower()
+            data = str(item.get("data") or "").strip()
+            if not data:
+                continue
+            if media_type == "image":
+                content.append({"type": "image_url", "image_url": {"url": data}})
+            elif media_type == "video":
+                content.append({"type": "video_url", "video_url": {"url": data}})
+
+        return [
+            {
+                "role": "system",
+                "content": (
+                    "You are a visual media perception module for a fashion retail "
+                    "shopping assistant. Return compact JSON only."
+                ),
+            },
+            {"role": "user", "content": content},
+        ]
+
+
+def _perception_prompt(query: str, context: str) -> str:
+    query_text = (query or "").strip()
+    if not query_text or query_text == MEDIA_ONLY_QUERY:
+        task = (
+            "No user text was supplied. Study the attached media neutrally for a "
+            "fashion retail assistant."
+        )
+    else:
+        task = f"User request: {query_text}"
+
+    recent = (context or "").strip()
+    if len(recent) > 2000:
+        recent = recent[-2000:]
+
+    return f"""\
+{task}
+
+Recent conversation context:
+{recent or "(none)"}
+
+Focus on visible apparel, accessories, colors, materials or textures, silhouette,
+style, occasion, and shopping-relevant attributes. Do not identify people or
+infer sensitive traits. Separate visual observations from catalog facts; you do
+not know catalog availability.
+
+Return JSON with exactly these keys:
+summary, fashion_items, style_terms, colors, materials_or_textures, occasion,
+search_queries, constraints_detected, uncertainties, safety_notes.
+"""
+
+
+def _disabled_analysis(media: list[dict[str, Any]]) -> str:
+    has_video = any(str(item.get("type") or "").lower() == "video" for item in media)
+    if not has_video:
+        return ""
+    return json.dumps(
+        {
+            "summary": "Video was attached, but VLM media understanding is not configured.",
+            "fashion_items": [],
+            "style_terms": [],
+            "colors": [],
+            "materials_or_textures": [],
+            "occasion": [],
+            "search_queries": [],
+            "constraints_detected": {},
+            "uncertainties": ["Video understanding requires an enabled VLM."],
+            "safety_notes": [],
+        },
+        sort_keys=True,
+    )
+
+
+def _normalize_vlm_content(content: str) -> str:
+    cleaned = (content or "").strip()
+    if not cleaned:
+        return json.dumps(
+            {
+                "summary": "Media was attached, but the VLM returned no analysis.",
+                "fashion_items": [],
+                "style_terms": [],
+                "colors": [],
+                "materials_or_textures": [],
+                "occasion": [],
+                "search_queries": [],
+                "constraints_detected": {},
+                "uncertainties": ["VLM returned an empty response."],
+                "safety_notes": [],
+            },
+            sort_keys=True,
+        )
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        return json.dumps(
+            {
+                "summary": cleaned[:1000],
+                "fashion_items": [],
+                "style_terms": [],
+                "colors": [],
+                "materials_or_textures": [],
+                "occasion": [],
+                "search_queries": [],
+                "constraints_detected": {},
+                "uncertainties": ["VLM did not return structured JSON."],
+                "safety_notes": [],
+            },
+            sort_keys=True,
+        )
+
+    if not isinstance(parsed, dict):
+        parsed = {"summary": str(parsed)}
+    return json.dumps(parsed, sort_keys=True)[:4000]

--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -50,6 +50,27 @@ services:
       retries: 60
       start_period: 60s
 
+  nemotron-omni:
+    image: nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:latest
+    ports:
+      - "8005:8000"
+    environment:
+      - NGC_API_KEY=${NGC_API_KEY}
+    volumes:
+      - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
+    user: "${UID:-1000}"
+    shm_size: "32gb"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['0','1']
+              capabilities: [gpu]
+    restart: "no"
+    networks:
+      - shopping-network
+
   embedqa:
     image: nvcr.io/nim/nvidia/nv-embedqa-e5-v5:1.6
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,9 @@ services:
       - LLM_API_KEY=${LLM_API_KEY:-}
       - LLM_BASE_URL=${LLM_BASE_URL:-}
       - LLM_MODEL=${LLM_MODEL:-}
+      - VLM_API_KEY=${VLM_API_KEY:-}
+      - VLM_BASE_URL=${VLM_BASE_URL:-}
+      - VLM_MODEL=${VLM_MODEL:-}
       - CATALOG_RETRIEVER_URL=http://catalog-retriever:8010
       - MEMORY_RETRIEVER_URL=http://memory-retriever:8011
     volumes:

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,7 +20,7 @@ The Retail Shopping Assistant API provides a comprehensive interface for an AI-p
 ### Key Features
 
 - **Real-time Streaming**: Server-Sent Events (SSE) for live responses
-- **Multi-modal Input**: Text queries and image uploads
+- **Multi-modal Input**: Text queries, image uploads, and optional VLM-backed video/image understanding
 - **Shopping Cart Management**: Add, remove, and view cart items
 - **Content Safety**: Built-in guardrails for safe interactions
 - **Performance Monitoring**: Detailed timing information
@@ -45,7 +45,8 @@ The main request model for all shopping queries.
 interface QueryRequest {
   user_id: number;                    // Unique user identifier
   query: string;                      // User's text query
-  image?: string;                     // Base64 encoded image (optional)
+  image?: string;                     // Legacy base64/data-URL image (optional)
+  media?: MediaAttachment[];          // Image/video attachments (optional)
   session_id?: string;                // Optional website/browser session identifier
   conversation_id?: string;           // Optional chat thread identifier
   cart_id?: string;                   // Optional cart identifier
@@ -55,6 +56,13 @@ interface QueryRequest {
   guardrails?: boolean;               // Enable content safety (default: true)
   image_bool?: boolean;               // Indicate if image is provided (default: false)
 }
+
+interface MediaAttachment {
+  type: 'image' | 'video';
+  data: string;                       // Base64 data URL, or raw base64 with mime_type
+  mime_type: string;                  // image/jpeg, image/png, or video/mp4 by default
+  filename?: string;
+}
 ```
 
 **Example:**
@@ -63,6 +71,7 @@ interface QueryRequest {
   "user_id": 123,
   "query": "Show me red dresses under $100",
   "image": "",
+  "media": [],
   "session_id": "session_abc",
   "conversation_id": "conversation_abc",
   "cart_id": "cart_abc",
@@ -91,6 +100,31 @@ scopes the Deep Agents thread and conversation memory, while `cart_id` scopes
 cart reads/writes. Production website integrations should move these IDs to a
 server-owned session/thread service before broad rollout so customer context and
 cart state cannot bleed across sessions.
+
+`image` remains supported for backward compatibility and is normalized into the
+same internal media list as `media[]`. New clients should use `media[]` for
+video uploads. The bundled UI calls `/capabilities` on load and enforces the
+configured media counts, MIME types, byte limits, and video duration limit.
+
+### Multi-modal Input
+
+Uploaded images can be used in two ways:
+
+- Image embedding search through the catalog retriever when image embeddings
+  are configured.
+- Optional VLM media perception when the `vlm` model role is enabled in
+  `shared/configs/models.yaml`.
+
+Uploaded videos require VLM media perception. If VLM is disabled, video
+understanding is unavailable and the assistant should not invent visual
+details. The VLM analysis is passed to the Deep Agents runtime as concise text
+context; raw media is not persisted into conversation memory.
+
+Descriptive media requests such as "what's in this look" or "describe this
+outfit" are answered from VLM media analysis and should not trigger catalog
+retrieval or product image cards. Catalog retrieval is reserved for explicit
+shopping intent, such as finding similar items, checking availability or price,
+asking for recommendations, or adding an item to the cart.
 
 ### QueryResponse
 
@@ -226,6 +260,32 @@ curl -X POST "http://localhost:8000/query/timing" \
 }
 ```
 
+### GET `/capabilities`
+
+Returns runtime media settings that clients should enforce before upload.
+The byte limits are raw client file sizes. Browser clients send attachments as
+base64 JSON data URLs, so reverse proxies must allow roughly 4/3 of the largest
+raw media limit plus JSON overhead. The default nginx configuration uses
+`client_max_body_size 80m` for the 50 MiB video limit below.
+
+**Response:**
+```json
+{
+  "media_input": {
+    "enabled": true,
+    "allow_mixed_media": true,
+    "max_images_per_turn": 1,
+    "max_videos_per_turn": 1,
+    "image_mime_types": ["image/jpeg", "image/png"],
+    "video_mime_types": ["video/mp4"],
+    "max_image_bytes": 10485760,
+    "max_video_bytes": 52428800,
+    "max_video_duration_seconds": 120,
+    "vlm_enabled": true
+  }
+}
+```
+
 ### GET `/health`
 
 Health check endpoint to verify service status.
@@ -258,6 +318,7 @@ Root endpoint with API information.
     "query": "/query",
     "stream": "/query/stream",
     "timing": "/query/timing",
+    "capabilities": "/capabilities",
     "health": "/health",
     "docs": "/docs"
   }
@@ -563,8 +624,12 @@ print(f"Timing: {response['timings']}")
 ## 📝 Notes
 
 - All timestamps are in Unix timestamp format (seconds since epoch)
-- Image data should be base64 encoded without the data URL prefix
+- Image data may be raw base64 or a `data:` URL; video media should include
+  `mime_type: "video/mp4"` and is sent through `media[]`
 - The API supports both local and cloud-based NIM deployments
+- The `vlm` model role is enabled by default for image/video media perception
+  and can be set to `disabled`; image embedding search remains separately controlled by the
+  `image_embedding` model role and `CATALOG_IMAGE_EMBEDDING_ENABLED`.
 - Content safety is enabled by default but can be disabled per request
 - `/query/stream` uses SSE framing. Token-level Deep Agents streaming is a
   known follow-up after the harness migration; this slice emits completed turn

--- a/docs/DEEP_AGENTS_MIGRATION_PLAN.md
+++ b/docs/DEEP_AGENTS_MIGRATION_PLAN.md
@@ -42,6 +42,13 @@ Current constraints:
 - Catalog search and cart-read tools return to the Deep Agents loop so a single
   shopper turn can discover products or read the cart before mutating it.
   Mutating cart tools return directly with the authoritative cart result.
+- Optional VLM media perception runs before the Deep Agents turn when the
+  `vlm` model role is enabled. It converts attached image/video media into a
+  concise `MEDIA ANALYSIS` text block. Raw media is not persisted in
+  conversation memory. Descriptive look-analysis requests are answered from
+  `MEDIA ANALYSIS` without catalog retrieval; catalog tools remain authoritative
+  for product names, prices, and availability when the shopper explicitly asks
+  to find, compare, price-check, or add products.
 
 Filesystem and built-in Deep Agents tools:
 
@@ -189,6 +196,7 @@ logic:
 
 - `product_discovery`
 - `image_shopping`
+- `video_shopping` when VLM media perception is enabled
 - `cart_management`
 - `budget_sensitive_recommendation`
 - `persona_aware_recommendation`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -323,6 +323,7 @@ docker stack deploy -c docker-compose.prod.yaml retail-assistant
 |----------|-------------|----------|---------|
 | `NGC_API_KEY` | NVIDIA NGC API key | Yes | - |
 | `LLM_API_KEY` | Language model API key | Yes | - |
+| `VLM_API_KEY` | Optional VLM media perception API key | When `vlm` uses an authenticated endpoint | - |
 | `EMBED_API_KEY` | Embedding model API key | Yes | - |
 | `RAIL_API_KEY` | Guardrails API key | Yes | - |
 | `CATALOG_SEARCH_TIMEOUT_SECONDS` | Optional chain-server timeout for catalog search requests | No | no timeout |
@@ -412,6 +413,11 @@ roles that do not need request-time auth, use `api_key_env: null`. Local NIM
 container startup credentials are separate and are listed once under
 `local_nims.required_env`.
 
+The `vlm` role controls image/video media perception for user uploads. It uses
+a hosted endpoint by default and can be set to `disabled` when media perception
+should be off. Image embedding search remains controlled separately by the
+`image_embedding` role and `CATALOG_IMAGE_EMBEDDING_ENABLED`.
+
 #### Standard Deployment Flow
 
 ```bash
@@ -472,6 +478,29 @@ models:
     source: local_nim
     provider: openai_compatible
     local_service: nvclip
+    api_key_env: null
+```
+
+For VLM media perception through a hosted endpoint:
+
+```yaml
+models:
+  vlm:
+    source: endpoint
+    provider: openai_compatible
+    base_url_env: VLM_BASE_URL
+    model_env: VLM_MODEL
+    api_key_env: VLM_API_KEY
+```
+
+For VLM media perception through the Compose-managed local Omni NIM:
+
+```yaml
+models:
+  vlm:
+    source: local_nim
+    provider: openai_compatible
+    local_service: nemotron_omni
     api_key_env: null
 ```
 
@@ -750,6 +779,11 @@ deploy:
 ```
 
 ### Load Balancing
+
+The bundled UI sends uploaded media as base64 JSON. Keep any reverse proxy
+request-body limit aligned with `media_input.max_video_bytes` after base64
+expansion. With the default 50 MiB raw video cap, `nginx.conf` uses
+`client_max_body_size 80m`.
 
 ```yaml
 # nginx.conf

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,9 +88,9 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 - [API - Cart Operations](API.md#shopping-cart-operations)
 - [Data Models - Cart](API.md#cart)
 
-#### Image Upload
+#### Media Upload
 - [User Guide - Image Upload Feature](USER_GUIDE.md#image-upload-feature)
-- [API - Image-based Search](API.md#image-based-search)
+- [API - Multi-modal Input](API.md#multi-modal-input)
 - [Troubleshooting - Image Issues](USER_GUIDE.md#image-upload-fails)
 
 #### Deployment

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,10 +3,11 @@ events {
 }
 
 http {
-    # Allow image-bearing JSON requests from the UI.
-    # The UI caps uploads at 10MB (ui/src/config/config.ts), and base64 encoding
-    # inflates payload size by ~33%. 20m leaves comfortable headroom.
-    client_max_body_size 20m;
+    # Allow media-bearing JSON requests from the UI. The API advertises raw
+    # upload byte limits, but the UI sends media as base64 data URLs in JSON,
+    # inflating payloads by ~33%. 80m covers the default 50 MiB video limit
+    # plus request overhead.
+    client_max_body_size 80m;
 
     upstream frontend {
         server frontend:3000;

--- a/shared/configs/chain_server/config.yaml
+++ b/shared/configs/chain_server/config.yaml
@@ -104,4 +104,17 @@ memory_length: 16384
 top_k_retrieve: 4
 catalog_search_timeout_seconds: null
 multimodal: True
+media_input:
+  enabled: true
+  allow_mixed_media: true
+  max_images_per_turn: 1
+  max_videos_per_turn: 1
+  image_mime_types:
+    - "image/jpeg"
+    - "image/png"
+  video_mime_types:
+    - "video/mp4"
+  max_image_bytes: 10485760
+  max_video_bytes: 52428800
+  max_video_duration_seconds: 120
 unsafe_message: "Sorry, I am a shopping assistant that specializes in apparel. Do you have any questions that align better with my expertise?"

--- a/shared/configs/models.yaml
+++ b/shared/configs/models.yaml
@@ -24,6 +24,12 @@ local_nims:
       base_url: "http://nvclip:8000/v1"
       model: "nvidia/nvclip"
 
+    nemotron_omni:
+      compose_file: docker-compose-nim-local.yaml
+      compose_service: nemotron-omni
+      base_url: "http://nemotron-omni:8000/v1"
+      model: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+
     content_safety_nim:
       compose_file: docker-compose-nim-local.yaml
       compose_service: content
@@ -63,6 +69,16 @@ models:
     model_env: IMAGE_EMBED_MODEL
     model: "nvidia/nvclip"
     api_key_env: EMBED_API_KEY
+
+  vlm:
+    source: endpoint
+    provider: openai_compatible
+    local_service: nemotron_omni
+    base_url_env: VLM_BASE_URL
+    base_url: "https://integrate.api.nvidia.com/v1"
+    model_env: VLM_MODEL
+    model: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+    api_key_env: VLM_API_KEY
 
   content_safety:
     source: endpoint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ if str(REPO_ROOT) not in sys.path:
 
 # Several service modules read API keys at import time. Set harmless defaults
 # before any test imports them so we never trip on KeyError during collection.
-for _key in ("LLM_API_KEY", "EMBED_API_KEY", "RAIL_API_KEY", "NVIDIA_API_KEY"):
+for _key in ("LLM_API_KEY", "EMBED_API_KEY", "RAIL_API_KEY", "NVIDIA_API_KEY", "VLM_API_KEY"):
     os.environ.setdefault(_key, f"test-{_key.lower()}")
 os.environ.setdefault("SHARED_CONFIG_ROOT", str(REPO_ROOT / "shared" / "configs"))
 
@@ -68,6 +68,22 @@ def base_config() -> SimpleNamespace:
         top_k_retrieve=4,
         catalog_search_timeout_seconds=None,
         multimodal=True,
+        media_input=SimpleNamespace(
+            enabled=True,
+            allow_mixed_media=True,
+            max_images_per_turn=1,
+            max_videos_per_turn=1,
+            image_mime_types=["image/jpeg", "image/png"],
+            video_mime_types=["video/mp4"],
+            max_image_bytes=10 * 1024 * 1024,
+            max_video_bytes=50 * 1024 * 1024,
+            max_video_duration_seconds=120,
+        ),
+        vlm_enabled=True,
+        vlm_port="http://localhost:8006/v1",
+        vlm_name="test-vlm",
+        vlm_api_key_env="VLM_API_KEY",
+        vlm_api_key_required=True,
         unsafe_message="Sorry, I can only help with shopping questions.",
     )
 

--- a/tests/unit/catalog_retriever/test_utils.py
+++ b/tests/unit/catalog_retriever/test_utils.py
@@ -97,6 +97,7 @@ class TestImagePathToBase64:
     ) -> None:
         # The function hardcodes the ``/app/shared/`` prefix, so patch
         # ``open`` to redirect the path lookup to our temp file.
+        monkeypatch.setenv("SHARED_ROOT", "/app/shared")
         img_bytes = _build_jpeg_bytes()
         expected_path = "/app/shared/img.jpg"
         real_path = tmp_path / "img.jpg"
@@ -124,6 +125,7 @@ class TestImagePathToBase64:
     def test_returns_none_when_encoded_exceeds_limit(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.setenv("SHARED_ROOT", "/app/shared")
         img_bytes = _build_jpeg_bytes(size=(32, 32))
         real_path = tmp_path / "small.jpg"
         real_path.write_bytes(img_bytes)

--- a/tests/unit/chain_server/test_config.py
+++ b/tests/unit/chain_server/test_config.py
@@ -26,6 +26,20 @@ from chain_server.src.config import (
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
+def _clear_model_and_service_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "CATALOG_RETRIEVER_URL",
+        "MEMORY_RETRIEVER_URL",
+        "RAILS_URL",
+        "CATALOG_SEARCH_TIMEOUT_SECONDS",
+        "LLM_BASE_URL",
+        "LLM_MODEL",
+        "VLM_BASE_URL",
+        "VLM_MODEL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
 @pytest.fixture
 def write_yaml(tmp_path: Path):
     """Helper to drop a YAML config into a temporary directory."""
@@ -59,6 +73,9 @@ class TestChainServerConfigValidation:
         assert config.llm_port == valid_config_dict["llm_port"]
         assert config.categories == valid_config_dict["categories"]
         assert config.multimodal is True
+        assert config.vlm_enabled is False
+        assert config.media_input.max_images_per_turn == 1
+        assert config.media_input.max_videos_per_turn == 1
 
     @pytest.mark.parametrize(
         "missing_field",
@@ -158,6 +175,7 @@ class TestLoadConfig:
     def test_returns_typed_chain_server_config(
         self, write_yaml, valid_config_dict: dict, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        _clear_model_and_service_env(monkeypatch)
         monkeypatch.setenv("SHARED_CONFIG_ROOT", str(REPO_ROOT / "shared/configs"))
         monkeypatch.setenv("LLM_API_KEY", "test-key")
         path = write_yaml("config.yaml", valid_config_dict)
@@ -167,10 +185,12 @@ class TestLoadConfig:
         assert isinstance(config, ChainServerConfig)
         assert config.memory_length == valid_config_dict["memory_length"]
         assert config.llm_name == "nvidia/nemotron-3-super-120b-a12b"
+        assert config.vlm_enabled is True
 
     def test_invalid_yaml_surface_as_value_error(
         self, write_yaml, valid_config_dict: dict, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        _clear_model_and_service_env(monkeypatch)
         monkeypatch.setenv("SHARED_CONFIG_ROOT", str(REPO_ROOT / "shared/configs"))
         monkeypatch.setenv("LLM_API_KEY", "test-key")
         bad = dict(valid_config_dict)

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -119,6 +119,17 @@ class TestHealthAndRoot:
         assert body["status"] == "healthy"
         assert body["version"] == "1.0.0"
 
+    def test_capabilities_return_media_config(self, client: TestClient) -> None:
+        response = client.get("/capabilities")
+        assert response.status_code == 200
+
+        media = response.json()["media_input"]
+        assert media["enabled"] is True
+        assert media["max_images_per_turn"] == 1
+        assert media["max_videos_per_turn"] == 1
+        assert media["video_mime_types"] == ["video/mp4"]
+        assert media["vlm_enabled"] is True
+
     def test_root_describes_endpoints(self, client: TestClient) -> None:
         response = client.get("/")
         assert response.status_code == 200
@@ -126,7 +137,7 @@ class TestHealthAndRoot:
         body = response.json()
         assert body["message"] == "Shopping Assistant API"
         assert body["version"] == "1.0.0"
-        for key in ["query", "stream", "timing", "health", "docs"]:
+        for key in ["query", "stream", "timing", "capabilities", "health", "docs"]:
             assert key in body["endpoints"]
 
 
@@ -186,7 +197,60 @@ class TestStreamEndpoint:
         assert runtime.astream_calls
         state_arg, _ = runtime.astream_calls[-1]
         assert state_arg.image.startswith("data:image/jpeg")
-        assert "image" in state_arg.query.lower()
+        assert "media" in state_arg.query.lower()
+
+    def test_video_only_query_populates_media_placeholder(
+        self, main_module, client: TestClient
+    ) -> None:
+        runtime = main_module._test_runtime
+        runtime.astream_calls.clear()
+
+        with client.stream(
+            "POST",
+            "/query/stream",
+            json={
+                "user_id": 1,
+                "query": "",
+                "media": [
+                    {
+                        "type": "video",
+                        "mime_type": "video/mp4",
+                        "data": "data:video/mp4;base64,QUFB",
+                    }
+                ],
+            },
+        ) as stream_response:
+            for _ in stream_response.iter_lines():
+                pass
+
+        assert runtime.astream_calls
+        state_arg, _ = runtime.astream_calls[-1]
+        assert state_arg.image == ""
+        assert state_arg.query == "The user submitted visual media without additional text."
+        assert state_arg.media[0]["type"] == "video"
+        assert state_arg.media[0]["mime_type"] == "video/mp4"
+
+    def test_rejects_too_many_images(
+        self, client: TestClient
+    ) -> None:
+        response = client.post(
+            "/query/timing",
+            json={
+                "user_id": 1,
+                "query": "find these",
+                "image": "data:image/jpeg;base64,QUFB",
+                "media": [
+                    {
+                        "type": "image",
+                        "mime_type": "image/png",
+                        "data": "data:image/png;base64,QkJC",
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 400
+        assert "At most 1 image" in response.json()["detail"]
 
     def test_optional_identity_fields_reach_runtime(
         self, main_module, client: TestClient
@@ -309,6 +373,41 @@ class TestDeepAgentsRuntimeScopes:
 
 
 class TestDeepAgentsRuntimeRefs:
+    def test_media_catalog_search_intent_gate(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        assert (
+            runtime_mod._media_query_allows_catalog_search("What's in this look")
+            is False
+        )
+        assert (
+            runtime_mod._media_query_allows_catalog_search("describe this outfit")
+            is False
+        )
+        assert runtime_mod._media_query_allows_catalog_search(
+            "The user submitted visual media without additional text."
+        ) is False
+        assert (
+            runtime_mod._media_query_allows_catalog_search(
+                "what is this similar to stylistically"
+            )
+            is False
+        )
+        assert (
+            runtime_mod._media_query_allows_catalog_search("find shoes like this")
+            is True
+        )
+        assert (
+            runtime_mod._media_query_allows_catalog_search(
+                "do you have this under $100"
+            )
+            is True
+        )
+        assert (
+            runtime_mod._media_query_allows_catalog_search("add this to my cart")
+            is True
+        )
+
     def test_search_and_cart_read_tools_are_chainable(
         self,
         base_config,
@@ -369,6 +468,82 @@ class TestDeepAgentsRuntimeRefs:
         assert tools_by_name["add_cart_item_tool"].return_direct is True
         assert tools_by_name["remove_cart_item_tool"].return_direct is True
         assert tools_by_name["view_cart_total_tool"].return_direct is True
+
+    def test_media_analysis_query_skips_catalog_tool(
+        self,
+        base_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        captured: Dict[str, Any] = {}
+        deepagents_mod = ModuleType("deepagents")
+        tools_mod = ModuleType("langchain_core.tools")
+        openai_mod = ModuleType("langchain_openai")
+
+        class FakeProfile:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        class FakeChatOpenAI:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        def fake_tool(*, return_direct: bool = False):
+            def decorate(fn):
+                fn.return_direct = return_direct
+                return fn
+
+            return decorate
+
+        def fake_create_deep_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace()
+
+        def fail_search_catalog(*args, **kwargs):
+            raise AssertionError("descriptive media queries must not search catalog")
+
+        deepagents_mod.GeneralPurposeSubagentProfile = FakeProfile
+        deepagents_mod.HarnessProfile = FakeProfile
+        deepagents_mod.create_deep_agent = fake_create_deep_agent
+        deepagents_mod.register_harness_profile = lambda *args, **kwargs: None
+        tools_mod.tool = fake_tool
+        openai_mod.ChatOpenAI = FakeChatOpenAI
+
+        monkeypatch.setitem(sys.modules, "deepagents", deepagents_mod)
+        monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
+        monkeypatch.setitem(sys.modules, "langchain_openai", openai_mod)
+        monkeypatch.setattr(runtime_mod, "search_catalog", fail_search_catalog)
+
+        runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        identity = runtime_mod.RequestIdentity(
+            session_id="session-a",
+            conversation_id="conversation-a",
+            cart_id="cart-a",
+            context_user_id=111,
+            cart_user_id=222,
+            request_id="request-a",
+        )
+        state = State(
+            user_id=111,
+            query="What's in this look",
+            media=[
+                {
+                    "type": "image",
+                    "mime_type": "image/jpeg",
+                    "data": "data:image/jpeg;base64,QUFB",
+                }
+            ],
+            media_analysis='{"summary": "black blazer and white trousers"}',
+        )
+
+        runtime._create_agent(state, identity)
+        tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
+
+        result = tools_by_name["search_catalog_tool"]("black blazer")
+
+        assert "Catalog search skipped" in result
+        assert state.retrieved == {}
 
     def test_product_refs_are_cached_by_conversation(
         self,

--- a/tests/unit/chain_server/test_media_perception.py
+++ b/tests/unit/chain_server/test_media_perception.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from chain_server.src.agenttypes import State
+from chain_server.src.media_perception import MediaPerceptionClient
+
+
+@pytest.mark.asyncio
+async def test_disabled_vlm_returns_video_capability_note(base_config) -> None:
+    config = SimpleNamespace(
+        **{
+            **base_config.__dict__,
+            "vlm_enabled": False,
+            "vlm_port": None,
+            "vlm_name": None,
+            "vlm_api_key_env": None,
+        }
+    )
+    client = MediaPerceptionClient(config)
+    state = State(
+        user_id=1,
+        query="",
+        media=[
+            {
+                "type": "video",
+                "mime_type": "video/mp4",
+                "data": "data:video/mp4;base64,QUFB",
+            }
+        ],
+    )
+
+    analysis = json.loads(await client.analyze(state))
+
+    assert "not configured" in analysis["summary"]
+    assert analysis["search_queries"] == []
+
+
+@pytest.mark.asyncio
+async def test_disabled_vlm_leaves_image_only_path_empty(base_config) -> None:
+    config = SimpleNamespace(
+        **{
+            **base_config.__dict__,
+            "vlm_enabled": False,
+            "vlm_port": None,
+            "vlm_name": None,
+            "vlm_api_key_env": None,
+        }
+    )
+    client = MediaPerceptionClient(config)
+    state = State(
+        user_id=1,
+        query="find this",
+        image="data:image/jpeg;base64,QUFB",
+        media=[
+            {
+                "type": "image",
+                "mime_type": "image/jpeg",
+                "data": "data:image/jpeg;base64,QUFB",
+            }
+        ],
+    )
+
+    assert await client.analyze(state) == ""
+
+
+@pytest.mark.asyncio
+async def test_enabled_vlm_returns_normalized_json(base_config, monkeypatch: pytest.MonkeyPatch) -> None:
+    from chain_server.src import media_perception as media_perception_mod
+
+    captured = {}
+
+    class FakeCompletions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            message = SimpleNamespace(
+                content=json.dumps(
+                    {
+                        "summary": "black strappy sandal",
+                        "fashion_items": ["sandals"],
+                        "style_terms": ["dressy"],
+                        "colors": ["black"],
+                        "materials_or_textures": [],
+                        "occasion": [],
+                        "search_queries": ["black strappy sandals"],
+                        "constraints_detected": {},
+                        "uncertainties": [],
+                        "safety_notes": [],
+                    }
+                )
+            )
+            return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    class FakeOpenAI:
+        def __init__(self, *args, **kwargs):
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(media_perception_mod, "OpenAI", FakeOpenAI)
+    config = SimpleNamespace(
+        **{
+            **base_config.__dict__,
+            "vlm_enabled": True,
+            "vlm_port": "http://vlm.example/v1",
+            "vlm_name": "vlm-model",
+            "vlm_api_key_env": None,
+        }
+    )
+    client = MediaPerceptionClient(config)
+    state = State(
+        user_id=1,
+        query="find shoes like this",
+        media=[
+            {
+                "type": "image",
+                "mime_type": "image/jpeg",
+                "data": "data:image/jpeg;base64,QUFB",
+            }
+        ],
+    )
+
+    analysis = json.loads(await client.analyze(state))
+
+    assert analysis["search_queries"] == ["black strappy sandals"]
+    assert captured["model"] == "vlm-model"
+    assert captured["messages"][1]["content"][1]["type"] == "image_url"

--- a/tests/unit/shared/test_upload_proxy_limits.py
+++ b/tests/unit/shared/test_upload_proxy_limits.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import math
+import re
+
+import yaml
+
+from tests.conftest import REPO_ROOT
+
+
+def test_nginx_body_limit_covers_base64_expanded_video_upload() -> None:
+    chain_config = yaml.safe_load(
+        (REPO_ROOT / "shared/configs/chain_server/config.yaml").read_text()
+    )
+    nginx_config = (REPO_ROOT / "nginx.conf").read_text()
+
+    raw_video_bytes = chain_config["media_input"]["max_video_bytes"]
+    body_limit_bytes = _parse_nginx_size(
+        re.search(r"client_max_body_size\s+([^;]+);", nginx_config).group(1)
+    )
+
+    base64_video_bytes = math.ceil(raw_video_bytes / 3) * 4
+    request_overhead_bytes = 1024 * 1024
+
+    assert body_limit_bytes >= base64_video_bytes + request_overhead_bytes
+
+
+def _parse_nginx_size(value: str) -> int:
+    match = re.fullmatch(r"\s*(\d+)([kKmMgG]?)\s*", value)
+    assert match is not None
+
+    amount = int(match.group(1))
+    suffix = match.group(2).lower()
+    multipliers = {
+        "": 1,
+        "k": 1024,
+        "m": 1024 * 1024,
+        "g": 1024 * 1024 * 1024,
+    }
+    return amount * multipliers[suffix]

--- a/ui/README.md
+++ b/ui/README.md
@@ -37,7 +37,7 @@ src/
 - **Type Safety**: Full TypeScript implementation with proper type definitions
 - **Configuration Management**: Centralized config for easy customization
 - **Error Handling**: Comprehensive error handling with user feedback
-- **Image Upload**: Secure image upload with validation
+- **Media Upload**: Capability-driven image upload and optional video upload with validation
 - **Real-time Streaming**: Live message streaming from the backend
 - **Responsive Design**: Mobile-friendly interface
 - **Accessibility**: ARIA labels and semantic HTML
@@ -81,7 +81,7 @@ The application uses a centralized configuration system in `src/config/config.ts
 
 - **API Settings**: Backend URLs and endpoints
 - **UI Settings**: Default images, categories, and styling
-- **Feature Flags**: Enable/disable features like guardrails and image upload
+- **Feature Flags**: Enable/disable features like guardrails and media upload
 - **File Upload**: Size limits and allowed file types
 
 ## Type Definitions
@@ -162,4 +162,4 @@ Enable debug logging by setting `NODE_ENV=development` in your environment.
 
 ## License
 
-Apache 2.0 License - see LICENSE file for details. 
+Apache 2.0 License - see LICENSE file for details.

--- a/ui/src/components/chatbox/ChatMessage.tsx
+++ b/ui/src/components/chatbox/ChatMessage.tsx
@@ -23,7 +23,7 @@ import React from "react";
 import Showdown from "showdown";
 import SafeHTML from "./SafeHTML";
 import Loader from "./Loader";
-import { ChatMessageProps, MessageRole, ImageContent, ImageRowContent } from "../../types";
+import { ChatMessageProps, ImageContent, ImageRowContent } from "../../types";
 import { isFashionMode } from "../../config/config";
 import nvinfo from "../../assets/nvinfo.jpg";
 
@@ -161,6 +161,19 @@ const ChatMessage = React.forwardRef<HTMLDivElement, ChatMessageProps>(
             src={content as string} 
             alt="User upload"
             style={{ borderRadius: "20px" }} 
+          />
+        </div>
+      );
+    }
+
+    if (role === "user_video" && content) {
+      return (
+        <div className={`messages__item messages__item--${role}`} ref={ref}>
+          <video
+            src={content as string}
+            controls
+            muted
+            style={{ width: "180px", maxHeight: "140px", borderRadius: "20px" }}
           />
         </div>
       );

--- a/ui/src/components/chatbox/chatbox.tsx
+++ b/ui/src/components/chatbox/chatbox.tsx
@@ -28,7 +28,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 
 import ChatMessage from "./ChatMessage";
-import { ChatboxProps } from "../../types";
+import { CapabilitiesResponse, ChatboxProps, MediaAttachment, MediaCapabilities } from "../../types";
 import { config } from "../../config/config";
 import {
   clearUserSession,
@@ -56,12 +56,29 @@ const CustomSwitch = styled(Switch)(({ theme }) => ({
 }));
 
 const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
+  const defaultMediaCapabilities: MediaCapabilities = {
+    enabled: config.features.imageUpload.enabled,
+    allow_mixed_media: true,
+    max_images_per_turn: 1,
+    max_videos_per_turn: 0,
+    image_mime_types: config.features.imageUpload.allowedTypes,
+    video_mime_types: [],
+    max_image_bytes: config.features.imageUpload.maxSize * 1024 * 1024,
+    max_video_bytes: 0,
+    max_video_duration_seconds: 120,
+    vlm_enabled: false,
+  };
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const [hasBeenOpened, setHasBeenOpened] = useState<boolean>(false);
   const [newMessage, setNewMessage] = useState<string>("");
   const [isGuardrailsOn, setIsGuardrailsOn] = useState(config.features.guardrails.defaultState);
   const [image, setImage] = useState("");
   const [previewImage, setPreviewImage] = useState("");
+  const [video, setVideo] = useState("");
+  const [previewVideo, setPreviewVideo] = useState("");
+  const [videoMimeType, setVideoMimeType] = useState("");
+  const [videoFilename, setVideoFilename] = useState("");
+  const [mediaCapabilities, setMediaCapabilities] = useState<MediaCapabilities>(defaultMediaCapabilities);
   const [messages, setMessages] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const messageRefs = useRef<React.RefObject<HTMLDivElement>[]>([]);
@@ -93,6 +110,23 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
     return new Blob([byteArray], { type: "image/png" });
   };
 
+  const getVideoDuration = (file: File): Promise<number> => {
+    return new Promise((resolve, reject) => {
+      const url = window.URL.createObjectURL(file);
+      const element = document.createElement("video");
+      element.preload = "metadata";
+      element.onloadedmetadata = () => {
+        window.URL.revokeObjectURL(url);
+        resolve(element.duration || 0);
+      };
+      element.onerror = () => {
+        window.URL.revokeObjectURL(url);
+        reject(new Error("Failed to read video metadata."));
+      };
+      element.src = url;
+    });
+  };
+
   // Event handlers
   const toggleGuardrails = () => {
     setIsGuardrailsOn(!isGuardrailsOn);
@@ -107,36 +141,82 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
     if (!files || files.length === 0) return;
 
     const file = files[0];
-    
-    // Validate file
-    const maxSizeMB = config.features.imageUpload.maxSize;
-    if (file.size > maxSizeMB * 1024 * 1024) {
-      toast.error(`File size must be less than ${maxSizeMB}MB`);
+
+    if (!mediaCapabilities.enabled) {
+      toast.error("Media uploads are disabled.");
       return;
     }
 
-    if (!config.features.imageUpload.allowedTypes.includes(file.type)) {
-              toast.error('Please select a valid image file (JPEG or PNG only)');
+    const isImage = mediaCapabilities.image_mime_types.includes(file.type);
+    const isVideo = mediaCapabilities.video_mime_types.includes(file.type);
+    const videoAllowed = mediaCapabilities.vlm_enabled && mediaCapabilities.max_videos_per_turn > 0;
+
+    if (!isImage && !isVideo) {
+      toast.error("Please select a supported image or video file.");
       return;
+    }
+    if (isImage && mediaCapabilities.max_images_per_turn <= 0) {
+      toast.error("Image upload is not available with the current configuration.");
+      return;
+    }
+    if (isVideo && !videoAllowed) {
+      toast.error("Video upload is not available with the current configuration.");
+      return;
+    }
+    if (!mediaCapabilities.allow_mixed_media && ((isImage && video) || (isVideo && image))) {
+      toast.error("This configuration allows only one media type per turn.");
+      return;
+    }
+
+    const maxBytes = isImage ? mediaCapabilities.max_image_bytes : mediaCapabilities.max_video_bytes;
+    if (file.size > maxBytes) {
+      toast.error(`File size must be less than ${(maxBytes / (1024 * 1024)).toFixed(0)}MB`);
+      return;
+    }
+
+    if (isVideo) {
+      try {
+        const duration = await getVideoDuration(file);
+        if (duration > mediaCapabilities.max_video_duration_seconds) {
+          toast.error(`Video must be ${mediaCapabilities.max_video_duration_seconds} seconds or shorter.`);
+          return;
+        }
+      } catch (error) {
+        toast.error("Failed to inspect video duration.");
+        return;
+      }
     }
 
     try {
-      const base64Image = await convertToBase64(file);
-      setImage(base64Image);
-      
-      const decodedImage = base64ToBlob(base64Image);
-      const imageUrl = window.URL.createObjectURL(decodedImage);
-      setPreviewImage(imageUrl);
+      const base64Media = await convertToBase64(file);
+      if (isImage) {
+        setImage(base64Media);
+        const decodedImage = base64ToBlob(base64Media);
+        const imageUrl = window.URL.createObjectURL(decodedImage);
+        setPreviewImage(imageUrl);
+      } else {
+        setVideo(base64Media);
+        setPreviewVideo(window.URL.createObjectURL(file));
+        setVideoMimeType(file.type);
+        setVideoFilename(file.name);
+      }
       
       e.target.value = "";
     } catch (error) {
-      toast.error('Failed to upload image');
+      toast.error('Failed to upload media');
     }
   };
 
   const clearImage = () => {
     setPreviewImage("");
     setImage("");
+  };
+
+  const clearVideo = () => {
+    setPreviewVideo("");
+    setVideo("");
+    setVideoMimeType("");
+    setVideoFilename("");
   };
 
   const addMessage = (role: string, content: any, productName: string = "") => {
@@ -184,7 +264,7 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
   };
 
   const handleSendMessage = async () => {
-    if (!newMessage.trim() && !image) return;
+    if (!newMessage.trim() && !image && !video) return;
 
     // Clear previous cart operation notifications for new message
     shownCartOperations.current.clear();
@@ -214,22 +294,38 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
       if (image) {
         addMessage("user_image", previewImage, "");
       }
+      if (video) {
+        addMessage("user_video", previewVideo, "");
+      }
 
       // Add loading message
       addMessage("assistant", "loader", "");
       setNewMessage("");
 
       // Prepare API request
+      const media: MediaAttachment[] = video
+        ? [{
+            type: "video",
+            data: video,
+            mime_type: videoMimeType,
+            filename: videoFilename,
+          }]
+        : [];
       const payload = createApiRequest(
         userSession,
         newMessage,
         image || "",
-        isGuardrailsOn
+        isGuardrailsOn,
+        media
       );
       
-      // Clear image immediately after preparing payload
+      // Clear media immediately after preparing payload
       setImage("");
       setPreviewImage("");
+      setVideo("");
+      setPreviewVideo("");
+      setVideoMimeType("");
+      setVideoFilename("");
 
       const url = `${config.api.baseUrl}${config.api.endpoints.stream}`;
 
@@ -346,6 +442,10 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
     setMessages([]);
     setImage("");
     setPreviewImage("");
+    setVideo("");
+    setPreviewVideo("");
+    setVideoMimeType("");
+    setVideoFilename("");
     setNewRenderImage("");
     clearUserSession();
 
@@ -387,6 +487,22 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
       setHasBeenOpened(true);
     }
   }, [isOpen]);
+
+  useEffect(() => {
+    const loadCapabilities = async () => {
+      try {
+        const response = await fetch(`${config.api.baseUrl}${config.api.endpoints.capabilities}`);
+        if (!response.ok) return;
+        const data = await response.json() as CapabilitiesResponse;
+        if (data.media_input) {
+          setMediaCapabilities(data.media_input);
+        }
+      } catch (error) {
+        console.warn("Failed to load media capabilities", error);
+      }
+    };
+    loadCapabilities();
+  }, []);
 
   useEffect(() => {
     if (hasBeenOpened) {
@@ -444,6 +560,29 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
               </div>
             )}
 
+            {previewVideo && (
+              <div style={{ position: 'relative', display: 'inline-block' }}>
+                <video src={previewVideo} muted style={{ width: '50px', height: '50px', objectFit: 'cover' }} />
+                <button
+                  type="button"
+                  style={{
+                    display: 'inline-flex',
+                    position: 'absolute',
+                    right: '-5px',
+                    top: '-5px',
+                    cursor: 'pointer',
+                    background: 'transparent',
+                    border: 'none',
+                    padding: 0,
+                  }}
+                  onClick={clearVideo}
+                  aria-label="Clear video"
+                >
+                  <FontAwesomeIcon icon={faTimesCircle} />
+                </button>
+              </div>
+            )}
+
             {/* Input field */}
             <input
               ref={inputRef}
@@ -482,9 +621,12 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
               <input
                 style={{ display: "none" }}
                 type="file"
-                accept="image/*"
+                accept={[
+                  ...mediaCapabilities.image_mime_types,
+                  ...(mediaCapabilities.vlm_enabled ? mediaCapabilities.video_mime_types : []),
+                ].join(",")}
                 id="image-upload"
-                name="image"
+                name="media"
                 onChange={handleImageUpload}
               />
             </div>

--- a/ui/src/config/config.ts
+++ b/ui/src/config/config.ts
@@ -9,11 +9,12 @@ export interface AppConfig {
   api: {
     baseUrl: string;
     port: number;
-    endpoints: {
-      query: string;
-      stream: string;
-      health: string;
-    };
+      endpoints: {
+        query: string;
+        stream: string;
+        capabilities: string;
+        health: string;
+      };
   };
   ui: {
     defaultImages: {
@@ -53,6 +54,7 @@ const getConfig = (): AppConfig => {
       endpoints: {
         query: '/query',
         stream: '/query/stream',
+        capabilities: '/capabilities',
         health: '/health',
       },
     },

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -17,7 +17,8 @@ export type MessageRole =
   | 'system' 
   | 'image' 
   | 'image_row' 
-  | 'user_image';
+  | 'user_image'
+  | 'user_video';
 
 export interface ImageContent {
   productUrl: string;
@@ -49,6 +50,7 @@ export interface ApiRequest {
   query: string;
   guardrails: boolean;
   image: string;
+  media?: MediaAttachment[];
   image_bool: boolean;
   session_id?: string;
   conversation_id?: string;
@@ -56,6 +58,30 @@ export interface ApiRequest {
   context?: string;
   cart?: CartData;
   retrieved?: Record<string, string>;
+}
+
+export interface MediaAttachment {
+  type: 'image' | 'video';
+  data: string;
+  mime_type: string;
+  filename?: string;
+}
+
+export interface MediaCapabilities {
+  enabled: boolean;
+  allow_mixed_media: boolean;
+  max_images_per_turn: number;
+  max_videos_per_turn: number;
+  image_mime_types: string[];
+  video_mime_types: string[];
+  max_image_bytes: number;
+  max_video_bytes: number;
+  max_video_duration_seconds: number;
+  vlm_enabled: boolean;
+}
+
+export interface CapabilitiesResponse {
+  media_input: MediaCapabilities;
 }
 
 export interface ApiResponse {

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -5,7 +5,7 @@
  * Utility functions for the Shopping Assistant UI
  */
 
-import { FileUploadResult, UserSession, StreamingChunk, ApiRequest } from '../types';
+import { FileUploadResult, UserSession, StreamingChunk, ApiRequest, MediaAttachment } from '../types';
 import { config } from '../config/config';
 
 const SESSION_STORAGE_KEY = 'shopping_session_identity';
@@ -125,7 +125,8 @@ export const createApiRequest = (
   userSession: UserSession,
   query: string,
   image: string = '',
-  guardrails: boolean = true
+  guardrails: boolean = true,
+  media: MediaAttachment[] = []
 ): ApiRequest => {
   return {
     user_id: userSession.userId,
@@ -135,6 +136,7 @@ export const createApiRequest = (
     query,
     guardrails,
     image,
+    media,
     image_bool: !!image,
   };
 };


### PR DESCRIPTION
## Summary
- add VLM media perception for image/video uploads and inject media analysis into the Deep Agents turn
- expose media capabilities to the UI and enforce configured image/video limits client-side and server-side
- add hosted/local NIM model config for Nemotron Omni VLM
- keep descriptive media prompts such as "what's in this look" on VLM analysis without automatic catalog retrieval
- align nginx request body limit with base64-expanded 50 MiB video uploads