### PR TITLE
Catalog refactor: dynamic capabilities and structured search boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,10 @@ Key env vars:
 - `CartItem` rows carry a `price` column; the deterministic `view_cart_total` tool uses these prices instead of letting the LLM do arithmetic. Older DBs are auto-migrated by `_ensure_price_column`.
 - Cart add/remove uses catalog name matching (with normalization + Jaccard fallback) before memory mutation; pure semantic similarity on descriptions is no longer used.
 - The cart agent deterministically resolves pronouns (`it`, `this`) against the most recent product in `RECENT DISCUSSION` and overrides the LLM's `item_name` if they disagree.
-- For image search, catalog retriever bypasses category filtering and relies on similarity ranking. Top-k is applied before price filters, so a tight budget on a high-priced image-similarity cluster can legitimately return zero matches.
+- Catalog retriever applies explicit hard filters, including category and price,
+  over a wider candidate window for text, image, and hybrid search before
+  trimming to top-k. Available filter values come from catalog retriever
+  `/capabilities`, not chain-server category config.
 - Local LLM service is named `nemotron` (was `llama`); chain-server reaches it through `shared/configs/models.yaml` when the app LLM role uses `source: local_nim`.
 - Tool calling against the local NIM requires `--enable-auto-tool-choice --tool-call-parser llama3_json` passthrough args. Without them, requests with `tool_choice="auto"` 400.
 - Nemotron sometimes returns tool calls as XML/JSON inside the assistant `content` field instead of `message.tool_calls`. `chain_server/src/functions.py::parse_tool_call_fallback` handles both shapes; `_coerce_value` parses stringified Python literals (`"[]"`, `"{'k':'v'}"`) so list/dict args don't reach downstream code as strings.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The Brev deployment guide walks you through the entire process from creating a L
 
 - **[User Guide](docs/USER_GUIDE.md)**: How to use the application
 - **[API Documentation](docs/API.md)**: Complete API reference
+- **[Catalog Filter Configuration](docs/CATALOG_FILTERS.md)**: How to declare catalog filter fields without hardcoding enum values
 - **[Commerce Contracts](docs/COMMERCE_CONTRACTS.md)**: Internal product, cart, and commerce tool contracts
 - **[Deep Agents Migration Plan](docs/DEEP_AGENTS_MIGRATION_PLAN.md)**: SDK migration, session isolation, tools, skills, and scaling notes
 - **[Deep Agents Cart Tool Goal](docs/DEEP_AGENTS_CART_TOOL_GOAL.md)**: Minimal cart-tool smoke gate and constraints

--- a/catalog_retriever/src/capabilities.py
+++ b/catalog_retriever/src/capabilities.py
@@ -15,7 +15,6 @@ from typing import Any
 
 from shared.commerce_contracts import (
     CatalogCapabilities,
-    CatalogFacetCapability,
     CatalogFilterCapability,
 )
 
@@ -23,16 +22,10 @@ from shared.commerce_contracts import (
 def build_catalog_capabilities(config: dict[str, Any]) -> CatalogCapabilities:
     rows = _read_rows(config.get("data_source", ""))
     filter_registry = config.get("filter_registry") or {}
-    soft_facet_registry = config.get("soft_facets") or {}
 
     filters = {
         name: _build_filter_capability(spec, rows)
         for name, spec in filter_registry.items()
-        if isinstance(spec, dict)
-    }
-    soft_facets = {
-        name: _build_facet_capability(spec, rows)
-        for name, spec in soft_facet_registry.items()
         if isinstance(spec, dict)
     }
 
@@ -45,7 +38,6 @@ def build_catalog_capabilities(config: dict[str, Any]) -> CatalogCapabilities:
         retrieval_modes=retrieval_modes,
         image_search_enabled=bool(config.get("image_enabled")),
         filters=filters,
-        soft_facets=soft_facets,
     )
 
 
@@ -84,19 +76,6 @@ def _build_filter_capability(
             str(key): str(value)
             for key, value in (spec.get("request_aliases") or {}).items()
         },
-    )
-
-
-def _build_facet_capability(
-    spec: dict[str, Any], rows: list[dict[str, str]]
-) -> CatalogFacetCapability:
-    source_fields = _source_fields(spec)
-    capability_type = str(spec.get("type") or "text")
-    values = _enum_values(rows, source_fields) if capability_type == "enum" else []
-    return CatalogFacetCapability(
-        type=capability_type,  # type: ignore[arg-type]
-        source_fields=source_fields,
-        values=values,
     )
 
 

--- a/catalog_retriever/src/capabilities.py
+++ b/catalog_retriever/src/capabilities.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Catalog-owned capability discovery.
+
+The catalog service declares which fields are real filters. Runtime data is
+used only to fill enum values and numeric ranges for those declared fields.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+from shared.commerce_contracts import (
+    CatalogCapabilities,
+    CatalogFacetCapability,
+    CatalogFilterCapability,
+)
+
+
+def build_catalog_capabilities(config: dict[str, Any]) -> CatalogCapabilities:
+    rows = _read_rows(config.get("data_source", ""))
+    filter_registry = config.get("filter_registry") or {}
+    soft_facet_registry = config.get("soft_facets") or {}
+
+    filters = {
+        name: _build_filter_capability(spec, rows)
+        for name, spec in filter_registry.items()
+        if isinstance(spec, dict)
+    }
+    soft_facets = {
+        name: _build_facet_capability(spec, rows)
+        for name, spec in soft_facet_registry.items()
+        if isinstance(spec, dict)
+    }
+
+    retrieval_modes = ["text"]
+    if bool(config.get("image_enabled")):
+        retrieval_modes.extend(["image", "hybrid"])
+
+    return CatalogCapabilities(
+        catalog_id=str(config.get("catalog_id") or "default"),
+        retrieval_modes=retrieval_modes,
+        image_search_enabled=bool(config.get("image_enabled")),
+        filters=filters,
+        soft_facets=soft_facets,
+    )
+
+
+def _read_rows(csv_path: str) -> list[dict[str, str]]:
+    if not csv_path:
+        return []
+    path = Path(csv_path)
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _build_filter_capability(
+    spec: dict[str, Any], rows: list[dict[str, str]]
+) -> CatalogFilterCapability:
+    source_fields = _source_fields(spec)
+    capability_type = str(spec.get("type") or "text")
+    values: list[str] = []
+    min_value: float | None = None
+    max_value: float | None = None
+
+    if capability_type == "enum":
+        values = _enum_values(rows, source_fields)
+    elif capability_type == "number":
+        min_value, max_value = _number_range(rows, source_fields)
+
+    return CatalogFilterCapability(
+        type=capability_type,  # type: ignore[arg-type]
+        operators=[str(value) for value in spec.get("operators", [])],
+        source_fields=source_fields,
+        values=values,
+        min_value=min_value,
+        max_value=max_value,
+        request_aliases={
+            str(key): str(value)
+            for key, value in (spec.get("request_aliases") or {}).items()
+        },
+    )
+
+
+def _build_facet_capability(
+    spec: dict[str, Any], rows: list[dict[str, str]]
+) -> CatalogFacetCapability:
+    source_fields = _source_fields(spec)
+    capability_type = str(spec.get("type") or "text")
+    values = _enum_values(rows, source_fields) if capability_type == "enum" else []
+    return CatalogFacetCapability(
+        type=capability_type,  # type: ignore[arg-type]
+        source_fields=source_fields,
+        values=values,
+    )
+
+
+def _source_fields(spec: dict[str, Any]) -> list[str]:
+    fields = spec.get("source_fields")
+    if isinstance(fields, list):
+        return [str(field) for field in fields if str(field).strip()]
+    field = spec.get("source_field")
+    return [str(field)] if field else []
+
+
+def _enum_values(rows: list[dict[str, str]], source_fields: list[str]) -> list[str]:
+    values: set[str] = set()
+    for row in rows:
+        for field in source_fields:
+            value = str(row.get(field) or "").strip()
+            if value:
+                values.add(value)
+    return sorted(values)
+
+
+def _number_range(
+    rows: list[dict[str, str]], source_fields: list[str]
+) -> tuple[float | None, float | None]:
+    values: list[float] = []
+    for row in rows:
+        for field in source_fields:
+            value = _coerce_float(row.get(field))
+            if value is not None:
+                values.append(value)
+    if not values:
+        return None, None
+    return min(values), max(values)
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/catalog_retriever/src/main.py
+++ b/catalog_retriever/src/main.py
@@ -94,6 +94,7 @@ data.update(
         "image_api_key_env": image_embedding.api_key_env if image_enabled else None,
     }
 )
+capabilities = build_catalog_capabilities(data)
 
 
 # Setup Retriever once when app starts
@@ -109,7 +110,8 @@ config = RetrieverConfig(
     db_name=data["db_name"],
     sim_threshold=data["sim_threshold"],
     text_collection=data["text_collection"],
-    image_collection=data["image_collection"]
+    image_collection=data["image_collection"],
+    filter_capabilities=capabilities.filters,
 )
 
 logging.info("CATALOG RETRIEVER | startup | config.yaml ingested.")
@@ -118,7 +120,6 @@ retriever = Retriever(config=config)
 logging.info("CATALOG RETRIEVER | startup | Checking and populating Milvus database if needed.")
 retriever.milvus_from_csv(csv_path=data["data_source"], verbose=True)
 logging.info("CATALOG RETRIEVER | startup | Milvus database ready.")
-capabilities = build_catalog_capabilities(data)
 
 # Request bodies
 class TextQueryRequest(BaseModel):

--- a/catalog_retriever/src/main.py
+++ b/catalog_retriever/src/main.py
@@ -13,8 +13,10 @@ import sys
 from shared.model_config import resolve_model_config, validate_model_config
 
 try:
+    from app.capabilities import build_catalog_capabilities
     from app.retriever import Retriever, RetrieverConfig
 except ModuleNotFoundError:
+    from .capabilities import build_catalog_capabilities
     from .retriever import Retriever, RetrieverConfig
 
 # Set up logging 
@@ -116,6 +118,7 @@ retriever = Retriever(config=config)
 logging.info("CATALOG RETRIEVER | startup | Checking and populating Milvus database if needed.")
 retriever.milvus_from_csv(csv_path=data["data_source"], verbose=True)
 logging.info("CATALOG RETRIEVER | startup | Milvus database ready.")
+capabilities = build_catalog_capabilities(data)
 
 # Request bodies
 class TextQueryRequest(BaseModel):
@@ -180,3 +183,9 @@ async def health_check():
         "timestamp": time.time(),
         "version": "1.0.0"
     }
+
+
+@app.get("/capabilities")
+async def get_capabilities():
+    """Return catalog-owned search and filter capabilities."""
+    return capabilities.model_dump()

--- a/catalog_retriever/src/main.py
+++ b/catalog_retriever/src/main.py
@@ -126,6 +126,7 @@ class TextQueryRequest(BaseModel):
     categories: List[str] = []
     filters: Dict[str, Any] = Field(default_factory=dict)
     k: int = 4
+    candidate_k: int | None = None
 
 class ImageQueryRequest(BaseModel):
     text: List[str] = []
@@ -133,46 +134,55 @@ class ImageQueryRequest(BaseModel):
     categories: List[str] = []
     filters: Dict[str, Any] = Field(default_factory=dict)
     k: int = 4
+    candidate_k: int | None = None
 
 # Handles queries only containing text.
 @app.post("/query/text")
 async def query_text(req: TextQueryRequest):
     logging.info(f"CATALOG RETRIEVER | query_text() | Received POST: {req}.")
