### PR TITLE
fix: ground against hydrated memory lanes, not just tool calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Top-level orchestration is via `docker-compose.yaml`; optional local NIM model c
 - Dormant, directly constructible weather wrapper:
   `chain_server/src/weather_tool.py`
 - Shared request/state models: `chain_server/src/agenttypes.py`
+- The grounding editor must run whenever any hydrated authority lane exists — tool evidence, historical product identity, or cart. Dialogue is intent only and never grounds a product claim.
 - Committed commerce effects ride on the tool artifact and must be consulted before any read-only failure fallback. If the graph snapshot cannot be read, warn about the cart: absence of evidence is not evidence of absence.
 - Tool-loop control outcomes are typed: tools return `(text, artifact)` via `chain_server/src/control_signals.py`, and the middleware reads the artifact. Never recover control state by parsing tool text.
 - Tool-loop control prefixes are defined once in `chain_server/src/tool_loop_control.py`. Never re-declare one as a literal elsewhere; producers render from the constant and matchers key off it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -345,6 +345,21 @@ The newest focused gate is recorded first. Older implementation gates remain
 below as comparison points; generated quality and timing
 artifacts stay in the required local archive rather than versioned source.
 
+- Grounding-gate hydration fix (2026-08-03): every turn hydrates memory lanes
+  before the model runs, but the gate deciding whether to run the grounding
+  editor counted only current-turn *tool* evidence — and prior-turn evidence is
+  structurally always empty, since the graph is invoked with one human message
+  per turn. A follow-up or styling turn grounded in the historical product index
+  or the authoritative cart therefore skipped grounding entirely and returned the
+  model draft unchecked. The gate now counts every hydrated authority lane:
+  current tool evidence, historical product identity, and cart contents.
+  Dialogue is deliberately excluded — it establishes shopper intent, never
+  product fact, so a product claim cannot be checked against it. The historical
+  product index is now carried typed on `State` rather than only rendered.
+  Verified by mutation: restoring the old gate fails the two tests that cover
+  index-only and cart-only turns. The offline suite moved from 941 to 946
+  passed with 1 xfailed.
+
 - Committed-mutation receipt gate (2026-08-03): a cart change that committed
   before a turn failed could be concealed. `_execute_turn` handled
   `agent_timeout` correctly but every other exception — recursion limit, skill

--- a/chain_server/src/agenttypes.py
+++ b/chain_server/src/agenttypes.py
@@ -114,6 +114,13 @@ class State(BaseModel):
         default_factory=list,
         description="Typed prior turns; authoritative for shopper intent context"
     )
+    historical_product_sets: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Typed historical product reference sets; identity authority only, "
+            "never current product-fact authority"
+        )
+    )
     context: str = Field(
         default="",
         description="Rendered prompt text only; never parsed back into state"

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -3607,7 +3607,7 @@ class DeepAgentsRuntime:
                 result,
                 request_id=request_id,
             )
-        if not current_evidence and not prior_evidence:
+        if not _has_grounding_authority(state, current_evidence, prior_evidence):
             return _scrub_internal_shopper_language(draft_response)
 
         start = time.monotonic()
@@ -4183,6 +4183,7 @@ Rules:
         except (ConversationMemoryError, ValidationError) as exc:
             logger.error("Failed to start durable conversation turn: %s", exc)
             state.dialogue = []
+            state.historical_product_sets = []
             state.context = ""
             state.cart = Cart()
             state.shopper_context = None
@@ -4240,6 +4241,11 @@ Rules:
             turn.previous_selected_skill_names
         )
         state.shopper_context = turn.shopper_context
+        state.historical_product_sets = [
+            entry
+            for entry in (turn.projection.product_reference_index or [])
+            if isinstance(entry, dict)
+        ]
         historical_products = format_historical_product_index(
             turn.projection.product_reference_index
         )
@@ -5083,6 +5089,32 @@ def _committed_effect_receipt(
         "twice."
     )
     return "\n".join(lines)
