### PR TITLE
chore: ignore generated evaluation output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ tests/evaluation/results/*
 .env
 .env.*
 !.env.example
+
+# Generated evaluation output — archived under ~/exec-briefs, never committed
+tests/integration/conversations/*/quality/
+tests/integration/conversations/*/quality_progress/
+tests/integration/conversations/shopping/gate0_*/
+tests/integration/conversations/shopping/*_run*/


### PR DESCRIPTION
Evaluation runs leave the working tree dirty with artifacts that must never be committed.

- Challenger runs write to `tests/evaluation/results/`.
- Golden-replay collections write into subdirectories of `tests/integration/conversations/`, one level inside the directory holding the committed golden `conv_*.yaml`.
- None of it was ignored.

The canonical archive is `~/exec-briefs/retail-shopping-assistant/quality/`.

Notes:

- The committed goldens themselves are untouched — only generated subdirectories are ignored.
- Register item E3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)