-    texts, ids, sims, names, images = await retriever.retrieve(
+    result = await retriever.retrieve(
         query=req.text,
         categories=req.categories,
         filters=req.filters,
         k=req.k,
+        candidate_k=req.candidate_k,
         image_bool=False,
         verbose=True
     )
     return {
-        "texts": texts,
-        "ids": ids,
-        "similarities": sims,
-        "names": names,
-        "images": images
+        "texts": result.texts,
+        "ids": result.ids,
+        "similarities": result.similarities,
+        "names": result.names,
+        "images": result.images,
+        "products": result.products,
+        "diagnostics": result.diagnostics,
+        "no_result_reason": result.no_result_reason,
     }
 
 # Handles queries containing text and b64 images.
 @app.post("/query/image")
 async def query_image(req: ImageQueryRequest):
     logging.info(f"CATALOG RETRIEVER | query_image() | Received POST.")
-    texts, ids, sims, names, images = await retriever.retrieve(
+    result = await retriever.retrieve(
         query=req.text,
         image=req.image_base64,
         categories=req.categories,
         filters=req.filters,
         k=req.k,
+        candidate_k=req.candidate_k,
         image_bool=True,
         verbose=True
     )
     return {
-        "texts": texts,
-        "ids": ids,
-        "similarities": sims,
-        "names": names,
-        "images": images
+        "texts": result.texts,
+        "ids": result.ids,
+        "similarities": result.similarities,
+        "names": result.names,
+        "images": result.images,
+        "products": result.products,
+        "diagnostics": result.diagnostics,
+        "no_result_reason": result.no_result_reason,
     }
 
 @app.get("/health")

--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -9,7 +9,7 @@ Performs both of these in parallel and then re-ranks the results from bothmodels
 """
 
 from openai import OpenAI
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from dataclasses import dataclass, field
 from typing import List, Tuple, Dict, Any
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -25,6 +25,7 @@ from .utils import image_url_to_base64, is_url, is_path, image_path_to_base64, r
 import logging
 import asyncio
 from types import SimpleNamespace
+from shared.commerce_contracts import CatalogFilterCapability
 
 # Set up logging 
 logging.basicConfig(
@@ -47,6 +48,7 @@ class RetrieverConfig(BaseModel):
     sim_threshold: float
     text_collection: str
     image_collection: str
+    filter_capabilities: Dict[str, CatalogFilterCapability] = Field(default_factory=dict)
 
 
 @dataclass
@@ -291,6 +293,7 @@ class Retriever:
         self.sim_threshold = config.sim_threshold
         self.text_collection = config.text_collection
         self.image_collection = config.image_collection
+        self.filter_capabilities = config.filter_capabilities
 
         text_key = os.environ.get(self.text_api_key_env, "") if self.text_api_key_env else ""
         image_key = os.environ.get(self.image_api_key_env, "") if self.image_api_key_env else ""
@@ -897,28 +900,15 @@ class Retriever:
         if not filters:
             return results
 
-        min_price = self._coerce_float(filters.get("min_price"))
-        max_price = self._coerce_float(filters.get("max_price"))
-        category_values = self._normalize_filter_values(filters.get("category"))
-
-        if min_price is None and max_price is None and not category_values:
+        canonical_filters = self._canonical_filters(filters)
+        if not canonical_filters:
             return results
 
         filtered_results: List[Tuple[Any, float]] = []
         for result in results:
             doc = result[0]
-            if category_values and not self._metadata_matches_category(
-                doc.metadata, category_values
-            ):
+            if not self._metadata_matches_filters(doc.metadata, canonical_filters):
                 continue
-            price = self._coerce_float(doc.metadata.get("price"))
-            if min_price is not None or max_price is not None:
-                if price is None:
-                    continue
-                if min_price is not None and price < min_price:
-                    continue
-                if max_price is not None and price > max_price:
-                    continue
             filtered_results.append(result)
 
         if verbose:
@@ -929,6 +919,129 @@ class Retriever:
 
         return filtered_results
 
+    def _canonical_filters(self, filters: Dict[str, Any]) -> Dict[str, Any]:
+        canonical: Dict[str, Any] = {}
+        for name, capability in self.filter_capabilities.items():
+            if name in filters:
+                canonical[name] = filters[name]
+            if capability.type == "number":
+                alias_filter = self._number_alias_filter(filters, name, capability)
+                if alias_filter:
+                    existing = canonical.get(name)
+                    if isinstance(existing, dict):
+                        canonical[name] = {**existing, **alias_filter}
+                    else:
+                        canonical[name] = alias_filter
+        return {
+            name: value
+            for name, value in canonical.items()
+            if value not in (None, "", [], {})
+        }
+
+    @staticmethod
+    def _number_alias_filter(
+        filters: Dict[str, Any],
+        name: str,
+        capability: CatalogFilterCapability,
+    ) -> Dict[str, Any]:
+        aliases = {
+            "min": capability.request_aliases.get("min") or f"min_{name}",
+            "max": capability.request_aliases.get("max") or f"max_{name}",
+        }
+        number_filter: Dict[str, Any] = {}
+        for bound, alias in aliases.items():
+            if alias in filters:
+                number_filter[bound] = filters[alias]
+        return number_filter
+
+    def _metadata_matches_filters(
+        self,
+        metadata: Dict[str, Any],
+        filters: Dict[str, Any],
+    ) -> bool:
+        for name, value in filters.items():
+            capability = self.filter_capabilities.get(name)
+            if capability is None:
+                continue
+            if capability.type == "number":
+                if not self._metadata_matches_number_filter(
+                    metadata, value, name, capability
+                ):
+                    return False
+                continue
+            if not self._metadata_matches_value_filter(metadata, value, name, capability):
+                return False
+        return True
+
+    def _metadata_matches_number_filter(
+        self,
+        metadata: Dict[str, Any],
+        value: Any,
+        name: str,
+        capability: CatalogFilterCapability,
+    ) -> bool:
+        bounds = self._normalize_number_filter(value)
+        if not bounds:
+            return True
+        if (
+            bounds.get("min") is not None
+            and bounds.get("max") is not None
+            and bounds["min"] > bounds["max"]
+        ):
+            return False
+
+        metadata_value = self._first_metadata_number(metadata, name, capability)
+        if metadata_value is None:
+            return False
+        if bounds.get("min") is not None and metadata_value < bounds["min"]:
+            return False
+        if bounds.get("max") is not None and metadata_value > bounds["max"]:
+            return False
+        return True
+
+    @classmethod
+    def _normalize_number_filter(cls, value: Any) -> Dict[str, float]:
+        if not isinstance(value, dict):
+            return {}
+        bounds: Dict[str, float] = {}
+        lower = cls._coerce_float(value.get("min", value.get("gte")))
+        upper = cls._coerce_float(value.get("max", value.get("lte")))
+        if lower is not None:
+            bounds["min"] = lower
+        if upper is not None:
+            bounds["max"] = upper
+        return bounds
+
+    @classmethod
+    def _first_metadata_number(
+        cls,
+        metadata: Dict[str, Any],
+        name: str,
+        capability: CatalogFilterCapability,
+    ) -> float | None:
+        for field in capability.source_fields or [name]:
+            value = cls._coerce_float(metadata.get(field))
+            if value is not None:
+                return value
+        return None
+
+    def _metadata_matches_value_filter(
+        self,
+        metadata: Dict[str, Any],
+        value: Any,
+        name: str,
+        capability: CatalogFilterCapability,
+    ) -> bool:
+        requested_values = self._normalize_filter_values(value)
+        if not requested_values:
+            return True
+        metadata_values = {
+            str(metadata.get(field) or "").strip().lower()
+            for field in capability.source_fields or [name]
+            if str(metadata.get(field) or "").strip()
+        }
+        return bool(metadata_values.intersection(requested_values))
+
     @staticmethod
     def _normalize_filter_values(value: Any) -> set[str]:
         if value is None:
@@ -937,17 +1050,6 @@ class Retriever:
             return {str(item).strip().lower() for item in value if str(item).strip()}
         text = str(value).strip()
         return {text.lower()} if text else set()
-
-    @classmethod
-    def _metadata_matches_category(
-        cls, metadata: Dict[str, Any], category_values: set[str]
-    ) -> bool:
-        product_values = set()
-        for field in ("category", "subcategory"):
-            value = str(metadata.get(field) or "").strip().lower()
-            if value:
-                product_values.add(value)
-        return bool(product_values.intersection(category_values))
 
     @staticmethod
     def _effective_filters(

--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -10,6 +10,7 @@ Performs both of these in parallel and then re-ranks the results from bothmodels
 
 from openai import OpenAI
 from pydantic import BaseModel
+from dataclasses import dataclass, field
 from typing import List, Tuple, Dict, Any
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_core.embeddings import Embeddings
@@ -46,6 +47,25 @@ class RetrieverConfig(BaseModel):
     sim_threshold: float
     text_collection: str
     image_collection: str
+
+
+@dataclass
+class RetrievalOutput:
+    texts: List[str] = field(default_factory=list)
+    ids: List[str] = field(default_factory=list)
+    similarities: List[float] = field(default_factory=list)
+    names: List[str] = field(default_factory=list)
+    images: List[str] = field(default_factory=list)
+    products: List[Dict[str, Any]] = field(default_factory=list)
+    diagnostics: Dict[str, Any] = field(default_factory=dict)
+    no_result_reason: str | None = None
+
+    def __iter__(self):
+        yield self.texts
+        yield self.ids
+        yield self.similarities
+        yield self.names
+        yield self.images
 
 # Defines a type for storing and embedding text.
 class TextEmbeddings(Embeddings):
@@ -647,22 +667,34 @@ class Retriever:
         filters: Dict[str, Any] | None = None,
         image: str = "",
         k: int = 4,
+        candidate_k: int | None = None,
         image_bool: bool = False,
         verbose: bool = True
-    ) -> Tuple[List[str], List[str], List[float], List[str], List[str]]:
+    ) -> RetrievalOutput:
         """
         Asynchronously retrieve relevant items from both text and image databases.
         """
+        candidate_limit = max(k, candidate_k or (k * 5))
+        diagnostics: Dict[str, Any] = {
+            "requested_top_k": k,
+            "candidate_k": candidate_limit,
+            "search_mode": "image" if image_bool else "text",
+        }
 
         # Check if our query is blank. If it is, replace it with dummy text.
         local_queries = query
         if not query:
             local_queries = ["Can you find me something like this image?"]
+        query_count = max(1, len(local_queries))
 
         if image_bool:
             if not self.image_enabled or self.image_db is None:
                 logging.info("CATALOG RETRIEVER | retrieve() | Image retrieval requested but image embeddings are disabled.")
-                return [], [], [], [], []
+                diagnostics["returned_count"] = 0
+                return RetrievalOutput(
+                    diagnostics=diagnostics,
+                    no_result_reason="image_embeddings_disabled",
+                )
 
             if verbose:
                 logging.info("CATALOG RETRIEVER | retrieve() | Performing dual retrieval for image input.")
@@ -672,7 +704,13 @@ class Retriever:
             for local_query in local_queries:
                 if verbose:
                     logging.info(f"\t| retrieve() | Checking query: {local_query}.")
-                t2t_tasks.append(asyncio.to_thread(self.text_db.similarity_search_with_relevance_scores, local_query, k=k))
+                t2t_tasks.append(
+                    asyncio.to_thread(
+                        self.text_db.similarity_search_with_relevance_scores,
+                        local_query,
+                        k=candidate_limit,
+                    )
+                )
             if verbose:
                 logging.info("CATALOG RETRIEVER | retrieve() | Started text task.")
             base64_string = image.replace("data:application/octet-stream", "data:image/jpeg")
@@ -680,7 +718,11 @@ class Retriever:
                 logging.info(f"CATALOG RETRIEVER | retrieve() | Starting image task...\n\t| {base64_string[:100]}")
             if verbose:
                 logging.info(f"CATALOG RETRIEVER | retrieve() | Obtained embedding...")
-            i2i_task = asyncio.to_thread(self.image_db.similarity_search_with_relevance_scores, base64_string, k=k*len(query))
+            i2i_task = asyncio.to_thread(
+                self.image_db.similarity_search_with_relevance_scores,
+                base64_string,
+                k=candidate_limit * query_count,
+            )
 
             unformatted_results = await asyncio.gather(*t2t_tasks, i2i_task)
         else:
@@ -691,8 +733,18 @@ class Retriever:
             for local_query in local_queries:
                 if verbose:
                     logging.info(f"\t| retrieve() | Launching text-only retrieval. Query type: {type(local_query)}, Query: {local_query}")
-                results.append(asyncio.to_thread(self.text_db.similarity_search_with_relevance_scores, local_query, k=k*len(query)))
+                results.append(
+                    asyncio.to_thread(
+                        self.text_db.similarity_search_with_relevance_scores,
+                        local_query,
+                        k=candidate_limit * query_count,
+                    )
+                )
             unformatted_results = await asyncio.gather(*results)
+
+        diagnostics["source_result_count"] = sum(
+            len(query_results) for query_results in unformatted_results
+        )
 
         sorted_unformatted_results = []
         for query_results in unformatted_results:
@@ -743,22 +795,51 @@ class Retriever:
                 final_results.append(res)
         
         all_results = final_results
+        diagnostics["deduped_count"] = len(all_results)
 
         if verbose:
             logging.info(f"""CATALOG RETRIEVER | retrieve() | All retrieved results length. {len(all_results)}
                             \n\t| Similarities: {[res[1] for res in all_results]}
                             \n\t| Names: {[res[0].metadata['name'] for res in all_results]}""")
 
-        # Keep the highest-ranked top-k first, then apply explicit filters to that window.
-        ranked_results = all_results[:k]
-        ranked_results = [res for res in ranked_results if res[1] > self.sim_threshold]
-        ranked_results = sorted(ranked_results, key=lambda item: item[1], reverse=True)
+        if not all_results:
+            diagnostics["returned_count"] = 0
+            return RetrievalOutput(
+                diagnostics=diagnostics,
+                no_result_reason="no_candidates",
+            )
+
+        # Apply threshold and hard filters across a wider candidate window before
+        # trimming to the final top-k response.
+        candidate_results = all_results[:candidate_limit]
+        diagnostics["candidate_window_count"] = len(candidate_results)
+        thresholded_results = [
+            res for res in candidate_results if res[1] > self.sim_threshold
+        ]
+        diagnostics["after_threshold_count"] = len(thresholded_results)
+        if not thresholded_results:
+            diagnostics["returned_count"] = 0
+            return RetrievalOutput(
+                diagnostics=diagnostics,
+                no_result_reason="below_similarity_threshold",
+            )
+
+        structured_filters = self._effective_filters(filters, categories)
+        ranked_results = sorted(thresholded_results, key=lambda item: item[1], reverse=True)
         ranked_results = self._apply_structured_filters(
             ranked_results,
-            filters=filters,
+            filters=structured_filters,
             verbose=verbose
         )
+        diagnostics["after_filter_count"] = len(ranked_results)
+        if not ranked_results:
+            diagnostics["returned_count"] = 0
+            return RetrievalOutput(
+                diagnostics=diagnostics,
+                no_result_reason="filtered_out",
+            )
         ranked_results = ranked_results[:k]
+        diagnostics["returned_count"] = len(ranked_results)
 
         if verbose:
             logging.info(
@@ -771,82 +852,23 @@ class Retriever:
         final_sims = [res[1] for res in ranked_results]
         final_names = [res[0].metadata['name'] for res in ranked_results]
         final_images = [res[0].metadata['image'] for res in ranked_results]
+        final_products = [
+            self._product_payload_from_result(res)
+            for res in ranked_results
+        ]
 
         if verbose:
             logging.info(f"CATALOG RETRIEVER | retrieve() | \n\tnames: {final_names} \n\tsimilarities: {final_sims}")
 
-        # Safely extract categories from texts
-        cat_list = []
-        for text in final_texts:
-            try:
-                # Text format: "name | description | category,subcategory"
-                # Extract the last part after | and split by comma
-                category_part = text.split("|")[-1].strip()
-                if "PRICE:" in category_part:
-                    # Handle malformed data where price info got mixed with category
-                    category_part = category_part.split("PRICE:")[0].strip()
-                
-                # Split by comma to get [category, subcategory]
-                parts = category_part.split(",")
-                cats = []
-                for part in parts:
-                    cleaned = part.strip().lower()
-                    if cleaned and not cleaned.startswith("/"):  # Skip malformed data like "/images/..."
-                        cats.append(cleaned)
-                cat_list.append(cats)
-            except Exception as e:
-                if verbose:
-                    logging.warning(f"CATALOG RETRIEVER | Error parsing category from: {text[:50]}... Error: {e}")
-                cat_list.append([])
-
-        if verbose:
-            logging.info(f"CATALOG RETRIEVER | pre-category filtering:\n\tCategories: {cat_list}\n\tUser input: {categories}")
-
-        # For image searches, ALWAYS return all results without category filtering
-        # Image similarity should determine relevance, not predefined categories
-        if image_bool:
-            if verbose:
-                logging.info("CATALOG RETRIEVER | Image search - returning all similarity-based results without category filtering")
-            return final_texts, final_ids, final_sims, final_names, final_images
-        
-        # For text searches, if no categories provided, return empty
-        if not categories:
-            if verbose:
-                logging.info("CATALOG RETRIEVER | No categories provided for text search, returning empty.")
-            return [], [], [], [], []
-
-        # Filter by category - check if any user category matches any product category/subcategory
-        filtered = []
-        for text, id_, sim, name, img, cats in zip(final_texts, 
-                                                   final_ids, 
-                                                   final_sims, 
-                                                   final_names, 
-                                                   final_images, 
-                                                   cat_list):
-            # Check if any user-provided category matches any product category/subcategory
-            match_found = False
-            for user_cat in categories:
-                user_cat_lower = user_cat.lower().strip()
-                for prod_cat in cats:
-                    # Check for partial match (e.g., "bag" matches "bags", "dress" matches "dresses")
-                    if user_cat_lower in prod_cat or prod_cat in user_cat_lower:
-                        match_found = True
-                        break
-                if match_found:
-                    break
-            
-            if match_found:
-                filtered.append((text, id_, sim, name, img))
-
-        if not filtered:
-            if verbose:
-                logging.info("CATALOG RETRIEVER | No matches after category filtering.")
-            return [], [], [], [], []
-
-        texts_out, ids_out, sims_out, names_out, images_out = zip(*filtered)
-        if verbose:
-            logging.info(f"CATALOG RETRIEVER | length of output items: {len(names_out)}")
-        return list(texts_out), list(ids_out), list(sims_out), list(names_out), list(images_out)
+        return RetrievalOutput(
+            texts=final_texts,
+            ids=final_ids,
+            similarities=final_sims,
+            names=final_names,
+            images=final_images,
+            products=final_products,
+            diagnostics=diagnostics,
+        )
 
     @staticmethod
     def _coerce_float(value: Any) -> float | None:
@@ -877,20 +899,26 @@ class Retriever:
 
         min_price = self._coerce_float(filters.get("min_price"))
         max_price = self._coerce_float(filters.get("max_price"))
+        category_values = self._normalize_filter_values(filters.get("category"))
 
-        if min_price is None and max_price is None:
+        if min_price is None and max_price is None and not category_values:
             return results
 
         filtered_results: List[Tuple[Any, float]] = []
         for result in results:
             doc = result[0]
+            if category_values and not self._metadata_matches_category(
+                doc.metadata, category_values
+            ):
+                continue
             price = self._coerce_float(doc.metadata.get("price"))
-            if price is None:
-                continue
-            if min_price is not None and price < min_price:
-                continue
-            if max_price is not None and price > max_price:
-                continue
+            if min_price is not None or max_price is not None:
+                if price is None:
+                    continue
+                if min_price is not None and price < min_price:
+                    continue
+                if max_price is not None and price > max_price:
+                    continue
             filtered_results.append(result)
 
         if verbose:
@@ -900,3 +928,57 @@ class Retriever:
             )
 
         return filtered_results
+
+    @staticmethod
+    def _normalize_filter_values(value: Any) -> set[str]:
+        if value is None:
+            return set()
+        if isinstance(value, list):
+            return {str(item).strip().lower() for item in value if str(item).strip()}
+        text = str(value).strip()
+        return {text.lower()} if text else set()
+
+    @classmethod
+    def _metadata_matches_category(
+        cls, metadata: Dict[str, Any], category_values: set[str]
+    ) -> bool:
+        product_values = set()
+        for field in ("category", "subcategory"):
+            value = str(metadata.get(field) or "").strip().lower()
+            if value:
+                product_values.add(value)
+        return bool(product_values.intersection(category_values))
+
+    @staticmethod
+    def _effective_filters(
+        filters: Dict[str, Any] | None,
+        categories: List[str],
+    ) -> Dict[str, Any]:
+        effective = dict(filters or {})
+        if categories and "category" not in effective:
+            effective["category"] = categories
+        return effective
+
+    @staticmethod
+    def _product_payload_from_result(result: Tuple[Any, float]) -> Dict[str, Any]:
+        doc, similarity = result
+        metadata = doc.metadata
+        price = Retriever._coerce_float(metadata.get("price"))
+        product: Dict[str, Any] = {
+            "product_id": str(metadata.get("pk") or metadata.get("name")),
+            "display_name": str(metadata.get("name") or ""),
+            "description": str(metadata.get("description") or doc.page_content or ""),
+            "category": str(metadata.get("subcategory") or metadata.get("category") or ""),
+            "image_url": str(metadata.get("image") or ""),
+            "attributes": {
+                "catalog_text": (
+                    doc.page_content + f"\nPRICE: {metadata.get('price')}"
+                ),
+                "similarity": float(similarity),
+                "source_category": metadata.get("category"),
+                "source_subcategory": metadata.get("subcategory"),
+            },
+        }
+        if price is not None:
+            product["price"] = {"amount": price, "currency": "USD"}
+        return product

--- a/chain_server/src/catalog_capabilities.py
+++ b/chain_server/src/catalog_capabilities.py
@@ -10,10 +10,14 @@ from typing import Any
 
 import requests
 
-from shared.commerce_contracts import CatalogCapabilities
+from shared.commerce_contracts import (
+    CatalogCapabilities,
+    CatalogFilterCapability,
+)
 
 
 logger = logging.getLogger(__name__)
+_DEFAULT_TIMEOUT_SECONDS = 2.0
 
 
 class CatalogCapabilitiesClient:
@@ -27,7 +31,9 @@ class CatalogCapabilitiesClient:
         session: Any | None = None,
     ) -> None:
         self.catalog_retriever_url = catalog_retriever_url.rstrip("/")
-        self.timeout_seconds = timeout_seconds
+        self.timeout_seconds = (
+            timeout_seconds if timeout_seconds is not None else _DEFAULT_TIMEOUT_SECONDS
+        )
         self.session = session or requests
         self._cached: CatalogCapabilities | None = None
 
@@ -44,10 +50,57 @@ class CatalogCapabilitiesClient:
             capabilities = CatalogCapabilities.model_validate(response.json())
         except (requests.RequestException, ValueError) as exc:
             logger.warning("Catalog capabilities unavailable: %s", exc)
-            capabilities = CatalogCapabilities(catalog_id="unavailable")
+            return CatalogCapabilities(catalog_id="unavailable")
 
         self._cached = capabilities
         return capabilities
 
     def clear(self) -> None:
         self._cached = None
+
+
+def format_catalog_capabilities_for_prompt(
+    capabilities: CatalogCapabilities,
+) -> str:
+    """Render catalog-owned filter metadata for the agent prompt."""
+
+    if capabilities.catalog_id == "unavailable":
+        return (
+            "Catalog capability metadata is currently unavailable. Use "
+            "search_catalog_tool for product discovery and ask a concise "
+            "clarifying question when the shopper request is underspecified."
+        )
+
+    lines = [f"Catalog ID: {capabilities.catalog_id}"]
+    if capabilities.retrieval_modes:
+        lines.append(f"Retrieval modes: {', '.join(capabilities.retrieval_modes)}")
+
+    if capabilities.filters:
+        lines.append("Hard filters:")
+        for name, capability in sorted(capabilities.filters.items()):
+            lines.append(f"- {name}: {_format_filter_capability(capability)}")
+
+    return "\n".join(lines)
+
+
+def _format_filter_capability(capability: CatalogFilterCapability) -> str:
+    parts = [capability.type]
+    if capability.operators:
+        parts.append(f"operators {', '.join(capability.operators)}")
+    if capability.values:
+        parts.append(f"values {_format_values(capability.values)}")
+    elif capability.min_value is not None or capability.max_value is not None:
+        parts.append(f"range {_format_range(capability.min_value, capability.max_value)}")
+    return "; ".join(parts)
+
+
+def _format_values(values: list[str], *, limit: int = 80) -> str:
+    displayed = values[:limit]
+    suffix = f", ... +{len(values) - limit} more" if len(values) > limit else ""
+    return ", ".join(displayed) + suffix
+
+
+def _format_range(min_value: float | None, max_value: float | None) -> str:
+    minimum = "*" if min_value is None else str(min_value)
+    maximum = "*" if max_value is None else str(max_value)
+    return f"{minimum} to {maximum}"

--- a/chain_server/src/catalog_capabilities.py
+++ b/chain_server/src/catalog_capabilities.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Chain-server client for catalog-owned capability metadata."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+from shared.commerce_contracts import CatalogCapabilities
+
+
+logger = logging.getLogger(__name__)
+
+
+class CatalogCapabilitiesClient:
+    """Fetch and cache catalog capabilities from the catalog service."""
+
+    def __init__(
+        self,
+        catalog_retriever_url: str,
+        *,
+        timeout_seconds: float | None = None,
+        session: Any | None = None,
+    ) -> None:
+        self.catalog_retriever_url = catalog_retriever_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.session = session or requests
+        self._cached: CatalogCapabilities | None = None
+
+    def get(self, *, force_refresh: bool = False) -> CatalogCapabilities:
+        if self._cached is not None and not force_refresh:
+            return self._cached
+
+        try:
+            response = self.session.get(
+                f"{self.catalog_retriever_url}/capabilities",
+                timeout=self.timeout_seconds,
+            )
+            response.raise_for_status()
+            capabilities = CatalogCapabilities.model_validate(response.json())
+        except (requests.RequestException, ValueError) as exc:
+            logger.warning("Catalog capabilities unavailable: %s", exc)
+            capabilities = CatalogCapabilities(catalog_id="unavailable")
+
+        self._cached = capabilities
+        return capabilities
+
+    def clear(self) -> None:
+        self._cached = None

--- a/chain_server/src/catalog_execution.py
+++ b/chain_server/src/catalog_execution.py
@@ -46,7 +46,7 @@ def execute_catalog_search(
     if (
         plan.search_mode == "hybrid"
         and image_base64
-        and plan.queries
+        and plan.semantic_queries
         and result.ok
         and not result.products
     ):
@@ -71,10 +71,10 @@ def _request_from_plan(
         categories = []
 
     effective_image = image_base64 if plan.search_mode in {"image", "hybrid"} else ""
-    query = " ".join(plan.queries)
+    query = " ".join(plan.semantic_queries)
     return SearchCatalogInput(
         query=query,
-        queries=plan.queries,
+        queries=plan.semantic_queries,
         image_base64=effective_image,
         categories=categories,
         filters=hard_filters,

--- a/chain_server/src/catalog_execution.py
+++ b/chain_server/src/catalog_execution.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure catalog search execution for structured search plans."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pydantic import BaseModel
+
+from .catalog_request import CatalogSearchPlan
+from .commerce_tools import search_catalog
+from shared.commerce_contracts import SearchCatalogInput, SearchCatalogResult
+
+
+SearchCatalogFn = Callable[..., SearchCatalogResult]
+
+
+class CatalogSearchExecution(BaseModel):
+    result: SearchCatalogResult
+    fallback_used: bool = False
+
+
+def execute_catalog_search(
+    plan: CatalogSearchPlan,
+    catalog_retriever_url: str,
+    *,
+    image_base64: str = "",
+    timeout_seconds: float | None = None,
+    search_fn: SearchCatalogFn = search_catalog,
+) -> CatalogSearchExecution:
+    if not plan.should_search:
+        return CatalogSearchExecution(
+            result=SearchCatalogResult(ok=True, products=[])
+        )
+
+    request = _request_from_plan(plan, image_base64=image_base64)
+    result = search_fn(
+        request,
+        catalog_retriever_url,
+        timeout_seconds=timeout_seconds,
+    )
+    fallback_used = False
+
+    if (
+        plan.search_mode == "hybrid"
+        and image_base64
+        and plan.queries
+        and result.ok
+        and not result.products
+    ):
+        result = search_fn(
+            _request_from_plan(plan, image_base64=""),
+            catalog_retriever_url,
+            timeout_seconds=timeout_seconds,
+        )
+        fallback_used = bool(result.products)
+
+    return CatalogSearchExecution(result=result, fallback_used=fallback_used)
+
+
+def _request_from_plan(
+    plan: CatalogSearchPlan,
+    *,
+    image_base64: str,
+) -> SearchCatalogInput:
+    hard_filters = dict(plan.hard_filters)
+    categories = hard_filters.pop("category", [])
+    if not isinstance(categories, list):
+        categories = []
+
+    effective_image = image_base64 if plan.search_mode in {"image", "hybrid"} else ""
+    query = " ".join(plan.queries)
+    return SearchCatalogInput(
+        query=query,
+        queries=plan.queries,
+        image_base64=effective_image,
+        categories=categories,
+        filters=hard_filters,
+        top_k=plan.top_k,
+    )

--- a/chain_server/src/catalog_request.py
+++ b/chain_server/src/catalog_request.py
@@ -14,20 +14,17 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from shared.commerce_contracts import CatalogCapabilities
+from shared.commerce_contracts import CatalogCapabilities, CatalogFilterCapability
 
 
 SearchMode = Literal["text", "image", "hybrid"]
-SearchStrictness = Literal["unspecified", "hard", "soft"]
+SearchStrictness = Literal["unspecified", "hard"]
 
 
 class CatalogSearchIntent(BaseModel):
     query: str = ""
     queries: list[str] = Field(default_factory=list)
-    categories: list[str] = Field(default_factory=list)
-    min_price: float | None = None
-    max_price: float | None = None
-    soft_preferences: dict[str, Any] = Field(default_factory=dict)
+    filters: dict[str, Any] = Field(default_factory=dict)
     strictness: SearchStrictness = "unspecified"
     search_mode: SearchMode | None = None
 
@@ -35,9 +32,6 @@ class CatalogSearchIntent(BaseModel):
     def normalize_query_fields(self) -> "CatalogSearchIntent":
         self.query = self.query.strip()
         self.queries = [query.strip() for query in self.queries if query.strip()]
-        self.categories = [
-            category.strip() for category in self.categories if category.strip()
-        ]
         return self
 
 
@@ -45,7 +39,6 @@ class CatalogSearchPlan(BaseModel):
     should_search: bool
     queries: list[str] = Field(default_factory=list)
     hard_filters: dict[str, Any] = Field(default_factory=dict)
-    soft_preferences: dict[str, Any] = Field(default_factory=dict)
     strictness: SearchStrictness = "unspecified"
     search_mode: SearchMode = "text"
     top_k: int = 4
@@ -62,7 +55,6 @@ def build_catalog_search_plan(
     queries = intent.queries or ([intent.query] if intent.query else [])
     mode = _search_mode(intent.search_mode, capabilities, has_image=has_image)
     hard_filters = _hard_filters(intent, capabilities)
-    soft_preferences = _soft_preferences(intent, capabilities)
 
     if not queries and not has_image:
         return CatalogSearchPlan(
@@ -70,7 +62,6 @@ def build_catalog_search_plan(
             search_mode=mode,
             top_k=top_k,
             strictness=intent.strictness,
-            soft_preferences=soft_preferences,
             hard_filters=hard_filters,
             no_search_reason="missing_query_or_image",
         )
@@ -79,7 +70,6 @@ def build_catalog_search_plan(
         should_search=True,
         queries=queries,
         hard_filters=hard_filters,
-        soft_preferences=soft_preferences,
         strictness=intent.strictness,
         search_mode=mode,
         top_k=top_k,
@@ -91,43 +81,15 @@ def _hard_filters(
     capabilities: CatalogCapabilities,
 ) -> dict[str, Any]:
     filters: dict[str, Any] = {}
-    category_values = _filter_values(capabilities, "category")
-    if category_values is not None:
-        categories = [
-            category
-            for category in intent.categories
-            if category in category_values
-        ]
-        if categories:
-            filters["category"] = categories
-
-    price_filter = capabilities.filters.get("price")
-    if price_filter is not None and price_filter.type == "number":
-        if intent.min_price is not None and intent.min_price > 0:
-            filters["min_price"] = intent.min_price
-        if intent.max_price is not None and intent.max_price > 0:
-            filters["max_price"] = intent.max_price
-
-    if (
-        "min_price" in filters
-        and "max_price" in filters
-        and filters["min_price"] > filters["max_price"]
-    ):
-        filters.pop("min_price")
-        filters.pop("max_price")
+    for name, raw_value in intent.filters.items():
+        capability = capabilities.filters.get(name)
+        if capability is None:
+            continue
+        value = _validated_filter_value(raw_value, capability)
+        if value not in (None, "", [], {}):
+            filters[name] = value
 
     return filters
-
-
-def _soft_preferences(
-    intent: CatalogSearchIntent,
-    capabilities: CatalogCapabilities,
-) -> dict[str, Any]:
-    return {
-        key: value
-        for key, value in intent.soft_preferences.items()
-        if key in capabilities.soft_facets and value not in (None, "", [], {})
-    }
 
 
 def _search_mode(
@@ -146,11 +108,70 @@ def _search_mode(
     return "text"
 
 
-def _filter_values(
-    capabilities: CatalogCapabilities,
-    filter_name: str,
-) -> set[str] | None:
-    capability = capabilities.filters.get(filter_name)
-    if capability is None or capability.type != "enum":
+def _validated_filter_value(
+    value: Any,
+    capability: CatalogFilterCapability,
+) -> Any:
+    if capability.type == "number":
+        return _number_filter(value)
+    if capability.type == "enum":
+        return _enum_filter(value, capability.values)
+    if capability.type == "text":
+        return _text_filter(value)
+    return None
+
+
+def _enum_filter(value: Any, allowed_values: list[str]) -> list[str]:
+    if not allowed_values:
+        return []
+    candidates = _filter_values(value)
+    allowed = set(allowed_values)
+    return [candidate for candidate in candidates if candidate in allowed]
+
+
+def _text_filter(value: Any) -> list[str]:
+    return _filter_values(value)
+
+
+def _filter_values(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value).strip()
+    return [text] if text else []
+
+
+def _number_filter(value: Any) -> dict[str, float]:
+    if not isinstance(value, dict):
+        return {}
+
+    lower = _first_number(value, ("min", "gte"))
+    upper = _first_number(value, ("max", "lte"))
+    if lower is not None and upper is not None and lower > upper:
+        return {}
+
+    number_filter: dict[str, float] = {}
+    if lower is not None:
+        number_filter["min"] = lower
+    if upper is not None:
+        number_filter["max"] = upper
+    return number_filter
+
+
+def _first_number(values: dict[str, Any], keys: tuple[str, ...]) -> float | None:
+    for key in keys:
+        if key in values:
+            return _coerce_float(values[key])
+    return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
         return None
-    return set(capability.values)
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None

--- a/chain_server/src/catalog_request.py
+++ b/chain_server/src/catalog_request.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build catalog search plans from structured agent intent.
+
+This module does not parse shopper language. The agent or another language
+understanding layer supplies structured intent; this builder validates that
+intent against catalog-owned capabilities.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from shared.commerce_contracts import CatalogCapabilities
+
+
+SearchMode = Literal["text", "image", "hybrid"]
+SearchStrictness = Literal["unspecified", "hard", "soft"]
+
+
+class CatalogSearchIntent(BaseModel):
+    query: str = ""
+    queries: list[str] = Field(default_factory=list)
+    categories: list[str] = Field(default_factory=list)
+    min_price: float | None = None
+    max_price: float | None = None
+    soft_preferences: dict[str, Any] = Field(default_factory=dict)
+    strictness: SearchStrictness = "unspecified"
+    search_mode: SearchMode | None = None
+
+    @model_validator(mode="after")
+    def normalize_query_fields(self) -> "CatalogSearchIntent":
+        self.query = self.query.strip()
+        self.queries = [query.strip() for query in self.queries if query.strip()]
+        self.categories = [
+            category.strip() for category in self.categories if category.strip()
+        ]
+        return self
+
+
+class CatalogSearchPlan(BaseModel):
+    should_search: bool
+    queries: list[str] = Field(default_factory=list)
+    hard_filters: dict[str, Any] = Field(default_factory=dict)
+    soft_preferences: dict[str, Any] = Field(default_factory=dict)
+    strictness: SearchStrictness = "unspecified"
+    search_mode: SearchMode = "text"
+    top_k: int = 4
+    no_search_reason: str | None = None
+
+
+def build_catalog_search_plan(
+    intent: CatalogSearchIntent,
+    capabilities: CatalogCapabilities,
+    *,
+    has_image: bool = False,
+    top_k: int = 4,
+) -> CatalogSearchPlan:
+    queries = intent.queries or ([intent.query] if intent.query else [])
+    mode = _search_mode(intent.search_mode, capabilities, has_image=has_image)
+    hard_filters = _hard_filters(intent, capabilities)
+    soft_preferences = _soft_preferences(intent, capabilities)
+
+    if not queries and not has_image:
+        return CatalogSearchPlan(
+            should_search=False,
+            search_mode=mode,
+            top_k=top_k,
+            strictness=intent.strictness,
+            soft_preferences=soft_preferences,
+            hard_filters=hard_filters,
+            no_search_reason="missing_query_or_image",
+        )
+
+    return CatalogSearchPlan(
+        should_search=True,
+        queries=queries,
+        hard_filters=hard_filters,
+        soft_preferences=soft_preferences,
+        strictness=intent.strictness,
+        search_mode=mode,
+        top_k=top_k,
+    )
+
+
+def _hard_filters(
+    intent: CatalogSearchIntent,
+    capabilities: CatalogCapabilities,
+) -> dict[str, Any]:
+    filters: dict[str, Any] = {}
+    category_values = _filter_values(capabilities, "category")
+    if category_values is not None:
+        categories = [
+            category
+            for category in intent.categories
+            if category in category_values
+        ]
+        if categories:
+            filters["category"] = categories
+
+    price_filter = capabilities.filters.get("price")
+    if price_filter is not None and price_filter.type == "number":
+        if intent.min_price is not None and intent.min_price > 0:
+            filters["min_price"] = intent.min_price
+        if intent.max_price is not None and intent.max_price > 0:
+            filters["max_price"] = intent.max_price
+
+    if (
+        "min_price" in filters
+        and "max_price" in filters
+        and filters["min_price"] > filters["max_price"]
+    ):
+        filters.pop("min_price")
+        filters.pop("max_price")
+
+    return filters
+
+
+def _soft_preferences(
+    intent: CatalogSearchIntent,
+    capabilities: CatalogCapabilities,
+) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in intent.soft_preferences.items()
+        if key in capabilities.soft_facets and value not in (None, "", [], {})
+    }
+
+
+def _search_mode(
+    requested: SearchMode | None,
+    capabilities: CatalogCapabilities,
+    *,
+    has_image: bool,
+) -> SearchMode:
+    supported = set(capabilities.retrieval_modes)
+    if requested in supported:
+        return requested
+    if has_image and "hybrid" in supported:
+        return "hybrid"
+    if has_image and "image" in supported:
+        return "image"
+    return "text"
+
+
+def _filter_values(
+    capabilities: CatalogCapabilities,
+    filter_name: str,
+) -> set[str] | None:
+    capability = capabilities.filters.get(filter_name)
+    if capability is None or capability.type != "enum":
+        return None
+    return set(capability.values)

--- a/chain_server/src/catalog_request.py
+++ b/chain_server/src/catalog_request.py
@@ -22,22 +22,24 @@ SearchStrictness = Literal["unspecified", "hard"]
 
 
 class CatalogSearchIntent(BaseModel):
-    query: str = ""
-    queries: list[str] = Field(default_factory=list)
+    semantic_query: str = ""
+    semantic_queries: list[str] = Field(default_factory=list)
     filters: dict[str, Any] = Field(default_factory=dict)
     strictness: SearchStrictness = "unspecified"
     search_mode: SearchMode | None = None
 
     @model_validator(mode="after")
     def normalize_query_fields(self) -> "CatalogSearchIntent":
-        self.query = self.query.strip()
-        self.queries = [query.strip() for query in self.queries if query.strip()]
+        self.semantic_query = self.semantic_query.strip()
+        self.semantic_queries = [
+            query.strip() for query in self.semantic_queries if query.strip()
+        ]
         return self
 
 
 class CatalogSearchPlan(BaseModel):
     should_search: bool
-    queries: list[str] = Field(default_factory=list)
+    semantic_queries: list[str] = Field(default_factory=list)
     hard_filters: dict[str, Any] = Field(default_factory=dict)
     strictness: SearchStrictness = "unspecified"
     search_mode: SearchMode = "text"
@@ -52,11 +54,13 @@ def build_catalog_search_plan(
     has_image: bool = False,
     top_k: int = 4,
 ) -> CatalogSearchPlan:
-    queries = intent.queries or ([intent.query] if intent.query else [])
+    semantic_queries = intent.semantic_queries or (
+        [intent.semantic_query] if intent.semantic_query else []
+    )
     mode = _search_mode(intent.search_mode, capabilities, has_image=has_image)
     hard_filters = _hard_filters(intent, capabilities)
 
-    if not queries and not has_image:
+    if not semantic_queries and not has_image:
         return CatalogSearchPlan(
             should_search=False,
             search_mode=mode,
@@ -68,7 +72,7 @@ def build_catalog_search_plan(
 
     return CatalogSearchPlan(
         should_search=True,
-        queries=queries,
+        semantic_queries=semantic_queries,
         hard_filters=hard_filters,
         strictness=intent.strictness,
         search_mode=mode,

--- a/chain_server/src/commerce_tools.py
+++ b/chain_server/src/commerce_tools.py
@@ -10,7 +10,6 @@ Agents tools, and later protocol adapters can share the same typed boundary.
 
 from __future__ import annotations
 
-import re
 from typing import Any
 
 import requests
@@ -32,9 +31,6 @@ from shared.commerce_contracts import (
     SearchCatalogResult,
     ToolMeta,
 )
-
-
-_PRICE_RE = re.compile(r"\bPRICE:\s*\$?([0-9][0-9,]*(?:\.[0-9]+)?)", re.IGNORECASE)
 
 
 def search_catalog(
@@ -69,6 +65,8 @@ def search_catalog(
         "filters": request.filters,
         "k": request.top_k,
     }
+    if request.candidate_k is not None:
+        payload["candidate_k"] = request.candidate_k
     if image:
         payload["image_base64"] = image
 
@@ -101,7 +99,12 @@ def search_catalog(
             ),
         )
 
-    return SearchCatalogResult(ok=True, products=_products_from_catalog_response(data))
+    return SearchCatalogResult(
+        ok=True,
+        products=_products_from_catalog_response(data),
+        diagnostics=data.get("diagnostics") or {},
+        no_result_reason=data.get("no_result_reason"),
+    )
 
 
 def get_cart(
@@ -282,6 +285,18 @@ def _catalog_session() -> requests.Session:
 
 
 def _products_from_catalog_response(data: dict[str, Any]) -> list[ProductSummary]:
+    structured_products = data.get("products") or []
+    if structured_products:
+        products: list[ProductSummary] = []
+        for product in structured_products:
+            if not isinstance(product, dict):
+                continue
+            try:
+                products.append(ProductSummary.model_validate(product))
+            except ValueError:
+                continue
+        return products
+
     texts = data.get("texts") or []
     ids = data.get("ids") or []
     names = data.get("names") or []
@@ -371,17 +386,24 @@ def _float_or_default(value: Any, default: float | None) -> float | None:
 
 
 def _price_from_text(text: str) -> Money | None:
-    match = _PRICE_RE.search(text)
-    if not match:
-        return None
-    try:
-        return Money(amount=float(match.group(1).replace(",", "")))
-    except ValueError:
-        return None
+    for line in text.splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip().upper() == "PRICE":
+            try:
+                return Money(amount=float(value.strip().replace("$", "").replace(",", "")))
+            except ValueError:
+                return None
+    return None
 
 
 def _strip_price(text: str) -> str:
-    return _PRICE_RE.sub("", text).strip()
+    lines = []
+    for line in text.splitlines():
+        key, separator, _value = line.partition(":")
+        if separator and key.strip().upper() == "PRICE":
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
 
 
 def _category_from_text(text: str) -> str | None:

--- a/chain_server/src/config.py
+++ b/chain_server/src/config.py
@@ -87,8 +87,14 @@ class ChainServerConfig(BaseModel):
     routing_prompt: str = Field(..., description="System prompt for routing queries to appropriate agents")
     chatter_prompt: str = Field(..., description="System prompt for general conversation")
     
-    # Product Configuration
-    categories: List[str] = Field(..., description="List of product categories")
+    # Legacy Product Configuration
+    categories: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Legacy category list for non-entrypoint graph agents. The active "
+            "Deep Agents runtime gets catalog filters from catalog capabilities."
+        ),
+    )
     agent_choices: List[str] = Field(..., description="Available agent types")
     
     # Performance Configuration
@@ -141,7 +147,7 @@ class ChainServerConfig(BaseModel):
             raise ValueError("catalog_search_timeout_seconds must be positive")
         return v
     
-    @validator('categories', 'agent_choices')
+    @validator('agent_choices')
     def validate_lists_not_empty(cls, v):
         """Validate that lists are not empty."""
         if not v:

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -18,7 +18,10 @@ from langgraph.checkpoint.memory import MemorySaver
 import requests
 
 from .agenttypes import Cart, State
-from .catalog_capabilities import CatalogCapabilitiesClient
+from .catalog_capabilities import (
+    CatalogCapabilitiesClient,
+    format_catalog_capabilities_for_prompt,
+)
 from .catalog_execution import execute_catalog_search
 from .catalog_request import CatalogSearchIntent, build_catalog_search_plan
 from .commerce_tools import (
@@ -29,6 +32,7 @@ from .commerce_tools import (
 from .media_perception import MediaPerceptionClient
 from shared.commerce_contracts import (
     AddCartItemInput,
+    CatalogCapabilities,
     GetCartInput,
     ProductSummary,
     RemoveCartItemInput,
@@ -76,6 +80,11 @@ class DeepAgentsRuntime:
             config.retriever_port,
             timeout_seconds=config.catalog_search_timeout_seconds,
         )
+
+    def catalog_capabilities(self, *, force_refresh: bool = False) -> CatalogCapabilities:
+        """Return catalog-owned capability metadata for API/UI consumers."""
+
+        return self._catalog_capabilities.get(force_refresh=force_refresh)
 
     async def astream(
         self, state: State, identity: RequestIdentity
@@ -170,14 +179,11 @@ class DeepAgentsRuntime:
         @tool(return_direct=False)
         def search_catalog_tool(
             query: str,
-            category: str = "",
-            min_price: float | None = None,
-            max_price: float | None = None,
-            soft_preferences: dict[str, Any] | None = None,
+            filters: dict[str, Any] | None = None,
             strictness: str = "unspecified",
             search_mode: str | None = None,
         ) -> str:
-            """Execute a structured catalog search request for product discovery."""
+            """Execute product discovery with catalog-declared hard filters."""
 
             capabilities = self._catalog_capabilities.get()
             if capabilities.catalog_id == "unavailable" and not capabilities.filters:
@@ -185,12 +191,7 @@ class DeepAgentsRuntime:
 
             intent = CatalogSearchIntent(
                 query=query,
-                categories=[category] if category else [],
-                min_price=min_price,
-                max_price=max_price,
-                soft_preferences=(
-                    soft_preferences if isinstance(soft_preferences, dict) else {}
-                ),
+                filters=filters if isinstance(filters, dict) else {},
                 strictness=_tool_strictness(strictness),
                 search_mode=_tool_search_mode(search_mode),
             )
@@ -333,17 +334,26 @@ class DeepAgentsRuntime:
         )
 
     def _system_prompt(self) -> str:
-        categories = ", ".join(self.config.categories)
+        catalog_context = format_catalog_capabilities_for_prompt(
+            self._catalog_capabilities.get()
+        )
         return f"""You are a retail shopping assistant for clothing and accessories.
 
 Use tools for catalog facts and cart actions. Do not invent product names,
 prices, availability, materials, care instructions, or cart changes.
 
-Available catalog categories: {categories}
+Catalog capabilities:
+{catalog_context}
 
 Rules:
 - Product discovery, product recommendations, budget filters, and image-similar
   shopping require search_catalog_tool.
+- Use the search_catalog_tool `filters` object only for hard filters listed in
+  Catalog capabilities. Enum filter values must exactly match the listed values.
+  Numeric filters use an object with `min` and/or `max`.
+- If the shopper says "only", "must be", "under", "over", or otherwise gives a
+  strict constraint that is listed as a catalog hard filter, include that
+  constraint in `filters`. Do not place unsupported constraints in `filters`.
 - Media-only or descriptive media requests such as "what's in this look",
   "describe this outfit", "what am I wearing", or "what colors are here" must
   be answered from MEDIA ANALYSIS. Do not call search_catalog_tool and do not
@@ -557,7 +567,7 @@ def _content_to_text(content: Any) -> str:
 
 
 def _tool_strictness(value: str) -> str:
-    return value if value in {"unspecified", "hard", "soft"} else "unspecified"
+    return value if value in {"unspecified", "hard"} else "unspecified"
 
 
 def _tool_search_mode(value: str | None) -> str | None:

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -15,6 +15,7 @@ from typing import Any, AsyncIterator
 import uuid
 
 from langgraph.checkpoint.memory import MemorySaver
+from pydantic import BaseModel, Field
 import requests
 
 from .agenttypes import Cart, State
@@ -44,6 +45,34 @@ logger = logging.getLogger(__name__)
 _EXCLUDED_DEEP_AGENT_TOOLS = frozenset(
     {"write_todos", "ls", "read_file", "write_file", "edit_file", "glob", "grep", "execute"}
 )
+
+
+class SearchCatalogToolInput(BaseModel):
+    semantic_query: str = Field(
+        default="",
+        description=(
+            "Semantic product search text only. Include product type, style, "
+            "occasion, material, visual descriptors, or other product meaning. "
+            "Exclude hard-filter constraints such as budget, exact enum values, "
+            "strictness words, or quantity limits; put enforceable constraints "
+            "in filters."
+        ),
+    )
+    filters: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Hard filters from Catalog capabilities only. Numeric filters use "
+            "objects like {'max': 100}; enum filters use exact listed values."
+        ),
+    )
+    strictness: str = Field(
+        default="unspecified",
+        description="Use 'hard' when the shopper states an enforceable constraint.",
+    )
+    search_mode: str | None = Field(
+        default=None,
+        description="Optional search mode from Catalog capabilities.",
+    )
 
 
 @dataclass(frozen=True)
