### PR TITLE
Normalize Milvus COSINE relevance scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ The application follows a microservices architecture:
   required capability-derived taxonomy envelope, deterministic constraint
   mapping, and same-scope search deduplication
 - **Catalog Retriever**: Generative-LLM-free text/image embedding search, hard
-  filtering, and deterministic result ranking
+  filtering, normalized COSINE relevance scores, and deterministic result
+  ranking
 - **Memory Retriever**: User context and cart management
 - **Guardrails**: Content safety and moderation
 - **UI**: React-based frontend interface

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,6 +12,8 @@ The schema-driven catalog refactor is implemented:
   improves how existing products can be discovered and verified;
 - startup builds one validated snapshot for indexing, capabilities, filtering,
   product details, and index-rebuild fingerprinting;
+- raw Milvus COSINE scores are normalized to `[0, 1]` relevance scores before
+  applying the configured similarity threshold;
 - catalog values and category-specific field availability are derived from the
   active rows rather than hard-coded in application logic;
 - the catalog publishes fields, values, ranges, coverage, taxonomy scopes, and

--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -313,7 +313,9 @@ class Milvus:
             fields.pop(self.VECTOR_FIELD, None)
             fields[self.PK_FIELD] = hit.id
             document = SimpleNamespace(page_content=page_content, metadata=fields)
-            results.append((document, float(hit.score)))
+            # Match langchain-milvus's COSINE relevance-score contract.
+            relevance_score = (float(hit.score) + 1.0) / 2.0
+            results.append((document, relevance_score))
         return results
 
 class Retriever:

--- a/docs/EMBEDDING_MANAGEMENT.md
+++ b/docs/EMBEDDING_MANAGEMENT.md
@@ -123,10 +123,11 @@ declared. See [Catalog Schema and Filters](CATALOG_FILTERS.md).
 At query time, the serving agent sends one entry in the `text` list. It receives
 one text embedding and vector search, followed by deterministic candidate
 fusion, product-ID deduplication, hard filtering, thresholding, and similarity
-ordering. Direct/internal
-clients retain the list shape for compatibility, and supplied entries are
-embedded concurrently. `/query/image` retains pooled image/text similarity
-ordering.
+ordering. Milvus COSINE scores are normalized from `[-1, 1]` to `[0, 1]`
+relevance scores before the configured similarity threshold is applied.
+Direct/internal clients retain the list shape for compatibility, and supplied
+entries are embedded concurrently. `/query/image` retains pooled image/text
+similarity ordering.
 
 Text:
 

--- a/tests/unit/catalog_retriever/test_retriever.py
+++ b/tests/unit/catalog_retriever/test_retriever.py
@@ -162,7 +162,7 @@ class TestMilvusAdapter:
 
         class _Hit:
             id = 42
-            score = 0.99
+            score = 0.2
             fields = {
                 "text": "Red Dress | bright | dress,day",
                 "name": "Red Dress",
@@ -236,7 +236,7 @@ class TestMilvusAdapter:
             "price": 12.5,
             "pk": 42,
         }
-        assert results[0][1] == pytest.approx(0.99)
+        assert results[0][1] == pytest.approx(0.6)
 
 
 # --------------------------------------------------------------------------->


### PR DESCRIPTION
## Summary

- Normalize raw Milvus COSINE scores from `[-1, 1]` to `[0, 1]` before applying the configured relevance threshold.
- Update the Milvus adapter unit test to verify the normalized score.
- Document the score contract in the README, project status, and embedding guide.

## Root cause

The catalog adapter passed raw Milvus COSINE scores directly into a retrieval pipeline that treats relevance scores as `[0, 1]`. With the configured `0.3` threshold, relevant products with positive raw scores below `0.3` were incorrectly discarded. For example, a raw score of `0.226` should be interpreted as a normalized relevance score of `0.613`.

This normalization already exists on `main` in `7fb002a`; this PR restores the missing behavior on `staging` without changing ranking, filters, catalog data, or public APIs.