+
+
+def _has_grounding_authority(
+    state: State,
+    current_evidence: str,
+    prior_evidence: str,
+) -> bool:
+    """Return whether this turn has any authority to check a draft against.
+
+    Every turn hydrates memory lanes before the model runs. Gating the grounding
+    editor on current-turn *tool* evidence alone discards that hydrated context:
+    a follow-up or styling turn grounded in the historical product index or the
+    authoritative cart would skip grounding entirely, leaving the draft free to
+    assert product facts nothing supports.
+
+    Dialogue is deliberately excluded. It establishes shopper intent, never
+    product, policy, inventory, or cart fact, so it is not something a product
+    claim can be checked against.
+    """
+
+    return bool(
+        current_evidence
+        or prior_evidence
+        or state.historical_product_sets
+        or state.cart.contents
+    )
 
 
 def _partial_product_results_response(state: State) -> str:

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -8002,3 +8002,60 @@ class TestCommittedMutationSurvivesTurnFailure:
         assert "review your cart" in receipt.lower()
         # must not look like the read-only catalog fallback
         assert "grounded catalog options" not in receipt
+
+
+class TestGroundingGateCountsHydratedLanes:
+    """Every turn hydrates memory lanes; the gate must not discard them."""
+
+    def _gate(self):
+        from chain_server.src import deepagents_runtime as runtime_mod
+        return runtime_mod._has_grounding_authority
+
+    def _state(self, **kw):
+        from chain_server.src.agenttypes import State
+        return State(user_id=1, query="q", **kw)
+
+    def test_tool_evidence_alone_still_grounds(self) -> None:
+        assert self._gate()(self._state(), "SEARCH_RESULT...", "") is True
+
+    def test_historical_product_index_grounds_without_a_tool_call(self) -> None:
+        """The regression this slice closes.
+
+        A follow-up turn about an earlier product runs no tool, but the
+        historical index hydrated real product identity. Previously the gate
+        saw no tool evidence and returned the draft unchecked.
+        """
+
+        state = self._state(
+            historical_product_sets=[
+                {"candidate_set_id": "s1", "turn_seq": 2, "products": [{"ref": "p1"}]}
+            ]
+        )
+
+        assert self._gate()(state, "", "") is True
+
+    def test_authoritative_cart_grounds_without_a_tool_call(self) -> None:
+        from chain_server.src.agenttypes import Cart
+
+        state = self._state(cart=Cart(contents=[{"item": "Work Bag", "amount": 1}]))
+
+        assert self._gate()(state, "", "") is True
+
+    def test_dialogue_alone_does_not_ground(self) -> None:
+        """Dialogue carries intent, never product fact — it cannot verify a claim."""
+
+        from chain_server.src.agenttypes import DialogueTurn
+
+        state = self._state(
+            dialogue=[
+                DialogueTurn(sequence=1, shopper_text="I like beige", assistant_text="noted")
+            ],
+            context="RECENT CONVERSATION:\n[turn 1]\nUser: I like beige",
+        )
+
+        assert self._gate()(state, "", "") is False
+
+    def test_a_genuinely_empty_turn_still_skips(self) -> None:
+        """No tool, no history, no cart: nothing to check, so no model call."""
+
+        assert self._gate()(self._state(), "", "") is False


### PR DESCRIPTION
Every turn hydrates memory lanes before the model runs. The grounding gate discarded them.

- The composer **receives** dialogue, cart, historical product index, and tool evidence. But the gate deciding whether to *run* the grounding editor counted only current-turn **tool** evidence — and prior-turn evidence is structurally always empty, since the graph is invoked with one human message per turn.
- So a follow-up or styling turn grounded in the historical product index or the authoritative cart **skipped grounding entirely** and returned the model's draft unchecked.
- The gate now counts every hydrated authority lane: current tool evidence, historical product identity, and cart contents.
- The historical product index is now carried **typed** on `State`, completing what the typed dialogue lane started; it was previously available only as rendered text.

Deliberate exclusions:

- **Dialogue does not ground.** It establishes shopper intent, never product, policy, inventory, or cart fact, so a product claim cannot be verified against it.
- **A genuinely empty turn still skips** the editor — no tool, no history, no cart means nothing to check, so no model call is added where it would do nothing.

Notes:

- Verified by mutation: restoring the old gate fails exactly the two tests covering index-only and cart-only turns.
- This targets the Challenger's measured `groundedness 2.17` and its critical failures for "style advice presented as catalog fact without transcript support".
- Suite 941 → 946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)