@@ -176,9 +205,9 @@ class DeepAgentsRuntime:
         retrieved: dict[str, str] = {}
         state.retrieved = retrieved
 
-        @tool(return_direct=False)
+        @tool(args_schema=SearchCatalogToolInput, return_direct=False)
         def search_catalog_tool(
-            query: str,
+            semantic_query: str,
             filters: dict[str, Any] | None = None,
             strictness: str = "unspecified",
             search_mode: str | None = None,
@@ -190,7 +219,7 @@ class DeepAgentsRuntime:
                 return "Catalog search is unavailable. Please try again."
 
             intent = CatalogSearchIntent(
-                query=query,
+                semantic_query=semantic_query,
                 filters=filters if isinstance(filters, dict) else {},
                 strictness=_tool_strictness(strictness),
                 search_mode=_tool_search_mode(search_mode),
@@ -348,6 +377,9 @@ Catalog capabilities:
 Rules:
 - Product discovery, product recommendations, budget filters, and image-similar
   shopping require search_catalog_tool.
+- Pass only semantic product text to search_catalog_tool.semantic_query. Do not
+  include hard-filter language such as budget limits, strictness words, or exact
+  filter values there. Put enforceable constraints only in filters.
 - Use the search_catalog_tool `filters` object only for hard filters listed in
   Catalog capabilities. Enum filter values must exactly match the listed values.
   Numeric filters use an object with `min` and/or `max`.

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -236,6 +236,18 @@ class DeepAgentsRuntime:
             state.cart = cart
             return _format_cart(cart)
 
+        @tool(return_direct=False)
+        def get_product_details_tool(product_ref: str) -> str:
+            """Read details for a PRODUCT_REF returned by search_catalog_tool."""
+
+            product = self._product_from_ref(identity, product_ref)
+            if product is None:
+                return (
+                    f"No product with PRODUCT_REF '{product_ref}' is available. "
+                    "Search the catalog first and use the PRODUCT_REF from the result."
+                )
+            return _format_product_details(product)
+
         @tool(return_direct=True)
         def add_cart_item_tool(product_ref: str, quantity: int = 1) -> str:
             """Add a catalog item by PRODUCT_REF from a prior search_catalog_tool result."""
@@ -310,6 +322,7 @@ class DeepAgentsRuntime:
             model=model,
             tools=[
                 search_catalog_tool,
+                get_product_details_tool,
                 get_cart_tool,
                 add_cart_item_tool,
                 remove_cart_item_tool,
@@ -341,6 +354,9 @@ Rules:
   answer from the results you have or ask one concise clarifying question.
 - A tool result is enough to produce a final answer. Do not keep searching for
   alternatives unless the shopper explicitly rejects the current result.
+- Product-detail or research questions about a product already returned by
+  search_catalog_tool should use get_product_details_tool with that
+  PRODUCT_REF. Do not run another broad catalog search for known-product facts.
 - When the shopper asks to add an item that has not already been searched in
   this conversation, call search_catalog_tool first, then call
   add_cart_item_tool with the selected PRODUCT_REF.
@@ -359,6 +375,8 @@ Rules:
   success.
 - Use PRODUCT_REF from search_catalog_tool when adding an item. Do not pass
   display names to add_cart_item_tool.
+- Use PRODUCT_REF from search_catalog_tool when requesting product details. Do
+  not pass display names to get_product_details_tool.
 - Use CART_LINE_ID from CURRENT CART or get_cart_tool when removing an item. Do
   not guess cart line IDs from product names.
 - If the shopper asks for anything under a budget without a product type,
@@ -555,6 +573,26 @@ def _format_product(product: Any) -> str:
         f"PRODUCT_REF: {product.product_id}\n"
         f"{product.display_name} | {product.description}{price}"
     ).strip()
+
+
+def _format_product_details(product: ProductSummary) -> str:
+    lines = [
+        f"PRODUCT_REF: {product.product_id}",
+        f"NAME: {product.display_name}",
+    ]
+    if product.category:
+        lines.append(f"CATEGORY: {product.category}")
+    if product.brand:
+        lines.append(f"BRAND: {product.brand}")
+    if product.price:
+        lines.append(f"PRICE: ${product.price.amount:.2f} {product.price.currency}")
+    if product.description:
+        lines.append(f"DESCRIPTION: {product.description}")
+    catalog_text = product.attributes.get("catalog_text") if product.attributes else None
+    if isinstance(catalog_text, str) and catalog_text.strip():
+        lines.append("CATALOG FACTS:")
+        lines.append(catalog_text.strip())
+    return "\n".join(lines)
 
 
 def _format_cart(cart: Cart) -> str:

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -10,7 +10,6 @@ import hashlib
 import json
 import logging
 import os
-import re
 import time
 from typing import Any, AsyncIterator
 import uuid
@@ -19,19 +18,20 @@ from langgraph.checkpoint.memory import MemorySaver
 import requests
 
 from .agenttypes import Cart, State
+from .catalog_capabilities import CatalogCapabilitiesClient
+from .catalog_execution import execute_catalog_search
+from .catalog_request import CatalogSearchIntent, build_catalog_search_plan
 from .commerce_tools import (
     add_cart_item,
     get_cart,
     remove_cart_item,
-    search_catalog,
 )
-from .media_perception import MEDIA_ONLY_QUERY, MediaPerceptionClient
+from .media_perception import MediaPerceptionClient
 from shared.commerce_contracts import (
     AddCartItemInput,
     GetCartInput,
     ProductSummary,
     RemoveCartItemInput,
-    SearchCatalogInput,
 )
 
 
@@ -72,6 +72,10 @@ class DeepAgentsRuntime:
         self._profile_registered = False
         self._product_refs: dict[str, dict[str, ProductSummary]] = {}
         self._media_perception = MediaPerceptionClient(config)
+        self._catalog_capabilities = CatalogCapabilitiesClient(
+            config.retriever_port,
+            timeout_seconds=config.catalog_search_timeout_seconds,
+        )
 
     async def astream(
         self, state: State, identity: RequestIdentity
@@ -169,47 +173,43 @@ class DeepAgentsRuntime:
             category: str = "",
             min_price: float | None = None,
             max_price: float | None = None,
+            soft_preferences: dict[str, Any] | None = None,
+            strictness: str = "unspecified",
+            search_mode: str | None = None,
         ) -> str:
-            """Search available catalog products. Use for product discovery and image-similar shopping."""
+            """Execute a structured catalog search request for product discovery."""
 
-            if state.media and not _media_query_allows_catalog_search(state.query):
-                return (
-                    "Catalog search skipped: the shopper asked for visual/style "
-                    "analysis, not product retrieval. Answer from MEDIA ANALYSIS "
-                    "only and do not discuss catalog availability, prices, or "
-                    "specific products."
-                )
+            capabilities = self._catalog_capabilities.get()
+            if capabilities.catalog_id == "unavailable" and not capabilities.filters:
+                return "Catalog search is unavailable. Please try again."
 
-            categories = self._tool_categories(category)
-            filters = {
-                key: value
-                for key, value in {"min_price": min_price, "max_price": max_price}.items()
-                if value is not None and value > 0
-            }
-            result = search_catalog(
-                SearchCatalogInput(
-                    query=query,
-                    image_base64=state.image,
-                    categories=categories,
-                    filters=filters,
-                    top_k=self.config.top_k_retrieve,
+            intent = CatalogSearchIntent(
+                query=query,
+                categories=[category] if category else [],
+                min_price=min_price,
+                max_price=max_price,
+                soft_preferences=(
+                    soft_preferences if isinstance(soft_preferences, dict) else {}
                 ),
+                strictness=_tool_strictness(strictness),
+                search_mode=_tool_search_mode(search_mode),
+            )
+            plan = build_catalog_search_plan(
+                intent,
+                capabilities,
+                has_image=bool(state.image),
+                top_k=self.config.top_k_retrieve,
+            )
+            if not plan.should_search:
+                return "Catalog search requires a query or image."
+
+            execution = execute_catalog_search(
+                plan,
                 self.config.retriever_port,
+                image_base64=state.image,
                 timeout_seconds=self.config.catalog_search_timeout_seconds,
             )
-            fallback_used = False
-            if state.image and state.media_analysis and not result.products and query.strip():
-                result = search_catalog(
-                    SearchCatalogInput(
-                        query=query,
-                        categories=categories,
-                        filters=filters,
-                        top_k=self.config.top_k_retrieve,
-                    ),
-                    self.config.retriever_port,
-                    timeout_seconds=self.config.catalog_search_timeout_seconds,
-                )
-                fallback_used = bool(result.products)
+            result = execution.result
             if not result.ok:
                 return result.error.message if result.error else "Catalog search failed."
             if not result.products:
@@ -223,7 +223,7 @@ class DeepAgentsRuntime:
                 lines.append(_format_product(product))
             prefix = (
                 "Image similarity returned no matches; text fallback results:\n\n"
-                if fallback_used
+                if execution.fallback_used
                 else ""
             )
             return prefix + "\n\n".join(lines)
@@ -383,12 +383,6 @@ Rules:
             f"RECENT DISCUSSION:\n{state.context or '(none)'}"
         )
 
-    def _tool_categories(self, category: str) -> list[str]:
-        cleaned = (category or "").strip()
-        if cleaned and cleaned in self.config.categories:
-            return [cleaned]
-        return list(self.config.categories)
-
     def _remember_products(
         self, identity: RequestIdentity, products: list[ProductSummary]
     ) -> None:
@@ -515,64 +509,6 @@ def _stable_numeric_id(namespace: str, value: str) -> int:
     return int(digest[:15], 16)
 
 
-_EXPLICIT_MEDIA_CATALOG_PATTERNS = (
-    "do you have",
-    "do you carry",
-    "do you sell",
-    "in stock",
-    "available",
-    "availability",
-    "find",
-    "search",
-    "shop",
-    "buy",
-    "purchase",
-    "browse",
-    "show me",
-    "recommend",
-    "suggest",
-    "options",
-    "something like this",
-    "anything like this",
-    "like these",
-    "like this under",
-    "under $",
-    "less than",
-    "cheaper",
-    "budget",
-    "price",
-    "cost",
-    "sale",
-    "add",
-    "cart",
-    "catalog",
-    "product",
-    "products",
-)
-
-_DESCRIPTIVE_MEDIA_QUERY_RE = re.compile(
-    r"^\s*(what(?:'s| is| are)?|describe|break down|analy[sz]e|tell me about|"
-    r"identify|explain|rate)\b",
-    re.IGNORECASE,
-)
-
-
-def _media_query_allows_catalog_search(query: str) -> bool:
-    """Return whether a media-attached turn has explicit shopping intent."""
-
-    normalized = " ".join((query or "").strip().lower().split())
-    if not normalized or normalized == MEDIA_ONLY_QUERY.lower():
-        return False
-
-    if any(pattern in normalized for pattern in _EXPLICIT_MEDIA_CATALOG_PATTERNS):
-        return True
-
-    if _DESCRIPTIVE_MEDIA_QUERY_RE.search(normalized):
-        return False
-
-    return False
-
-
 def _extract_final_text(result: Any) -> str:
     if isinstance(result, dict):
         messages = result.get("messages")
@@ -600,6 +536,14 @@ def _content_to_text(content: Any) -> str:
                 parts.append(item["text"])
         return "\n".join(parts).strip()
     return ""
+
+
+def _tool_strictness(value: str) -> str:
+    return value if value in {"unspecified", "hard", "soft"} else "unspecified"
+
+
+def _tool_search_mode(value: str | None) -> str | None:
+    return value if value in {"text", "image", "hybrid"} else None
 
 
 def _format_product(product: Any) -> str:

--- a/chain_server/src/main.py
+++ b/chain_server/src/main.py
@@ -216,6 +216,7 @@ async def health_check():
 async def capabilities():
     """Return runtime capabilities that the UI should enforce."""
     media_config = config.media_input
+    catalog = assistant_runtime.catalog_capabilities()
     return {
         "media_input": {
             "enabled": media_config.enabled,
@@ -228,7 +229,8 @@ async def capabilities():
             "max_video_bytes": media_config.max_video_bytes,
             "max_video_duration_seconds": media_config.max_video_duration_seconds,
             "vlm_enabled": config.vlm_enabled,
-        }
+        },
+        "catalog": catalog.model_dump(),
     }
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -356,6 +356,60 @@ are only soft preferences for request-building and ranking.
 }
 ```
 
+### Catalog Retriever POST `/query/text`
+
+Executes a structured text catalog search on the catalog service port, usually
+`http://localhost:8010/query/text`.
+
+**Request Body:**
+```json
+{
+  "text": ["practical work bag"],
+  "categories": ["bag"],
+  "filters": {"max_price": 60},
+  "k": 4,
+  "candidate_k": 20
+}
+```
+
+`candidate_k` is optional. When omitted, the catalog retriever searches a wider
+candidate window than `k`, applies hard filters over that wider window, and then
+trims the final response to `k`.
+
+**Response:**
+```json
+{
+  "texts": ["Work Bag | structured tote | accessories,bag\nPRICE: 59.0"],
+  "ids": ["123"],
+  "similarities": [0.91],
+  "names": ["Work Bag"],
+  "images": ["/images/work_bag.jpg"],
+  "products": [
+    {
+      "product_id": "123",
+      "display_name": "Work Bag",
+      "description": "structured tote",
+      "category": "bag",
+      "price": {"amount": 59.0, "currency": "USD"},
+      "image_url": "/images/work_bag.jpg",
+      "attributes": {"similarity": 0.91}
+    }
+  ],
+  "diagnostics": {
+    "requested_top_k": 4,
+    "candidate_k": 20,
+    "after_filter_count": 1,
+    "returned_count": 1
+  },
+  "no_result_reason": null
+}
+```
+
+### Catalog Retriever POST `/query/image`
+
+Accepts the same fields as `/query/text`, plus `image_base64`. Explicit category
+and price filters are hard filters for image and hybrid retrieval too.
+
 ### GET `/health`
 
 Health check endpoint to verify service status.

--- a/docs/API.md
+++ b/docs/API.md
@@ -43,6 +43,12 @@ The catalog retriever owns its filter and metadata capability contract. Chain
 server request-building code should consume this contract instead of inferring
 filterability from product text or hard-coded category lists.
 
+Filter fields are configured in `shared/configs/catalog_retriever/config.yaml`
+under `filter_registry`. Enum values are never configured statically; they are
+discovered from the configured CSV `source_fields` after the catalog data is
+loaded. See [Catalog Filter Configuration](CATALOG_FILTERS.md) for the operator
+workflow.
+
 ```typescript
 interface CatalogCapabilities {
   catalog_id: string;
@@ -57,18 +63,16 @@ interface CatalogCapabilities {
     max_value?: number;
     request_aliases?: Record<string, string>;
   }>;
-  soft_facets: Record<string, {
-    type: 'enum' | 'number' | 'text';
-    source_fields: string[];
-    values?: string[];
-  }>;
 }
 ```
 
 The default fashion catalog declares `category` as an enum filter sourced from
 the product `subcategory` column, `price` as a numeric filter with `min_price`
-and `max_price` request aliases, and style-oriented metadata such as color,
-material, style, occasion, and formality as soft facets.
+and `max_price` request aliases. Catalogs that can strictly filter by color,
+material, size, or other metadata should declare those fields under
+`filter_registry` too. Do not add static enum values to chain-server config,
+UI code, or prompts. Example enum values in documentation are illustrative
+only; runtime values come from `/capabilities`.
 
 ### QueryRequest
 
@@ -137,7 +141,8 @@ cart state cannot bleed across sessions.
 `image` remains supported for backward compatibility and is normalized into the
 same internal media list as `media[]`. New clients should use `media[]` for
 video uploads. The bundled UI calls `/capabilities` on load and enforces the
-configured media counts, MIME types, byte limits, and video duration limit.
+configured media counts, MIME types, byte limits, and video duration limit. That
+same endpoint also exposes catalog filter metadata for future UI controls.
 
 ### Multi-modal Input
 
@@ -295,7 +300,16 @@ curl -X POST "http://localhost:8000/query/timing" \
 
 ### GET `/capabilities`
 
-Returns runtime media settings that clients should enforce before upload.
+Returns runtime media settings that clients should enforce before upload and
+catalog-owned search capability metadata that clients can use to render filter
+controls. Catalog filter values come from the catalog retriever after
+the configured catalog data is loaded; they are not maintained in chain-server
+category config.
+
+The concrete enum values shown below are illustrative response data. Do not
+copy those values into chain-server, UI, or prompt configuration as static
+catalog truth.
+
 The byte limits are raw client file sizes. Browser clients send attachments as
 base64 JSON data URLs, so reverse proxies must allow roughly 4/3 of the largest
 raw media limit plus JSON overhead. The default nginx configuration uses
@@ -315,6 +329,33 @@ raw media limit plus JSON overhead. The default nginx configuration uses
     "max_video_bytes": 52428800,
     "max_video_duration_seconds": 120,
     "vlm_enabled": true
+  },
+  "catalog": {
+    "catalog_id": "fashion_products_extended",
+    "retrieval_modes": ["text", "image", "hybrid"],
+    "image_search_enabled": true,
+    "filters": {
+      "category": {
+        "type": "enum",
+        "operators": ["in"],
+        "source_fields": ["subcategory"],
+        "values": ["bag", "dress", "shoes"]
+      },
+      "price": {
+        "type": "number",
+        "operators": ["gte", "lte"],
+        "source_fields": ["price"],
+        "min_value": 39.9,
+        "max_value": 269.99,
+        "request_aliases": {"min": "min_price", "max": "max_price"}
+      },
+      "color": {
+        "type": "enum",
+        "operators": ["in"],
+        "source_fields": ["color"],
+        "values": ["black", "green"]
+      }
+    }
   }
 }
 ```
@@ -323,12 +364,18 @@ raw media limit plus JSON overhead. The default nginx configuration uses
 
 Catalog retriever exposes a separate capability endpoint on the catalog service
 port, usually `http://localhost:8010/capabilities`. This endpoint describes
-which catalog metadata fields are valid hard filters and which metadata concepts
-are only soft preferences for request-building and ranking.
+which catalog metadata fields are valid hard filters.
+
+For enum filters, `values` is generated from the loaded CSV rows. For numeric
+filters, `min_value` and `max_value` are generated from the loaded CSV rows.
+`filter_registry` specifies field names and types only.
 
 **Response:** `CatalogCapabilities`
 
 **Example Response:**
+The concrete enum values shown below are illustrative response data. The
+catalog retriever derives them from the loaded CSV rows.
+
 ```json
 {
   "catalog_id": "fashion_products_extended",
@@ -348,10 +395,13 @@ are only soft preferences for request-building and ranking.
       "min_value": 39.9,
       "max_value": 269.99,
       "request_aliases": {"min": "min_price", "max": "max_price"}
+    },
+    "color": {
+      "type": "enum",
+      "operators": ["in"],
+      "source_fields": ["color"],
+      "values": ["black", "green"]
     }
-  },
-  "soft_facets": {
-    "style": {"type": "text", "source_fields": []}
   }
 }
 ```
@@ -366,7 +416,7 @@ Executes a structured text catalog search on the catalog service port, usually
 {
   "text": ["practical work bag"],
   "categories": ["bag"],
-  "filters": {"max_price": 60},
+  "filters": {"price": {"max": 60}},
   "k": 4,
   "candidate_k": 20
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,6 +37,39 @@ Currently, the API does not require authentication for local deployments. For pr
 
 ## 📊 Data Models
 
+### Catalog Capabilities
+
+The catalog retriever owns its filter and metadata capability contract. Chain
+server request-building code should consume this contract instead of inferring
+filterability from product text or hard-coded category lists.
+
+```typescript
+interface CatalogCapabilities {
+  catalog_id: string;
+  retrieval_modes: Array<'text' | 'image' | 'hybrid'>;
+  image_search_enabled: boolean;
+  filters: Record<string, {
+    type: 'enum' | 'number' | 'text';
+    operators: string[];
+    source_fields: string[];
+    values?: string[];
+    min_value?: number;
+    max_value?: number;
+    request_aliases?: Record<string, string>;
+  }>;
+  soft_facets: Record<string, {
+    type: 'enum' | 'number' | 'text';
+    source_fields: string[];
+    values?: string[];
+  }>;
+}
+```
+
+The default fashion catalog declares `category` as an enum filter sourced from
+the product `subcategory` column, `price` as a numeric filter with `min_price`
+and `max_price` request aliases, and style-oriented metadata such as color,
+material, style, occasion, and formality as soft facets.
+
 ### QueryRequest
 
 The main request model for all shopping queries.
@@ -282,6 +315,43 @@ raw media limit plus JSON overhead. The default nginx configuration uses
     "max_video_bytes": 52428800,
     "max_video_duration_seconds": 120,
     "vlm_enabled": true
+  }
+}
+```
+
+### Catalog Retriever GET `/capabilities`
+
+Catalog retriever exposes a separate capability endpoint on the catalog service
+port, usually `http://localhost:8010/capabilities`. This endpoint describes
+which catalog metadata fields are valid hard filters and which metadata concepts
+are only soft preferences for request-building and ranking.
+
+**Response:** `CatalogCapabilities`
+
+**Example Response:**
+```json
+{
+  "catalog_id": "fashion_products_extended",
+  "retrieval_modes": ["text", "image", "hybrid"],
+  "image_search_enabled": true,
+  "filters": {
+    "category": {
+      "type": "enum",
+      "operators": ["in"],
+      "source_fields": ["subcategory"],
+      "values": ["bag", "dress", "shoes"]
+    },
+    "price": {
+      "type": "number",
+      "operators": ["gte", "lte"],
+      "source_fields": ["price"],
+      "min_value": 39.9,
+      "max_value": 269.99,
+      "request_aliases": {"min": "min_price", "max": "max_price"}
+    }
+  },
+  "soft_facets": {
+    "style": {"type": "text", "source_fields": []}
   }
 }
 ```

--- a/docs/CATALOG_FILTERS.md
+++ b/docs/CATALOG_FILTERS.md
@@ -189,7 +189,7 @@ plan can contain:
 
 ```json
 {
-  "query": "dresses",
+  "semantic_query": "dresses",
   "filters": {
     "category": ["dress"],
     "color": ["blue"],
@@ -199,6 +199,10 @@ plan can contain:
   "strictness": "hard"
 }
 ```
+
+`semantic_query` is product meaning only. Hard constraints such as budget,
+strict enum filters, and strictness words belong in `filters`/`strictness`, not
+in the semantic search text.
 
 If `color` is not declared as a filter, it is not sent as a hard filter. The
 catalog tool must not pretend it can enforce a field the catalog did not

--- a/docs/CATALOG_FILTERS.md
+++ b/docs/CATALOG_FILTERS.md
@@ -1,0 +1,249 @@
+# Catalog Filters
+
+This guide explains how catalog filter metadata works when you replace or
+extend the product catalog.
+
+## Core Rule
+
+Do not hardcode enum values in chain-server, UI, prompts, or docs.
+
+The only place you declare catalog filters is:
+
+```text
+shared/configs/catalog_retriever/config.yaml
+```
+
+That config declares **which CSV fields are valid hard filters**. It does not
+declare enum values such as `dress`, `bag`, `blue`, or `cotton`.
+
+Enum values and numeric ranges are discovered by the catalog retriever after it
+loads the configured CSV. The discovered filter contract is exposed through:
+
+```text
+http://localhost:8010/capabilities
+http://localhost:8009/capabilities
+```
+
+## What `filter_registry` Means
+
+`filter_registry` is catalog policy. Each entry answers:
+
+- What is the public filter name?
+- What type of filter is it?
+- Which CSV column or columns provide its values?
+- Which operators are supported?
+
+Example:
+
+```yaml
+filter_registry:
+  category:
+    type: "enum"
+    source_fields:
+      - "subcategory"
+    operators:
+      - "in"
+  price:
+    type: "number"
+    source_fields:
+      - "price"
+    operators:
+      - "gte"
+      - "lte"
+```
+
+This means:
+
+- `category` is an enforceable enum filter.
+- Its values are read from the CSV `subcategory` column.
+- `price` is an enforceable numeric filter.
+- Its range is read from the CSV `price` column.
+
+It does **not** mean the enum values are known ahead of time.
+
+## What You Need To Know Before Deployment
+
+You do not need to know enum values before deployment.
+
+You do need to decide which CSV columns are allowed to become hard filters. That
+is a catalog policy decision, not an enum-value decision.
+
+For example, before deployment you might know:
+
+```text
+This catalog has columns named color, material, size, and price.
+Users may strictly filter on those fields.
+```
+
+That is enough to write `filter_registry`. You do not need to know whether the
+loaded values are `blue`, `navy`, `teal`, `cotton`, `linen`, or any other
+specific value.
+
+If the incoming catalog schema is also unknown, inspect the CSV header before
+deployment and decide which fields should be filterable. Do not guess from user
+language and do not promote every column automatically. Some columns are product
+text, IDs, image paths, long descriptions, or internal metadata and should not
+be hard filters.
+
+## Example: New Catalog With Different Fields
+
+Suppose a new catalog CSV contains:
+
+```csv
+category,subcategory,name,description,image,price,color,material,size
+apparel,dress,Blue Silk Dress,Formal silk dress,/images/blue_dress.jpg,120,blue,silk,M
+apparel,dress,Green Cotton Dress,Casual cotton dress,/images/green_dress.jpg,80,green,cotton,L
+accessories,bag,Black Leather Tote,Work tote,/images/black_tote.jpg,180,black,leather,one size
+```
+
+If users should be able to say "only blue", "only silk", or "size M" and have
+the catalog strictly enforce that, declare those fields as filters:
+
+```yaml
+filter_registry:
+  category:
+    type: "enum"
+    source_fields:
+      - "subcategory"
+    operators:
+      - "in"
+  color:
+    type: "enum"
+    source_fields:
+      - "color"
+    operators:
+      - "in"
+  material:
+    type: "enum"
+    source_fields:
+      - "material"
+    operators:
+      - "in"
+  size:
+    type: "enum"
+    source_fields:
+      - "size"
+    operators:
+      - "in"
+  price:
+    type: "number"
+    source_fields:
+      - "price"
+    operators:
+      - "gte"
+      - "lte"
+```
+
+After restart/reindex, `/capabilities` will contain values discovered from the
+CSV, for example:
+
+```json
+{
+  "filters": {
+    "category": {
+      "type": "enum",
+      "source_fields": ["subcategory"],
+      "values": ["bag", "dress"]
+    },
+    "color": {
+      "type": "enum",
+      "source_fields": ["color"],
+      "values": ["black", "blue", "green"]
+    },
+    "material": {
+      "type": "enum",
+      "source_fields": ["material"],
+      "values": ["cotton", "leather", "silk"]
+    },
+    "size": {
+      "type": "enum",
+      "source_fields": ["size"],
+      "values": ["L", "M", "one size"]
+    },
+    "price": {
+      "type": "number",
+      "source_fields": ["price"],
+      "min_value": 80,
+      "max_value": 180
+    }
+  }
+}
+```
+
+The values above come from the ingested CSV. They are not copied into config.
+
+## How User Requests Use Filters
+
+The language layer builds a structured search request from user intent. The
+request builder then validates every requested filter against catalog
+capabilities.
+
+Example user request:
+
+```text
+Only show me blue silk dresses under 100.
+```
+
+If `category`, `color`, `material`, and `price` are declared filters, the search
+plan can contain:
+
+```json
+{
+  "query": "dresses",
+  "filters": {
+    "category": ["dress"],
+    "color": ["blue"],
+    "material": ["silk"],
+    "price": {"max": 100}
+  },
+  "strictness": "hard"
+}
+```
+
+If `color` is not declared as a filter, it is not sent as a hard filter. The
+catalog tool must not pretend it can enforce a field the catalog did not
+declare.
+
+## Current CSV Loader Expectations
+
+The current catalog loader expects the bundled product rows to include these
+core columns for indexing and display:
+
+| Column | Purpose |
+| --- | --- |
+| `name` | Product display name and retrieval text |
+| `description` | Product description and retrieval text |
+| `category` | Broad catalog grouping |
+| `subcategory` | Default public `category` filter source |
+| `image` | Product image path or URL |
+| `price` | Numeric price metadata when price filtering is enabled |
+
+Additional columns such as `color`, `material`, `size`, `brand`, or
+`department` may be used as filters when declared in `filter_registry`.
+
+## Refresh Checklist
+
+1. Put the new CSV under `shared/data/`.
+2. Set `data_source` in `shared/configs/catalog_retriever/config.yaml`.
+3. Declare only filter field names, types, source fields, and operators in
+   `filter_registry`.
+4. Do not write enum values in config.
+5. Clear/rebuild catalog embeddings if the product data changed.
+6. Restart catalog retriever and chain-server.
+7. Check `http://localhost:8010/capabilities`.
+8. Check `http://localhost:8009/capabilities`.
+
+## Troubleshooting
+
+If a filter is missing from `/capabilities`, check that it is declared in
+`filter_registry`.
+
+If an enum filter appears but its `values` list is empty, check that the
+configured `source_fields` exactly match CSV column names and that the CSV rows
+contain non-empty values.
+
+If a user asks for a strict filter and results are not filtered, check that the
+field is declared in `filter_registry` and appears under `/capabilities.filters`.
+
+If a new catalog uses different core columns for product text or images, update
+the catalog loader before deploying that catalog shape.

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -53,6 +53,9 @@ SDK adapter:
   request-builder layer validates structured agent intent against catalog-owned
   capabilities and produces a `CatalogSearchPlan`; the catalog execution layer
   only maps that plan to catalog service requests.
+- Structured agent intent separates semantic product search text from hard
+  filters. Budget and enum constraints are validated as filters instead of
+  being embedded into the semantic query sent to retrieval.
 - Deep Agents prompt context is also built from catalog-owned capabilities.
   Chain-server no longer ships a product category allowlist for the active
   runtime; changing catalog shape is handled by catalog retriever
@@ -107,9 +110,10 @@ deduplicate mutations yet.
 
 `SearchCatalogInput` intentionally has no `user_id`, cart, memory, session, or
 conversation-history fields. The agent layer can use conversation context to
-decide what query or query terms, optional image, categories, and filters to
-send, but `search_catalog` itself should remain a pure read against the catalog
-for the supplied request.
+decide what semantic product text, optional image, categories, and filters to
+send, but hard constraints such as budget and enum filters should stay out of
+the semantic text. `search_catalog` itself remains a pure read against the
+catalog for the supplied request.
 
 The chain-server request-builder layer consumes `CatalogCapabilities` before it
 creates a product search request. For the current fashion catalog, `category`

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -51,6 +51,10 @@ SDK adapter:
   capabilities, separates hard filters from soft preferences, and produces a
   `CatalogSearchPlan`; the catalog execution layer only maps that plan to
   catalog service requests.
+- Catalog retriever now searches a wider candidate window, applies hard filters
+  against structured metadata, then trims to the requested `top_k`. Query
+  responses include structured `products`, diagnostics, and an optional
+  `no_result_reason` in addition to the legacy parallel arrays.
 - Catalog search timeout is configurable through
   `catalog_search_timeout_seconds`. The default is `null`, preserving the
   previous no-timeout catalog POST behavior for slower remote embedding calls.

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -51,9 +51,12 @@ SDK adapter:
   conversation-history fields are passed to `search_catalog`.
 - Catalog request-building is now separate from catalog execution. The
   request-builder layer validates structured agent intent against catalog-owned
-  capabilities, separates hard filters from soft preferences, and produces a
-  `CatalogSearchPlan`; the catalog execution layer only maps that plan to
-  catalog service requests.
+  capabilities and produces a `CatalogSearchPlan`; the catalog execution layer
+  only maps that plan to catalog service requests.
+- Deep Agents prompt context is also built from catalog-owned capabilities.
+  Chain-server no longer ships a product category allowlist for the active
+  runtime; changing catalog shape is handled by catalog retriever
+  `filter_registry` plus the ingested catalog data.
 - Catalog retriever now searches a wider candidate window, applies hard filters
   against structured metadata, then trims to the requested `top_k`. Query
   responses include structured `products`, diagnostics, and an optional
@@ -79,7 +82,7 @@ No ACP/UCP adapter layer has been added yet.
 | `Cart` | User cart with structured lines and optional subtotal. |
 | `CommerceError` | Structured tool error with code, message, retryability, and details. |
 | `ToolMeta` | Trace and idempotency metadata returned by tools. |
-| `CatalogCapabilities` | Catalog-owned declaration of retrieval modes, hard filters, and soft facets. |
+| `CatalogCapabilities` | Catalog-owned declaration of retrieval modes and hard filters. |
 
 ## Tool Contracts
 
@@ -110,10 +113,23 @@ for the supplied request.
 
 The chain-server request-builder layer consumes `CatalogCapabilities` before it
 creates a product search request. For the current fashion catalog, `category`
-is treated as a hard filter sourced from the catalog `subcategory` field, while
-soft concepts such as color, material, style, occasion, and formality remain
-preferences for language understanding or ranking unless the catalog declares
-them as real filters.
+is treated as a hard filter sourced from the catalog `subcategory` field. If a
+future catalog can strictly filter by color, material, size, or another
+metadata field, that field should be declared under catalog retriever
+`filter_registry` and it will be treated as a hard filter too.
+
+`filter_registry` declares filter names, types, source fields, and operators. It
+does not declare enum values. Enum filter values and numeric min/max ranges are
+filled from the CSV rows when catalog retriever loads the configured
+`data_source`. The operational guide is
+[Catalog Filter Configuration](CATALOG_FILTERS.md).
+
+The active Deep Agents runtime formats the same `CatalogCapabilities` into the
+agent system prompt. This keeps the language layer aware of available hard
+filters without maintaining a second category list in
+`shared/configs/chain_server/config.yaml`. If a future catalog declares
+different filter names or enum values, the prompt, request builder, and catalog
+retriever all consume that catalog-owned shape.
 
 This keeps product search reusable by the Deep Agents adapter, future skills or
 subagents, and later protocol adapters without coupling catalog results to

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -39,6 +39,9 @@ SDK adapter:
   returned by catalog search for add operations, and `CART_LINE_ID` values
   returned by cart reads for remove operations. They do not perform hidden
   product-name lookup or fuzzy cart-line matching.
+- Deep Agents product details lookup uses explicit `PRODUCT_REF` values from a
+  prior catalog search in the same conversation. It deepens known products; it
+  is not a second broad search path.
 - Catalog search and cart-read wrapper tools return results to the agent loop
   so explicit cart-mutation requests can search/read and then mutate in one
   turn. Mutation tools still return the authoritative cart result directly.
@@ -85,7 +88,7 @@ The first tool contract set is:
 | Contract | Type | Purpose |
 | --- | --- | --- |
 | `SearchCatalogInput` / `SearchCatalogResult` | Read-only | Find products by query, category, filters, and `top_k`. |
-| `GetProductDetailsInput` / `GetProductDetailsResult` | Read-only | Reserved for fetching one product by durable `product_id` once the catalog exposes one. |
+| `GetProductDetailsInput` / `GetProductDetailsResult` | Read-only | Fetch facts for one known product ref; currently backed by the per-conversation search-result cache until the catalog exposes a durable detail endpoint. |
 | `GetCartInput` / `GetCartResult` | Read-only | Read the authoritative cart for a user. |
 | `GetStorePolicyInput` / `GetStorePolicyResult` | Read-only | Fetch controlled store-policy text by topic. |
 | `AddCartItemInput` / `CartMutationResult` | Mutating | Add a product or variant to the cart from an explicit product ref. |

--- a/docs/COMMERCE_CONTRACTS.md
+++ b/docs/COMMERCE_CONTRACTS.md
@@ -46,6 +46,11 @@ SDK adapter:
   reference and tests, but they are not the chain-server entrypoint.
 - Catalog search remains stateless: no user, cart, memory, session, or
   conversation-history fields are passed to `search_catalog`.
+- Catalog request-building is now separate from catalog execution. The
+  request-builder layer validates structured agent intent against catalog-owned
+  capabilities, separates hard filters from soft preferences, and produces a
+  `CatalogSearchPlan`; the catalog execution layer only maps that plan to
+  catalog service requests.
 - Catalog search timeout is configurable through
   `catalog_search_timeout_seconds`. The default is `null`, preserving the
   previous no-timeout catalog POST behavior for slower remote embedding calls.
@@ -67,6 +72,7 @@ No ACP/UCP adapter layer has been added yet.
 | `Cart` | User cart with structured lines and optional subtotal. |
 | `CommerceError` | Structured tool error with code, message, retryability, and details. |
 | `ToolMeta` | Trace and idempotency metadata returned by tools. |
+| `CatalogCapabilities` | Catalog-owned declaration of retrieval modes, hard filters, and soft facets. |
 
 ## Tool Contracts
 
@@ -94,6 +100,13 @@ conversation-history fields. The agent layer can use conversation context to
 decide what query or query terms, optional image, categories, and filters to
 send, but `search_catalog` itself should remain a pure read against the catalog
 for the supplied request.
+
+The chain-server request-builder layer consumes `CatalogCapabilities` before it
+creates a product search request. For the current fashion catalog, `category`
+is treated as a hard filter sourced from the catalog `subcategory` field, while
+soft concepts such as color, material, style, occasion, and formality remain
+preferences for language understanding or ranking unless the catalog declares
+them as real filters.
 
 This keeps product search reusable by the Deep Agents adapter, future skills or
 subagents, and later protocol adapters without coupling catalog results to

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -351,45 +351,62 @@ chatter_prompt: |
   You are a helpful shopping assistant specializing in...
 ```
 
-### Updating Categories
+### Updating Catalog Filter Metadata
 
-The system uses a static list of product categories for classification and retrieval. These categories are defined in the configuration file and should be updated when new product types are added to the system.
+The active runtime gets available product filters from the catalog retriever
+after the catalog data is loaded. Do not maintain product categories in
+`shared/configs/chain_server/config.yaml`.
 
-#### Current Categories
+The authoritative guide for this workflow is
+[Catalog Filter Configuration](CATALOG_FILTERS.md). The short version is:
+`filter_registry` declares filter field names, types, source fields, and
+operators; enum values are discovered from the ingested CSV and exposed through
+`/capabilities`.
 
-The following categories are currently supported:
-- **Bags**: Handbags, purses, clutches
-- **Sunglasses**: Eyewear and sun protection
-- **Dresses**: Various dress styles and lengths
-- **Skirts**: Different skirt types and lengths
-- **Top/Blouse/Sweater**: Upper body garments
-- **Shoes**: Footwear including heels, flats, and sandals
-- **Earrings**: Jewelry worn on the lobe or edge of the ear
-- **Bracelets**: Jewelry worn on the wrist or arm
-- **Necklaces**: Jawelry wrong around the neck
+#### How to Update Filters
 
-#### How to Update Categories
+1. **Update Product Data**: Add the relevant columns and values to the catalog
+   CSV configured by `shared/configs/catalog_retriever/config.yaml`.
+2. **Declare Hard Filters**: Add real filterable fields under
+   `filter_registry` in `shared/configs/catalog_retriever/config.yaml`. Enum
+   values are discovered from the configured `source_fields`; numeric filters
+   get their min/max range from the catalog rows. Do not hardcode enum values
+   in chain-server config, UI code, or prompts.
+3. **Restart/Reindex**: Restart the catalog retriever so it loads the new data
+   and exposes updated `/capabilities`.
+4. **Verify Capabilities**: Check `http://localhost:8010/capabilities` or the
+   chain-server aggregate `http://localhost:8009/capabilities`.
 
-1. **Edit Configuration Files**: Update the categories list in `shared/configs/chain_server/config.yaml`
-2. **Restart Services**: After updating categories, restart the chain server and catalog retriever services
-3. **Update Product Data**: Ensure new products in your catalog are tagged with the appropriate categories
-4. **Test Classification**: Verify that the LLM can properly classify queries into the new categories
-
-#### Configuration File Location
+#### Example Catalog Retriever Configuration
 
 ```yaml
-# shared/configs/chain_server/config.yaml
-categories: [
-    "bag",
-    "sunglasses", 
-    "dress",
-    "skirt",
-    "top blouse sweater",
-    "shoes",
-    "earrings",
-    "bracelet",
-    "necklace"
-]
+# shared/configs/catalog_retriever/config.yaml
+filter_registry:
+  category:
+    type: "enum"
+    source_fields:
+      - "subcategory"
+    operators:
+      - "in"
+  price:
+    type: "number"
+    source_fields:
+      - "price"
+    operators:
+      - "gte"
+      - "lte"
+  color:
+    type: "enum"
+    source_fields:
+      - "color"
+    operators:
+      - "in"
+  material:
+    type: "enum"
+    source_fields:
+      - "material"
+    operators:
+      - "in"
 ```
 
 ### Model Routing

--- a/docs/EMBEDDING_MANAGEMENT.md
+++ b/docs/EMBEDDING_MANAGEMENT.md
@@ -86,16 +86,26 @@ The application comes with sample product data (`products_extended.csv`), but yo
 
 ### CSV File Format
 
-Your custom CSV file should include the following columns:
+Your custom CSV file should include product text fields and any metadata fields
+you want the catalog retriever to expose as hard filters. The default
+fashion catalog uses the columns below, but future catalogs can use different
+filter columns when `shared/configs/catalog_retriever/config.yaml` declares
+them in `filter_registry`.
+
+Do not copy enum values such as colors, materials, sizes, or categories into
+configuration. Declare the CSV field names in `filter_registry`; the catalog
+retriever discovers the actual values after it loads the CSV. See
+[Catalog Filter Configuration](CATALOG_FILTERS.md) for the detailed workflow.
 
 | Column | Description | Required | Example |
 |--------|-------------|----------|---------|
-| `item_name` | Product name | Yes | "Classic Black Patent Leather Purse" |
-| `item_description` | Product description | Yes | "Elegant black patent leather purse..." |
-| `category` | Product category | Yes | "bag" |
+| `name` | Product name | Yes | "Classic Black Patent Leather Purse" |
+| `description` | Product description | Yes | "Elegant black patent leather purse..." |
+| `category` / `subcategory` | Default catalog category metadata | No | "bag" |
 | `brand` | Product brand | No | "Fashion Brand" |
 | `price` | Product price | No | "89.99" |
-| `image_url` | Product image URL or filename | No | "purse_image.jpg" |
+| custom metadata | Fields declared as filters | No | "green", "cotton" |
+| `image` | Product image URL or filename | No | "purse_image.jpg" |
 
 ### Step-by-Step Guide
 
@@ -104,9 +114,9 @@ Your custom CSV file should include the following columns:
 1. **Create your CSV file** with your product data:
    ```bash
    # Example: my_products.csv
-   item_name,item_description,category,brand,price,image_url
-   "Custom Product 1","Description of product 1","shoes","Brand A","99.99","product1.jpg"
-   "Custom Product 2","Description of product 2","bag","Brand B","149.99","product2.jpg"
+   name,description,category,subcategory,color,brand,price,image
+   "Custom Product 1","Description of product 1","fashion","shoes","black","Brand A","99.99","product1.jpg"
+   "Custom Product 2","Description of product 2","fashion","bag","green","Brand B","149.99","product2.jpg"
    ```
 
 2. **Add the CSV file** to the shared data directory:
@@ -162,7 +172,7 @@ If your products have images:
 
 2. **Update image URLs** in your CSV to reference the filenames:
    ```csv
-   item_name,item_description,category,image_url
+   name,description,subcategory,image
    "Product 1","Description","shoes","product1.jpg"
    ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 
 ### 🔧 Technical Documentation
 - **[API Documentation](API.md)** - Complete API reference
+- **[Catalog Filter Configuration](CATALOG_FILTERS.md)** - Declaring catalog filter fields without static enum values
 - **[Commerce Contracts](COMMERCE_CONTRACTS.md)** - Internal product, cart, and commerce tool contracts
 - **[Deep Agents Migration Plan](DEEP_AGENTS_MIGRATION_PLAN.md)** - SDK migration, session isolation, tools, skills, and scaling notes
 - **[Deep Agents Cart Tool Goal](DEEP_AGENTS_CART_TOOL_GOAL.md)** - Minimal cart-tool smoke gate and constraints
@@ -37,6 +38,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 | Document | Description | Audience |
 |----------|-------------|----------|
 | [API Documentation](API.md) | Complete API reference with examples | Developers, integrators |
+| [Catalog Filter Configuration](CATALOG_FILTERS.md) | Configure hard filters for uploaded catalogs without hardcoded enum values | Developers, operators |
 | [Commerce Contracts](COMMERCE_CONTRACTS.md) | Internal product, cart, and commerce tool contracts | Developers, architects |
 | [Deep Agents Migration Plan](DEEP_AGENTS_MIGRATION_PLAN.md) | SDK migration, session isolation, tools, skills, and scaling notes | Developers, architects |
 | [Deep Agents Cart Tool Goal](DEEP_AGENTS_CART_TOOL_GOAL.md) | Minimal cart-tool smoke gate and constraints | Developers, evaluators |
@@ -81,6 +83,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 #### Product Search
 - [User Guide - Product Search](USER_GUIDE.md#product-search)
 - [API - Product Search Examples](API.md#product-search)
+- [Catalog Filter Configuration](CATALOG_FILTERS.md)
 - [Main README - Usage Examples](../README.md#usage-examples)
 
 #### Shopping Cart

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -38,14 +38,23 @@ The application should be ready to use immediately. If you encounter any issues:
 - **💬 Conversational AI**: Natural language interactions
 - **📱 Responsive Design**: Works on desktop and mobile devices
 
-### Available Product Categories
+### Available Product Filters
 
-- **Bags**: Purses, handbags, totes, clutches
-- **Sunglasses**: Fashion eyewear and accessories
-- **Dresses**: Formal and casual dresses
-- **Skirts**: Various styles and lengths
-- **Tops**: Blouses, sweaters, and shirts
-- **Shoes**: Sandals, heels, flats, and boots
+Catalog filters and allowed values are determined by the loaded catalog and
+the catalog retriever `filter_registry`. They are not fixed in the UI or
+chain server.
+
+To see the current filter fields and values:
+
+```bash
+curl -s http://localhost:8010/capabilities
+curl -s http://localhost:8009/capabilities
+```
+
+The bundled sample catalog currently exposes category and price filters. A
+different catalog can expose different filter fields such as color, material,
+brand, size, department, or any other metadata columns declared in
+`shared/configs/catalog_retriever/config.yaml`.
 
 ## 💬 Using the Chat Interface
 
@@ -401,7 +410,9 @@ AI: "Here are some black shoes that match your image..."
 ### General Questions
 
 **Q: What products can I search for?**
-A: The application includes clothing and accessories: dresses, skirts, tops, shoes, bags, and sunglasses.
+A: Searchable products come from the currently loaded catalog. Check
+`http://localhost:8010/capabilities` for the active hard-filter fields and
+allowed enum values.
 
 **Q: How accurate are the search results?**
 A: The AI uses advanced language models to understand your queries and find relevant products. Results improve with more specific descriptions.

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -116,12 +116,15 @@ class SearchCatalogInput(CommerceModel):
     categories: list[str] = Field(default_factory=list)
     filters: dict[str, Any] = Field(default_factory=dict)
     top_k: int = Field(default=4, ge=1, le=50)
+    candidate_k: int | None = Field(default=None, ge=1, le=200)
 
 
 class SearchCatalogResult(CommerceModel):
     ok: bool
     products: list[ProductSummary] = Field(default_factory=list)
     error: CommerceError | None = None
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+    no_result_reason: str | None = None
     meta: ToolMeta = Field(default_factory=ToolMeta)
 
 

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -138,18 +138,11 @@ class CatalogFilterCapability(CommerceModel):
     request_aliases: dict[str, str] = Field(default_factory=dict)
 
 
-class CatalogFacetCapability(CommerceModel):
-    type: CatalogFilterType
-    source_fields: list[str] = Field(default_factory=list)
-    values: list[str] = Field(default_factory=list)
-
-
 class CatalogCapabilities(CommerceModel):
     catalog_id: str = "default"
     retrieval_modes: list[str] = Field(default_factory=list)
     image_search_enabled: bool = False
     filters: dict[str, CatalogFilterCapability] = Field(default_factory=dict)
-    soft_facets: dict[str, CatalogFacetCapability] = Field(default_factory=dict)
 
 
 class GetProductDetailsInput(CommerceModel):

--- a/shared/commerce_contracts.py
+++ b/shared/commerce_contracts.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 Availability = Literal["in_stock", "out_of_stock", "preorder", "backorder", "unknown"]
+CatalogFilterType = Literal["enum", "number", "text"]
 
 
 class CommerceModel(BaseModel):
@@ -122,6 +123,30 @@ class SearchCatalogResult(CommerceModel):
     products: list[ProductSummary] = Field(default_factory=list)
     error: CommerceError | None = None
     meta: ToolMeta = Field(default_factory=ToolMeta)
+
+
+class CatalogFilterCapability(CommerceModel):
+    type: CatalogFilterType
+    operators: list[str] = Field(default_factory=list)
+    source_fields: list[str] = Field(default_factory=list)
+    values: list[str] = Field(default_factory=list)
+    min_value: float | None = None
+    max_value: float | None = None
+    request_aliases: dict[str, str] = Field(default_factory=dict)
+
+
+class CatalogFacetCapability(CommerceModel):
+    type: CatalogFilterType
+    source_fields: list[str] = Field(default_factory=list)
+    values: list[str] = Field(default_factory=list)
+
+
+class CatalogCapabilities(CommerceModel):
+    catalog_id: str = "default"
+    retrieval_modes: list[str] = Field(default_factory=list)
+    image_search_enabled: bool = False
+    filters: dict[str, CatalogFilterCapability] = Field(default_factory=dict)
+    soft_facets: dict[str, CatalogFacetCapability] = Field(default_factory=dict)
 
 
 class GetProductDetailsInput(CommerceModel):

--- a/shared/configs/catalog_retriever/config.yaml
+++ b/shared/configs/catalog_retriever/config.yaml
@@ -6,6 +6,9 @@ text_collection: "shopping_advisor_text_db"
 image_collection: "shopping_advisor_image_db"
 #data_source: "/app/shared/data/products.csv"
 data_source: "/app/shared/data/products_extended.csv"
+# Declare filter field names and types here. Do not hardcode enum values:
+# enum values and numeric ranges are discovered from the loaded CSV and exposed
+# by /capabilities.
 filter_registry:
   category:
     type: "enum"
@@ -23,14 +26,3 @@ filter_registry:
     request_aliases:
       min: "min_price"
       max: "max_price"
-soft_facets:
-  color:
-    type: "text"
-  material:
-    type: "text"
-  style:
-    type: "text"
-  occasion:
-    type: "text"
-  formality:
-    type: "text"

--- a/shared/configs/catalog_retriever/config.yaml
+++ b/shared/configs/catalog_retriever/config.yaml
@@ -1,7 +1,36 @@
 db_port: "http://milvus:19530" 
 db_name: "shopping_advisor_db"
+catalog_id: "fashion_products_extended"
 sim_threshold: 0.3
 text_collection: "shopping_advisor_text_db"
 image_collection: "shopping_advisor_image_db"
 #data_source: "/app/shared/data/products.csv"
 data_source: "/app/shared/data/products_extended.csv"
+filter_registry:
+  category:
+    type: "enum"
+    source_fields:
+      - "subcategory"
+    operators:
+      - "in"
+  price:
+    type: "number"
+    source_fields:
+      - "price"
+    operators:
+      - "gte"
+      - "lte"
+    request_aliases:
+      min: "min_price"
+      max: "max_price"
+soft_facets:
+  color:
+    type: "text"
+  material:
+    type: "text"
+  style:
+    type: "text"
+  occasion:
+    type: "text"
+  formality:
+    type: "text"

--- a/shared/configs/chain_server/config.yaml
+++ b/shared/configs/chain_server/config.yaml
@@ -84,17 +84,6 @@ chatter_prompt: |
   - Always format product names as **Product Name** in bold.
   - Keep responses concise and focused on the user's actual request.
   - Respond directly with the final answer; no preamble or meta-commentary.
-categories: [
-    "bag",
-    "sunglasses",
-    "dress",
-    "skirt",
-    "top blouse sweater",
-    "shoes",
-    "earrings",
-    "bracelet",
-    "necklace"
-]
 agent_choices: [
             "cart", 
             "retriever",

--- a/shared/configs/rails/prompts.yml
+++ b/shared/configs/rails/prompts.yml
@@ -91,7 +91,7 @@ prompts:
 
   - task: topic_safety_check_input $model=topic_control
     content: |
-      You are a retail shopping assistant for a store that sells apparel and accessories, including dresses, tops, skirts, shoes, bags, sunglasses, and jewelry (earrings, bracelets, necklaces). Your primary function is to help customers browse, compare, and purchase these products. Customers may ask about specific products, compare products, ask about product attributes, request updates to their shopping cart, ask for recommendations, or ask follow-up questions about items they have discussed earlier in the conversation. Please allow for conversational context to better assist them.
+      You are a retail shopping assistant for a store whose sellable products come from the loaded catalog. Your primary function is to help customers browse, compare, and purchase catalog products. Customers may ask about specific products, compare products, ask about product attributes, request updates to their shopping cart, ask for recommendations, or ask follow-up questions about items they have discussed earlier in the conversation. Please allow for conversational context to better assist them.
 
       Available Specialists and their functions are as follows. Visualizer (visualizer): Use for customer requests related to trying on products or visualizing items in a scene. Cart Manager (cart_node): Use for any queries about purchasing, adding items to the cart, or removing items from the cart. Product Finder (search): Use for all searches regarding product availability, specific product information, or finding new items. General Assistant (chatter): Use for general conversation, small talk, and any queries that do not fall into the above categories.
 

--- a/tests/unit/catalog_retriever/test_capabilities.py
+++ b/tests/unit/catalog_retriever/test_capabilities.py
@@ -31,10 +31,11 @@ def test_capabilities_are_declared_and_filled_from_registry_fields(tmp_path) -> 
                 "operators": ["gte", "lte"],
                 "request_aliases": {"min": "min_price", "max": "max_price"},
             },
-        },
-        "soft_facets": {
-            "color": {"type": "enum", "source_fields": ["color"]},
-            "style": {"type": "text"},
+            "color": {
+                "type": "enum",
+                "source_fields": ["color"],
+                "operators": ["in"],
+            },
         },
     }
 
@@ -49,7 +50,7 @@ def test_capabilities_are_declared_and_filled_from_registry_fields(tmp_path) -> 
         "min": "min_price",
         "max": "max_price",
     }
-    assert capabilities.soft_facets["color"].values == ["black", "blue", "red"]
+    assert capabilities.filters["color"].values == ["black", "blue", "red"]
     assert "name" not in capabilities.filters
 
 

--- a/tests/unit/catalog_retriever/test_capabilities.py
+++ b/tests/unit/catalog_retriever/test_capabilities.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from catalog_retriever.src.capabilities import build_catalog_capabilities
+
+
+def test_capabilities_are_declared_and_filled_from_registry_fields(tmp_path) -> None:
+    csv_path = tmp_path / "products.csv"
+    csv_path.write_text(
+        "category,subcategory,name,price,color\n"
+        "apparel,dress,Blue Dress,49.99,blue\n"
+        "accessories,bag,Work Bag,89.50,black\n"
+        "ignored,ignored,No Price,,red\n",
+        encoding="utf-8",
+    )
+    config = {
+        "catalog_id": "test_catalog",
+        "data_source": str(csv_path),
+        "image_enabled": True,
+        "filter_registry": {
+            "category": {
+                "type": "enum",
+                "source_fields": ["subcategory"],
+                "operators": ["in"],
+            },
+            "price": {
+                "type": "number",
+                "source_fields": ["price"],
+                "operators": ["gte", "lte"],
+                "request_aliases": {"min": "min_price", "max": "max_price"},
+            },
+        },
+        "soft_facets": {
+            "color": {"type": "enum", "source_fields": ["color"]},
+            "style": {"type": "text"},
+        },
+    }
+
+    capabilities = build_catalog_capabilities(config)
+
+    assert capabilities.catalog_id == "test_catalog"
+    assert capabilities.retrieval_modes == ["text", "image", "hybrid"]
+    assert capabilities.filters["category"].values == ["bag", "dress", "ignored"]
+    assert capabilities.filters["price"].min_value == 49.99
+    assert capabilities.filters["price"].max_value == 89.5
+    assert capabilities.filters["price"].request_aliases == {
+        "min": "min_price",
+        "max": "max_price",
+    }
+    assert capabilities.soft_facets["color"].values == ["black", "blue", "red"]
+    assert "name" not in capabilities.filters
+
+
+def test_missing_catalog_data_still_returns_declared_capabilities() -> None:
+    capabilities = build_catalog_capabilities(
+        {
+            "catalog_id": "empty",
+            "data_source": "/missing/products.csv",
+            "image_enabled": False,
+            "filter_registry": {
+                "category": {
+                    "type": "enum",
+                    "source_fields": ["subcategory"],
+                    "operators": ["in"],
+                }
+            },
+        }
+    )
+
+    assert capabilities.catalog_id == "empty"
+    assert capabilities.retrieval_modes == ["text"]
+    assert capabilities.image_search_enabled is False
+    assert capabilities.filters["category"].values == []

--- a/tests/unit/catalog_retriever/test_retriever.py
+++ b/tests/unit/catalog_retriever/test_retriever.py
@@ -26,6 +26,7 @@ from catalog_retriever.src.retriever import (
     RetrieverConfig,
     TextEmbeddings,
 )
+from shared.commerce_contracts import CatalogFilterCapability
 
 
 # --------------------------------------------------------------------------->
@@ -45,6 +46,20 @@ def retriever_config() -> RetrieverConfig:
         sim_threshold=0.1,
         text_collection="text_col",
         image_collection="image_col",
+        filter_capabilities={
+            "category": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["subcategory"],
+                values=["bag", "dress"],
+            ),
+            "price": CatalogFilterCapability(
+                type="number",
+                operators=["gte", "lte"],
+                source_fields=["price"],
+                request_aliases={"min": "min_price", "max": "max_price"},
+            ),
+        },
     )
 
 
@@ -75,6 +90,7 @@ def _doc(
     price: Any = 49.99,
     category: str = "dress",
     subcategory: str | None = None,
+    color: str | None = None,
 ) -> SimpleNamespace:
     """Build a minimal object that quacks like a LangChain ``Document``.
 
@@ -93,6 +109,7 @@ def _doc(
             "image": f"{name.lower().replace(' ', '_')}.jpg",
             "category": category,
             "subcategory": sub,
+            "color": color,
         },
     )
 
@@ -293,10 +310,31 @@ class TestApplyStructuredFilters:
         )
         assert [r[0].metadata["name"] for r in filtered] == ["A"]
 
-    def test_no_price_filters_returns_input(self, retriever: Retriever) -> None:
-        # ``min_price`` / ``max_price`` both missing → just passthrough.
+    def test_unknown_filter_returns_input(self, retriever: Retriever) -> None:
         results = [(_doc("A", 10), 0.9)]
         assert retriever._apply_structured_filters(results, filters={"color": "red"}) == results
+
+    def test_enum_filter_uses_declared_metadata_field(
+        self, retriever: Retriever
+    ) -> None:
+        retriever.filter_capabilities["color"] = CatalogFilterCapability(
+            type="enum",
+            operators=["in"],
+            source_fields=["color"],
+            values=["blue", "green"],
+        )
+        results = [
+            (_doc("Blue Dress", color="blue"), 0.9),
+            (_doc("Green Dress", color="green"), 0.8),
+            (_doc("No Color"), 0.7),
+        ]
+
+        filtered = retriever._apply_structured_filters(
+            results,
+            filters={"color": ["blue"]},
+        )
+
+        assert [r[0].metadata["name"] for r in filtered] == ["Blue Dress"]
 
 
 # --------------------------------------------------------------------------->

--- a/tests/unit/catalog_retriever/test_retriever.py
+++ b/tests/unit/catalog_retriever/test_retriever.py
@@ -91,6 +91,8 @@ def _doc(
             "name": name,
             "price": price,
             "image": f"{name.lower().replace(' ', '_')}.jpg",
+            "category": category,
+            "subcategory": sub,
         },
     )
 
@@ -747,7 +749,7 @@ class TestRetrieve:
         assert len(ids) == 1
         assert images == ["silk_dress.jpg"]
 
-    async def test_text_only_no_categories_returns_empty(
+    async def test_text_only_without_categories_searches_all_categories(
         self, retriever: Retriever
     ) -> None:
         retriever.text_db.similarity_search_with_relevance_scores = MagicMock(
@@ -762,7 +764,8 @@ class TestRetrieve:
             verbose=False,
         )
 
-        assert (texts, ids, sims, names, images) == ([], [], [], [], [])
+        assert names == ["Silk Dress"]
+        assert texts and ids and sims and images
 
     async def test_similarity_threshold_drops_low_scores(
         self, retriever: Retriever
@@ -806,7 +809,7 @@ class TestRetrieve:
 
         assert names == ["Mid"]
 
-    async def test_image_search_skips_category_filter(
+    async def test_image_search_applies_explicit_category_filter(
         self, retriever: Retriever
     ) -> None:
         retriever.text_db.similarity_search_with_relevance_scores = MagicMock(
@@ -825,9 +828,32 @@ class TestRetrieve:
             verbose=False,
         )
 
-        # Image search returns results ordered by similarity without category gating.
-        assert "Image Match" in names
-        assert sims[0] == pytest.approx(0.95)
+        assert names == ["Text Match"]
+        assert sims[0] == pytest.approx(0.6)
+
+    async def test_filters_apply_before_trimming_to_top_k(
+        self, retriever: Retriever
+    ) -> None:
+        retriever.text_db.similarity_search_with_relevance_scores = MagicMock(
+            return_value=[
+                (_doc("Over Budget", price=200, category="bag"), 0.95),
+                (_doc("Under Budget", price=50, category="bag"), 0.9),
+            ]
+        )
+
+        output = await retriever.retrieve(
+            query=["work bag"],
+            categories=["bag"],
+            filters={"max_price": 60},
+            k=1,
+            image_bool=False,
+            verbose=False,
+        )
+
+        assert output.names == ["Under Budget"]
+        assert output.diagnostics["candidate_k"] == 5
+        assert output.diagnostics["after_filter_count"] == 1
+        assert output.products[0]["display_name"] == "Under Budget"
 
     async def test_blank_query_replaced_with_dummy(
         self, retriever: Retriever

--- a/tests/unit/chain_server/test_catalog_capabilities.py
+++ b/tests/unit/chain_server/test_catalog_capabilities.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import requests
+
+from chain_server.src.catalog_capabilities import CatalogCapabilitiesClient
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code: int = 200) -> None:
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+
+class FakeSession:
+    def __init__(self, response=None, exc: Exception | None = None) -> None:
+        self.response = response
+        self.exc = exc
+        self.calls = []
+
+    def get(self, url, timeout):
+        self.calls.append({"url": url, "timeout": timeout})
+        if self.exc:
+            raise self.exc
+        return self.response
+
+
+def test_fetches_catalog_capabilities() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "catalog_id": "fashion",
+                "retrieval_modes": ["text", "image"],
+                "image_search_enabled": True,
+                "filters": {
+                    "category": {
+                        "type": "enum",
+                        "operators": ["in"],
+                        "source_fields": ["subcategory"],
+                        "values": ["bag"],
+                    }
+                },
+                "soft_facets": {},
+            }
+        )
+    )
+    client = CatalogCapabilitiesClient(
+        "http://catalog-retriever:8010/",
+        timeout_seconds=3,
+        session=session,
+    )
+
+    capabilities = client.get()
+
+    assert capabilities.catalog_id == "fashion"
+    assert capabilities.filters["category"].values == ["bag"]
+    assert session.calls == [
+        {"url": "http://catalog-retriever:8010/capabilities", "timeout": 3}
+    ]
+
+
+def test_caches_capabilities_until_forced_refresh() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "catalog_id": "fashion",
+                "retrieval_modes": ["text"],
+                "image_search_enabled": False,
+                "filters": {},
+                "soft_facets": {},
+            }
+        )
+    )
+    client = CatalogCapabilitiesClient("http://catalog", session=session)
+
+    assert client.get() is client.get()
+    assert len(session.calls) == 1
+
+    client.get(force_refresh=True)
+
+    assert len(session.calls) == 2
+
+
+def test_unavailable_capabilities_return_empty_contract() -> None:
+    client = CatalogCapabilitiesClient(
+        "http://catalog",
+        session=FakeSession(exc=requests.Timeout("down")),
+    )
+
+    capabilities = client.get()
+
+    assert capabilities.catalog_id == "unavailable"
+    assert capabilities.filters == {}

--- a/tests/unit/chain_server/test_catalog_capabilities.py
+++ b/tests/unit/chain_server/test_catalog_capabilities.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 
 import requests
 
-from chain_server.src.catalog_capabilities import CatalogCapabilitiesClient
+from chain_server.src.catalog_capabilities import (
+    CatalogCapabilitiesClient,
+    format_catalog_capabilities_for_prompt,
+)
+from shared.commerce_contracts import (
+    CatalogCapabilities,
+    CatalogFilterCapability,
+)
 
 
 class FakeResponse:
@@ -49,7 +56,6 @@ def test_fetches_catalog_capabilities() -> None:
                         "values": ["bag"],
                     }
                 },
-                "soft_facets": {},
             }
         )
     )
@@ -76,7 +82,6 @@ def test_caches_capabilities_until_forced_refresh() -> None:
                 "retrieval_modes": ["text"],
                 "image_search_enabled": False,
                 "filters": {},
-                "soft_facets": {},
             }
         )
     )
@@ -100,3 +105,49 @@ def test_unavailable_capabilities_return_empty_contract() -> None:
 
     assert capabilities.catalog_id == "unavailable"
     assert capabilities.filters == {}
+
+
+def test_unavailable_capabilities_are_not_cached() -> None:
+    session = FakeSession(exc=requests.Timeout("down"))
+    client = CatalogCapabilitiesClient("http://catalog", session=session)
+
+    assert client.get().catalog_id == "unavailable"
+    assert client.get().catalog_id == "unavailable"
+
+    assert len(session.calls) == 2
+
+
+def test_formats_catalog_owned_filters_for_prompt() -> None:
+    capabilities = CatalogCapabilities(
+        catalog_id="custom_catalog",
+        retrieval_modes=["text", "hybrid"],
+        image_search_enabled=True,
+        filters={
+            "category": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["department"],
+                values=["dress", "watch"],
+            ),
+            "price": CatalogFilterCapability(
+                type="number",
+                operators=["gte", "lte"],
+                source_fields=["price"],
+                min_value=10.0,
+                max_value=250.0,
+            ),
+            "color": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["color"],
+                values=["black", "green"],
+            ),
+        },
+    )
+
+    prompt_text = format_catalog_capabilities_for_prompt(capabilities)
+
+    assert "Catalog ID: custom_catalog" in prompt_text
+    assert "- category: enum; operators in; values dress, watch" in prompt_text
+    assert "- price: number; operators gte, lte; range 10.0 to 250.0" in prompt_text
+    assert "- color: enum; operators in; values black, green" in prompt_text

--- a/tests/unit/chain_server/test_catalog_execution.py
+++ b/tests/unit/chain_server/test_catalog_execution.py
@@ -24,7 +24,7 @@ def test_execute_catalog_search_maps_structured_filters_to_legacy_payload() -> N
         CatalogSearchPlan(
             should_search=True,
             queries=["work bag"],
-            hard_filters={"category": ["bag"], "max_price": 60},
+            hard_filters={"category": ["bag"], "price": {"max": 60}},
             search_mode="text",
             top_k=4,
         ),
@@ -38,7 +38,7 @@ def test_execute_catalog_search_maps_structured_filters_to_legacy_payload() -> N
     assert captured["timeout"] == 5
     assert captured["request"].queries == ["work bag"]
     assert captured["request"].categories == ["bag"]
-    assert captured["request"].filters == {"max_price": 60}
+    assert captured["request"].filters == {"price": {"max": 60}}
     assert captured["request"].image_base64 == ""
 
 

--- a/tests/unit/chain_server/test_catalog_execution.py
+++ b/tests/unit/chain_server/test_catalog_execution.py
@@ -23,7 +23,7 @@ def test_execute_catalog_search_maps_structured_filters_to_legacy_payload() -> N
     execution = execute_catalog_search(
         CatalogSearchPlan(
             should_search=True,
-            queries=["work bag"],
+            semantic_queries=["work bag"],
             hard_filters={"category": ["bag"], "price": {"max": 60}},
             search_mode="text",
             top_k=4,
@@ -57,7 +57,7 @@ def test_hybrid_search_retries_text_without_image_when_image_has_no_products() -
     execution = execute_catalog_search(
         CatalogSearchPlan(
             should_search=True,
-            queries=["work bag"],
+            semantic_queries=["work bag"],
             hard_filters={"category": ["bag"]},
             search_mode="hybrid",
             top_k=4,

--- a/tests/unit/chain_server/test_catalog_execution.py
+++ b/tests/unit/chain_server/test_catalog_execution.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from chain_server.src.catalog_execution import execute_catalog_search
+from chain_server.src.catalog_request import CatalogSearchPlan
+from shared.commerce_contracts import ProductSummary, SearchCatalogResult
+
+
+def test_execute_catalog_search_maps_structured_filters_to_legacy_payload() -> None:
+    captured = {}
+
+    def fake_search(request, catalog_retriever_url, timeout_seconds=None):
+        captured["request"] = request
+        captured["url"] = catalog_retriever_url
+        captured["timeout"] = timeout_seconds
+        return SearchCatalogResult(
+            ok=True,
+            products=[ProductSummary(product_id="prod_1", display_name="Work Bag")],
+        )
+
+    execution = execute_catalog_search(
+        CatalogSearchPlan(
+            should_search=True,
+            queries=["work bag"],
+            hard_filters={"category": ["bag"], "max_price": 60},
+            search_mode="text",
+            top_k=4,
+        ),
+        "http://catalog",
+        timeout_seconds=5,
+        search_fn=fake_search,
+    )
+
+    assert execution.result.products[0].display_name == "Work Bag"
+    assert captured["url"] == "http://catalog"
+    assert captured["timeout"] == 5
+    assert captured["request"].queries == ["work bag"]
+    assert captured["request"].categories == ["bag"]
+    assert captured["request"].filters == {"max_price": 60}
+    assert captured["request"].image_base64 == ""
+
+
+def test_hybrid_search_retries_text_without_image_when_image_has_no_products() -> None:
+    requests = []
+
+    def fake_search(request, catalog_retriever_url, timeout_seconds=None):
+        requests.append(request)
+        if request.image_base64:
+            return SearchCatalogResult(ok=True, products=[])
+        return SearchCatalogResult(
+            ok=True,
+            products=[ProductSummary(product_id="prod_2", display_name="Text Bag")],
+        )
+
+    execution = execute_catalog_search(
+        CatalogSearchPlan(
+            should_search=True,
+            queries=["work bag"],
+            hard_filters={"category": ["bag"]},
+            search_mode="hybrid",
+            top_k=4,
+        ),
+        "http://catalog",
+        image_base64="data:image/jpeg;base64,abc",
+        search_fn=fake_search,
+    )
+
+    assert execution.fallback_used is True
+    assert len(requests) == 2
+    assert requests[0].image_base64 == "data:image/jpeg;base64,abc"
+    assert requests[1].image_base64 == ""
+
+
+def test_no_search_plan_does_not_call_catalog() -> None:
+    def fail_search(*args, **kwargs):
+        raise AssertionError("catalog should not be called")
+
+    execution = execute_catalog_search(
+        CatalogSearchPlan(
+            should_search=False,
+            no_search_reason="missing_query_or_image",
+        ),
+        "http://catalog",
+        search_fn=fail_search,
+    )
+
+    assert execution.result.ok is True
+    assert execution.result.products == []

--- a/tests/unit/chain_server/test_catalog_request.py
+++ b/tests/unit/chain_server/test_catalog_request.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from chain_server.src.catalog_request import (
+    CatalogSearchIntent,
+    build_catalog_search_plan,
+)
+from shared.commerce_contracts import (
+    CatalogCapabilities,
+    CatalogFacetCapability,
+    CatalogFilterCapability,
+)
+
+
+def _capabilities() -> CatalogCapabilities:
+    return CatalogCapabilities(
+        catalog_id="fashion",
+        retrieval_modes=["text", "image", "hybrid"],
+        image_search_enabled=True,
+        filters={
+            "category": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["subcategory"],
+                values=["bag", "dress", "shoes"],
+            ),
+            "price": CatalogFilterCapability(
+                type="number",
+                operators=["gte", "lte"],
+                source_fields=["price"],
+                min_value=39.9,
+                max_value=269.99,
+            ),
+        },
+        soft_facets={
+            "style": CatalogFacetCapability(type="text"),
+            "occasion": CatalogFacetCapability(type="text"),
+        },
+    )
+
+
+def test_builds_hard_filters_from_structured_intent() -> None:
+    plan = build_catalog_search_plan(
+        CatalogSearchIntent(
+            query="work bag",
+            categories=["bag"],
+            max_price=60,
+            soft_preferences={"style": "practical", "unknown": "ignored"},
+            strictness="hard",
+        ),
+        _capabilities(),
+    )
+
+    assert plan.should_search is True
+    assert plan.queries == ["work bag"]
+    assert plan.hard_filters == {"category": ["bag"], "max_price": 60}
+    assert plan.soft_preferences == {"style": "practical"}
+    assert plan.strictness == "hard"
+    assert plan.search_mode == "text"
+
+
+def test_drops_unsupported_categories_and_invalid_price_range() -> None:
+    plan = build_catalog_search_plan(
+        CatalogSearchIntent(
+            query="watch",
+            categories=["watch"],
+            min_price=200,
+            max_price=50,
+        ),
+        _capabilities(),
+    )
+
+    assert plan.hard_filters == {}
+
+
+def test_defaults_to_hybrid_when_image_is_available() -> None:
+    plan = build_catalog_search_plan(
+        CatalogSearchIntent(query="similar shoes", categories=["shoes"]),
+        _capabilities(),
+        has_image=True,
+    )
+
+    assert plan.search_mode == "hybrid"
+    assert plan.hard_filters == {"category": ["shoes"]}
+
+
+def test_no_query_and_no_image_returns_no_search_plan() -> None:
+    plan = build_catalog_search_plan(
+        CatalogSearchIntent(soft_preferences={"style": "practical"}),
+        _capabilities(),
+    )
+
+    assert plan.should_search is False
+    assert plan.no_search_reason == "missing_query_or_image"
+    assert plan.soft_preferences == {"style": "practical"}
+
+
+def test_uses_explicit_queries_over_single_query() -> None:
+    plan = build_catalog_search_plan(
+        CatalogSearchIntent(query="ignored", queries=["bag", "work tote"]),
+        _capabilities(),
+    )
+
+    assert plan.queries == ["bag", "work tote"]

--- a/tests/unit/chain_server/test_catalog_request.py
+++ b/tests/unit/chain_server/test_catalog_request.py
@@ -9,7 +9,6 @@ from chain_server.src.catalog_request import (
 )
 from shared.commerce_contracts import (
     CatalogCapabilities,
-    CatalogFacetCapability,
     CatalogFilterCapability,
 )
 
@@ -33,10 +32,12 @@ def _capabilities() -> CatalogCapabilities:
                 min_value=39.9,
                 max_value=269.99,
             ),
-        },
-        soft_facets={
-            "style": CatalogFacetCapability(type="text"),
-            "occasion": CatalogFacetCapability(type="text"),
+            "color": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["color"],
+                values=["black", "blue"],
+            ),
         },
     )
 
@@ -45,9 +46,12 @@ def test_builds_hard_filters_from_structured_intent() -> None:
     plan = build_catalog_search_plan(
         CatalogSearchIntent(
             query="work bag",
-            categories=["bag"],
-            max_price=60,
-            soft_preferences={"style": "practical", "unknown": "ignored"},
+            filters={
+                "category": ["bag"],
+                "price": {"max": 60},
+                "color": ["blue"],
+                "unknown": "ignored",
+            },
             strictness="hard",
         ),
         _capabilities(),
@@ -55,19 +59,24 @@ def test_builds_hard_filters_from_structured_intent() -> None:
 
     assert plan.should_search is True
     assert plan.queries == ["work bag"]
-    assert plan.hard_filters == {"category": ["bag"], "max_price": 60}
-    assert plan.soft_preferences == {"style": "practical"}
+    assert plan.hard_filters == {
+        "category": ["bag"],
+        "price": {"max": 60.0},
+        "color": ["blue"],
+    }
     assert plan.strictness == "hard"
     assert plan.search_mode == "text"
 
 
-def test_drops_unsupported_categories_and_invalid_price_range() -> None:
+def test_drops_unsupported_filters_and_invalid_number_range() -> None:
     plan = build_catalog_search_plan(
         CatalogSearchIntent(
             query="watch",
-            categories=["watch"],
-            min_price=200,
-            max_price=50,
+            filters={
+                "category": ["watch"],
+                "color": ["purple"],
+                "price": {"min": 200, "max": 50},
+            },
         ),
         _capabilities(),
     )
@@ -77,7 +86,7 @@ def test_drops_unsupported_categories_and_invalid_price_range() -> None:
 
 def test_defaults_to_hybrid_when_image_is_available() -> None:
     plan = build_catalog_search_plan(
-        CatalogSearchIntent(query="similar shoes", categories=["shoes"]),
+        CatalogSearchIntent(query="similar shoes", filters={"category": ["shoes"]}),
         _capabilities(),
         has_image=True,
     )
@@ -88,13 +97,13 @@ def test_defaults_to_hybrid_when_image_is_available() -> None:
 
 def test_no_query_and_no_image_returns_no_search_plan() -> None:
     plan = build_catalog_search_plan(
-        CatalogSearchIntent(soft_preferences={"style": "practical"}),
+        CatalogSearchIntent(filters={"category": ["bag"]}),
         _capabilities(),
     )
 
     assert plan.should_search is False
     assert plan.no_search_reason == "missing_query_or_image"
-    assert plan.soft_preferences == {"style": "practical"}
+    assert plan.hard_filters == {"category": ["bag"]}
 
 
 def test_uses_explicit_queries_over_single_query() -> None:

--- a/tests/unit/chain_server/test_catalog_request.py
+++ b/tests/unit/chain_server/test_catalog_request.py
@@ -45,7 +45,7 @@ def _capabilities() -> CatalogCapabilities:
 def test_builds_hard_filters_from_structured_intent() -> None:
     plan = build_catalog_search_plan(
         CatalogSearchIntent(
-            query="work bag",
+            semantic_query="work bag",
             filters={
                 "category": ["bag"],
                 "price": {"max": 60},
@@ -58,7 +58,7 @@ def test_builds_hard_filters_from_structured_intent() -> None:
     )
 
     assert plan.should_search is True
-    assert plan.queries == ["work bag"]
+    assert plan.semantic_queries == ["work bag"]
     assert plan.hard_filters == {
         "category": ["bag"],
         "price": {"max": 60.0},
@@ -71,7 +71,7 @@ def test_builds_hard_filters_from_structured_intent() -> None:
 def test_drops_unsupported_filters_and_invalid_number_range() -> None:
     plan = build_catalog_search_plan(
         CatalogSearchIntent(
-            query="watch",
+            semantic_query="watch",
             filters={
                 "category": ["watch"],
                 "color": ["purple"],
@@ -86,7 +86,10 @@ def test_drops_unsupported_filters_and_invalid_number_range() -> None:
 
 def test_defaults_to_hybrid_when_image_is_available() -> None:
     plan = build_catalog_search_plan(
-        CatalogSearchIntent(query="similar shoes", filters={"category": ["shoes"]}),
+        CatalogSearchIntent(
+            semantic_query="similar shoes",
+            filters={"category": ["shoes"]},
+        ),
         _capabilities(),
         has_image=True,
     )
@@ -108,8 +111,31 @@ def test_no_query_and_no_image_returns_no_search_plan() -> None:
 
 def test_uses_explicit_queries_over_single_query() -> None:
     plan = build_catalog_search_plan(
-        CatalogSearchIntent(query="ignored", queries=["bag", "work tote"]),
+        CatalogSearchIntent(
+            semantic_query="ignored",
+            semantic_queries=["bag", "work tote"],
+        ),
         _capabilities(),
     )
 
-    assert plan.queries == ["bag", "work tote"]
+    assert plan.semantic_queries == ["bag", "work tote"]
+
+
+def test_semantic_query_keeps_hard_filters_out_of_search_text() -> None:
+    plan = build_catalog_search_plan(
+        CatalogSearchIntent(
+            semantic_query="floral dresses",
+            filters={
+                "category": ["dress"],
+                "price": {"max": 100},
+            },
+            strictness="hard",
+        ),
+        _capabilities(),
+    )
+
+    assert plan.semantic_queries == ["floral dresses"]
+    assert plan.hard_filters == {
+        "category": ["dress"],
+        "price": {"max": 100.0},
+    }

--- a/tests/unit/chain_server/test_commerce_tools.py
+++ b/tests/unit/chain_server/test_commerce_tools.py
@@ -97,6 +97,39 @@ def test_search_catalog_posts_stateless_text_payload() -> None:
     assert result.products[0].category == "bag"
 
 
+def test_search_catalog_prefers_structured_products_when_returned() -> None:
+    session = FakeSession(
+        FakeResponse(
+            {
+                "products": [
+                    {
+                        "product_id": "prod_1",
+                        "display_name": "Work Bag",
+                        "description": "structured tote",
+                        "category": "bag",
+                        "price": {"amount": 59.0, "currency": "USD"},
+                        "image_url": "/images/work_bag.jpg",
+                        "attributes": {"similarity": 0.91},
+                    }
+                ],
+                "diagnostics": {"returned_count": 1},
+                "no_result_reason": None,
+            }
+        )
+    )
+
+    result = search_catalog(
+        SearchCatalogInput(query="work bag"),
+        "http://catalog-retriever:8010",
+        session=session,
+    )
+
+    assert result.ok is True
+    assert result.products[0].display_name == "Work Bag"
+    assert result.products[0].price.amount == 59.0
+    assert result.diagnostics == {"returned_count": 1}
+
+
 def test_search_catalog_uses_configured_timeout_when_provided() -> None:
     session = FakeSession(
         FakeResponse(

--- a/tests/unit/chain_server/test_config.py
+++ b/tests/unit/chain_server/test_config.py
@@ -87,7 +87,6 @@ class TestChainServerConfigValidation:
             "rails_port",
             "routing_prompt",
             "chatter_prompt",
-            "categories",
             "agent_choices",
             "memory_length",
             "top_k_retrieve",
@@ -159,12 +158,22 @@ class TestChainServerConfigValidation:
                 **{**valid_config_dict, "catalog_search_timeout_seconds": value}
             )
 
-    @pytest.mark.parametrize("field", ["categories", "agent_choices"])
+    @pytest.mark.parametrize("field", ["agent_choices"])
     def test_empty_list_fields_are_rejected(
         self, valid_config_dict: dict, field: str
     ) -> None:
         with pytest.raises(ValidationError):
             ChainServerConfig(**{**valid_config_dict, field: []})
+
+    def test_categories_are_optional_legacy_config(
+        self, valid_config_dict: dict
+    ) -> None:
+        config_data = dict(valid_config_dict)
+        del config_data["categories"]
+
+        config = ChainServerConfig(**config_data)
+
+        assert config.categories == []
 
     def test_extra_fields_are_forbidden(self, valid_config_dict: dict) -> None:
         with pytest.raises(ValidationError):

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -417,8 +417,9 @@ class TestDeepAgentsRuntimeRefs:
             def __init__(self, *args, **kwargs) -> None:
                 pass
 
-        def fake_tool(*, return_direct: bool = False):
+        def fake_tool(*, args_schema=None, return_direct: bool = False):
             def decorate(fn):
+                fn.args_schema = args_schema
                 fn.return_direct = return_direct
                 return fn
 
@@ -502,8 +503,9 @@ class TestDeepAgentsRuntimeRefs:
             def __init__(self, *args, **kwargs) -> None:
                 pass
 
-        def fake_tool(*, return_direct: bool = False):
+        def fake_tool(*, args_schema=None, return_direct: bool = False):
             def decorate(fn):
+                fn.args_schema = args_schema
                 fn.return_direct = return_direct
                 return fn
 
@@ -591,7 +593,7 @@ class TestDeepAgentsRuntimeRefs:
         tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
 
         result = tools_by_name["search_catalog_tool"](
-            "practical work bag",
+            semantic_query="practical work bag",
             filters={
                 "category": ["bag"],
                 "price": {"max": 60},
@@ -602,6 +604,7 @@ class TestDeepAgentsRuntimeRefs:
 
         assert "PRODUCT_REF: prod_1" in result
         assert state.retrieved == {"Work Bag": "bag.jpg"}
+        assert captured_plan["plan"].semantic_queries == ["practical work bag"]
         assert captured_plan["plan"].hard_filters == {
             "category": ["bag"],
             "price": {"max": 60.0},
@@ -663,8 +666,9 @@ class TestDeepAgentsRuntimeRefs:
             def __init__(self, *args, **kwargs) -> None:
                 pass
 
-        def fake_tool(*, return_direct: bool = False):
+        def fake_tool(*, args_schema=None, return_direct: bool = False):
             def decorate(fn):
+                fn.args_schema = args_schema
                 fn.return_direct = return_direct
                 return fn
 

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -20,7 +20,15 @@ from fastapi.testclient import TestClient
 
 from chain_server.src.agenttypes import Cart, State
 from shared.commerce_contracts import Cart as CommerceCart
-from shared.commerce_contracts import CartLine, Money, ProductSummary
+from shared.commerce_contracts import (
+    CartLine,
+    CatalogCapabilities,
+    CatalogFacetCapability,
+    CatalogFilterCapability,
+    Money,
+    ProductSummary,
+    SearchCatalogResult,
+)
 
 
 class _StubRuntime:
@@ -373,41 +381,6 @@ class TestDeepAgentsRuntimeScopes:
 
 
 class TestDeepAgentsRuntimeRefs:
-    def test_media_catalog_search_intent_gate(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
-
-        assert (
-            runtime_mod._media_query_allows_catalog_search("What's in this look")
-            is False
-        )
-        assert (
-            runtime_mod._media_query_allows_catalog_search("describe this outfit")
-            is False
-        )
-        assert runtime_mod._media_query_allows_catalog_search(
-            "The user submitted visual media without additional text."
-        ) is False
-        assert (
-            runtime_mod._media_query_allows_catalog_search(
-                "what is this similar to stylistically"
-            )
-            is False
-        )
-        assert (
-            runtime_mod._media_query_allows_catalog_search("find shoes like this")
-            is True
-        )
-        assert (
-            runtime_mod._media_query_allows_catalog_search(
-                "do you have this under $100"
-            )
-            is True
-        )
-        assert (
-            runtime_mod._media_query_allows_catalog_search("add this to my cart")
-            is True
-        )
-
     def test_search_and_cart_read_tools_are_chainable(
         self,
         base_config,
@@ -469,7 +442,7 @@ class TestDeepAgentsRuntimeRefs:
         assert tools_by_name["remove_cart_item_tool"].return_direct is True
         assert tools_by_name["view_cart_total_tool"].return_direct is True
 
-    def test_media_analysis_query_skips_catalog_tool(
+    def test_search_catalog_tool_executes_structured_plan(
         self,
         base_config,
         monkeypatch: pytest.MonkeyPatch,
@@ -500,8 +473,45 @@ class TestDeepAgentsRuntimeRefs:
             captured.update(kwargs)
             return SimpleNamespace()
 
-        def fail_search_catalog(*args, **kwargs):
-            raise AssertionError("descriptive media queries must not search catalog")
+        capabilities = CatalogCapabilities(
+            catalog_id="fashion",
+            retrieval_modes=["text", "image", "hybrid"],
+            image_search_enabled=True,
+            filters={
+                "category": CatalogFilterCapability(
+                    type="enum",
+                    operators=["in"],
+                    source_fields=["subcategory"],
+                    values=["bag", "dress"],
+                ),
+                "price": CatalogFilterCapability(
+                    type="number",
+                    operators=["gte", "lte"],
+                    source_fields=["price"],
+                ),
+            },
+            soft_facets={
+                "style": CatalogFacetCapability(type="text"),
+            },
+        )
+        captured_plan = {}
+
+        def fake_execute_catalog_search(plan, *args, **kwargs):
+            captured_plan["plan"] = plan
+            return SimpleNamespace(
+                result=SearchCatalogResult(
+                    ok=True,
+                    products=[
+                        ProductSummary(
+                            product_id="prod_1",
+                            display_name="Work Bag",
+                            image_url="bag.jpg",
+                            price=Money(amount=59.0),
+                        )
+                    ],
+                ),
+                fallback_used=False,
+            )
 
         deepagents_mod.GeneralPurposeSubagentProfile = FakeProfile
         deepagents_mod.HarnessProfile = FakeProfile
@@ -513,9 +523,14 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch.setitem(sys.modules, "deepagents", deepagents_mod)
         monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
         monkeypatch.setitem(sys.modules, "langchain_openai", openai_mod)
-        monkeypatch.setattr(runtime_mod, "search_catalog", fail_search_catalog)
+        monkeypatch.setattr(
+            runtime_mod,
+            "execute_catalog_search",
+            fake_execute_catalog_search,
+        )
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        runtime._catalog_capabilities = SimpleNamespace(get=lambda: capabilities)
         identity = runtime_mod.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
@@ -526,24 +541,28 @@ class TestDeepAgentsRuntimeRefs:
         )
         state = State(
             user_id=111,
-            query="What's in this look",
-            media=[
-                {
-                    "type": "image",
-                    "mime_type": "image/jpeg",
-                    "data": "data:image/jpeg;base64,QUFB",
-                }
-            ],
-            media_analysis='{"summary": "black blazer and white trousers"}',
+            query="show me practical work bags under $60",
         )
 
         runtime._create_agent(state, identity)
         tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
 
-        result = tools_by_name["search_catalog_tool"]("black blazer")
+        result = tools_by_name["search_catalog_tool"](
+            "practical work bag",
+            category="bag",
+            max_price=60,
+            soft_preferences={"style": "practical"},
+            strictness="hard",
+        )
 
-        assert "Catalog search skipped" in result
-        assert state.retrieved == {}
+        assert "PRODUCT_REF: prod_1" in result
+        assert state.retrieved == {"Work Bag": "bag.jpg"}
+        assert captured_plan["plan"].hard_filters == {
+            "category": ["bag"],
+            "max_price": 60,
+        }
+        assert captured_plan["plan"].soft_preferences == {"style": "practical"}
+        assert captured_plan["plan"].strictness == "hard"
 
     def test_product_refs_are_cached_by_conversation(
         self,

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -23,7 +23,6 @@ from shared.commerce_contracts import Cart as CommerceCart
 from shared.commerce_contracts import (
     CartLine,
     CatalogCapabilities,
-    CatalogFacetCapability,
     CatalogFilterCapability,
     Money,
     ProductSummary,
@@ -50,6 +49,20 @@ class _StubRuntime:
             "response": self.response_text,
             "timings": {"chatter": 0.1, "memory": 0.01},
         }
+
+    def catalog_capabilities(self, *, force_refresh: bool = False) -> CatalogCapabilities:
+        return CatalogCapabilities(
+            catalog_id="test_catalog",
+            retrieval_modes=["text"],
+            filters={
+                "category": CatalogFilterCapability(
+                    type="enum",
+                    operators=["in"],
+                    source_fields=["subcategory"],
+                    values=["bag", "dress"],
+                )
+            },
+        )
 
 
 @pytest.fixture
@@ -131,12 +144,15 @@ class TestHealthAndRoot:
         response = client.get("/capabilities")
         assert response.status_code == 200
 
-        media = response.json()["media_input"]
+        body = response.json()
+        media = body["media_input"]
         assert media["enabled"] is True
         assert media["max_images_per_turn"] == 1
         assert media["max_videos_per_turn"] == 1
         assert media["video_mime_types"] == ["video/mp4"]
         assert media["vlm_enabled"] is True
+        assert body["catalog"]["catalog_id"] == "test_catalog"
+        assert body["catalog"]["filters"]["category"]["values"] == ["bag", "dress"]
 
     def test_root_describes_endpoints(self, client: TestClient) -> None:
         response = client.get("/")
@@ -424,6 +440,26 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch.setitem(sys.modules, "langchain_openai", openai_mod)
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        runtime._catalog_capabilities = SimpleNamespace(
+            get=lambda: CatalogCapabilities(
+                catalog_id="custom_catalog",
+                retrieval_modes=["text"],
+                filters={
+                    "category": CatalogFilterCapability(
+                        type="enum",
+                        operators=["in"],
+                        source_fields=["subcategory"],
+                        values=["dress"],
+                    ),
+                    "color": CatalogFilterCapability(
+                        type="enum",
+                        operators=["in"],
+                        source_fields=["color"],
+                        values=["blue"],
+                    )
+                },
+            )
+        )
         identity = runtime_mod.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
@@ -442,6 +478,9 @@ class TestDeepAgentsRuntimeRefs:
         assert tools_by_name["add_cart_item_tool"].return_direct is True
         assert tools_by_name["remove_cart_item_tool"].return_direct is True
         assert tools_by_name["view_cart_total_tool"].return_direct is True
+        assert "Catalog ID: custom_catalog" in captured["system_prompt"]
+        assert "values dress" in captured["system_prompt"]
+        assert "top blouse sweater" not in captured["system_prompt"]
 
     def test_search_catalog_tool_executes_structured_plan(
         self,
@@ -490,9 +529,12 @@ class TestDeepAgentsRuntimeRefs:
                     operators=["gte", "lte"],
                     source_fields=["price"],
                 ),
-            },
-            soft_facets={
-                "style": CatalogFacetCapability(type="text"),
+                "color": CatalogFilterCapability(
+                    type="enum",
+                    operators=["in"],
+                    source_fields=["color"],
+                    values=["blue", "black"],
+                ),
             },
         )
         captured_plan = {}
@@ -550,9 +592,11 @@ class TestDeepAgentsRuntimeRefs:
 
         result = tools_by_name["search_catalog_tool"](
             "practical work bag",
-            category="bag",
-            max_price=60,
-            soft_preferences={"style": "practical"},
+            filters={
+                "category": ["bag"],
+                "price": {"max": 60},
+                "color": ["blue"],
+            },
             strictness="hard",
         )
 
@@ -560,9 +604,9 @@ class TestDeepAgentsRuntimeRefs:
         assert state.retrieved == {"Work Bag": "bag.jpg"}
         assert captured_plan["plan"].hard_filters == {
             "category": ["bag"],
-            "max_price": 60,
+            "price": {"max": 60.0},
+            "color": ["blue"],
         }
-        assert captured_plan["plan"].soft_preferences == {"style": "practical"}
         assert captured_plan["plan"].strictness == "hard"
 
     def test_product_refs_are_cached_by_conversation(
@@ -642,6 +686,13 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch.setitem(sys.modules, "langchain_openai", openai_mod)
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        runtime._catalog_capabilities = SimpleNamespace(
+            get=lambda: CatalogCapabilities(
+                catalog_id="fashion",
+                retrieval_modes=["text"],
+                filters={},
+            )
+        )
         identity = runtime_mod.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -437,6 +437,7 @@ class TestDeepAgentsRuntimeRefs:
 
         tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
         assert tools_by_name["search_catalog_tool"].return_direct is False
+        assert tools_by_name["get_product_details_tool"].return_direct is False
         assert tools_by_name["get_cart_tool"].return_direct is False
         assert tools_by_name["add_cart_item_tool"].return_direct is True
         assert tools_by_name["remove_cart_item_tool"].return_direct is True
@@ -597,6 +598,81 @@ class TestDeepAgentsRuntimeRefs:
 
         assert runtime._product_from_ref(identity_a, "prod_123") == product
         assert runtime._product_from_ref(identity_b, "prod_123") is None
+
+    def test_product_details_tool_reads_cached_product_ref(
+        self,
+        base_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        captured: Dict[str, Any] = {}
+        deepagents_mod = ModuleType("deepagents")
+        tools_mod = ModuleType("langchain_core.tools")
+        openai_mod = ModuleType("langchain_openai")
+
+        class FakeProfile:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        class FakeChatOpenAI:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        def fake_tool(*, return_direct: bool = False):
+            def decorate(fn):
+                fn.return_direct = return_direct
+                return fn
+
+            return decorate
+
+        def fake_create_deep_agent(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace()
+
+        deepagents_mod.GeneralPurposeSubagentProfile = FakeProfile
+        deepagents_mod.HarnessProfile = FakeProfile
+        deepagents_mod.create_deep_agent = fake_create_deep_agent
+        deepagents_mod.register_harness_profile = lambda *args, **kwargs: None
+        tools_mod.tool = fake_tool
+        openai_mod.ChatOpenAI = FakeChatOpenAI
+
+        monkeypatch.setitem(sys.modules, "deepagents", deepagents_mod)
+        monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
+        monkeypatch.setitem(sys.modules, "langchain_openai", openai_mod)
+
+        runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        identity = runtime_mod.RequestIdentity(
+            session_id="session-a",
+            conversation_id="conversation-a",
+            cart_id="cart-a",
+            context_user_id=111,
+            cart_user_id=222,
+            request_id="request-a",
+        )
+        runtime._remember_products(
+            identity,
+            [
+                ProductSummary(
+                    product_id="prod_123",
+                    display_name="Work Bag",
+                    description="structured tote",
+                    category="bag",
+                    price=Money(amount=59.0),
+                    attributes={"catalog_text": "Work Bag | structured tote | bag"},
+                )
+            ],
+        )
+
+        runtime._create_agent(State(user_id=111, query="tell me more"), identity)
+        tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
+
+        details = tools_by_name["get_product_details_tool"]("prod_123")
+        missing = tools_by_name["get_product_details_tool"]("Work Bag")
+
+        assert "PRODUCT_REF: prod_123" in details
+        assert "DESCRIPTION: structured tote" in details
+        assert "No product with PRODUCT_REF 'Work Bag'" in missing
 
     def test_format_product_exposes_product_ref(self) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod

--- a/ui/src/components/chatbox/chatbox.tsx
+++ b/ui/src/components/chatbox/chatbox.tsx
@@ -460,7 +460,7 @@ const Chatbox: React.FC<ChatboxProps> = ({ setNewRenderImage }) => {
     addMessage("assistant", "", "");
     
     await sleep(1000);
-    const introduction = "Hello! 👋 I'm your dedicated Shopping Assistant created by NVIDIA. You can ask me anything—from finding the perfect item to learning more about product care.\n\nHere are some questions you could ask me:\n\n• Do you have any summer skirts?\n• Does the [product name] require dry cleaning?\n• Do you have any shoes like this? (upload an image)\n• Great! Add it to my cart";
+    const introduction = "Hello! 👋 I'm your dedicated Shopping Assistant created by NVIDIA. You can ask me anything—from finding the perfect item to learning more about product care.\n\nHere are some questions you could ask me:\n\n• Show me items under $100\n• Does the [product name] require dry cleaning?\n• Do you have anything like this? (upload an image)\n• Add the first item to my cart";
     
     const words = introduction.split(" ");
     for (const word of words) {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -80,8 +80,28 @@ export interface MediaCapabilities {
   vlm_enabled: boolean;
 }
 
+export type CatalogCapabilityType = 'enum' | 'number' | 'text';
+
+export interface CatalogFilterCapability {
+  type: CatalogCapabilityType;
+  operators: string[];
+  source_fields: string[];
+  values: string[];
+  min_value?: number | null;
+  max_value?: number | null;
+  request_aliases: Record<string, string>;
+}
+
+export interface CatalogCapabilities {
+  catalog_id: string;
+  retrieval_modes: string[];
+  image_search_enabled: boolean;
+  filters: Record<string, CatalogFilterCapability>;
+}
+
 export interface CapabilitiesResponse {
   media_input: MediaCapabilities;
+  catalog?: CatalogCapabilities;
 }
 
 export interface ApiResponse {


### PR DESCRIPTION
## Summary

- Move catalog filter capabilities to the catalog service and derive enum/range values from ingested catalog data.
- Add a chain-server catalog capabilities client and expose capabilities through API/UI contracts.
- Split catalog request planning from catalog search execution, with hard filters validated against catalog-owned metadata.
- Keep semantic catalog query text separate from structured filters in the DeepAgents catalog tool.
- Add product-details tool support plus docs and unit coverage for catalog capabilities, request planning, execution, and API behavior.