### PR TITLE
fix: let the model own unenforceable-requirement replies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Top-level orchestration is via `docker-compose.yaml`; optional local NIM model c
 - Dormant, directly constructible weather wrapper:
   `chain_server/src/weather_tool.py`
 - Shared request/state models: `chain_server/src/agenttypes.py`
+- Deterministic code may establish that a catalog filter is unadvertised; it must not decide the conversational move. Never substitute a fixed refusal for the model's composed answer.
 - The grounding editor must run whenever any hydrated authority lane exists — tool evidence, historical product identity, or cart. Dialogue is intent only and never grounds a product claim.
 - Committed commerce effects ride on the tool artifact and must be consulted before any read-only failure fallback. If the graph snapshot cannot be read, warn about the cart: absence of evidence is not evidence of absence.
 - Tool-loop control outcomes are typed: tools return `(text, artifact)` via `chain_server/src/control_signals.py`, and the middleware reads the artifact. Never recover control state by parsing tool text.

--- a/STATUS.md
+++ b/STATUS.md
@@ -345,6 +345,19 @@ The newest focused gate is recorded first. Older implementation gates remain
 below as comparison points; generated quality and timing
 artifacts stay in the required local archive rather than versioned source.
 
+- Unenforceable-requirement ownership fix (2026-08-03): when every tool outcome
+  reported an unadvertised hard filter, the runtime discarded the model's
+  composed answer and substituted a fixed question — "would you like me to treat
+  it as a preference?" — even when the shopper had already answered it in the
+  same message. It also bypassed the grounding editor on those turns. This was
+  the single largest deterministic failure mode in the Challenger baseline: 9 of
+  141 turns, more than scope guards, grounding failures, and timeouts combined.
+  Deterministic code still establishes that a filter is not advertised; the
+  model now decides what to say about it, and the tool outcome defers to what
+  the shopper has already stated rather than prescribing a single move. The dead
+  override and its test were removed. The offline suite moved from 946 to 948
+  passed with 1 xfailed.
+
 - Grounding-gate hydration fix (2026-08-03): every turn hydrates memory lanes
   before the model runs, but the gate deciding whether to run the grounding
   editor counted only current-turn *tool* evidence — and prior-turn evidence is

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -543,7 +543,10 @@ def _unsupported_requirement_message(requirements: list[str]) -> str:
             f"'{requirement}' is not an advertised hard filter"
             for requirement in requirements
         )
-        + ". Ask the shopper whether to treat it as a preference."
+        + ". Decide from what the shopper has already told you: if they have "
+        "said what to do when it cannot be confirmed, follow that; otherwise "
+        "treat it as a ranking preference and say plainly it is unconfirmed, "
+        "or ask them. Do not refuse the request."
     )
 
 
@@ -1841,15 +1844,13 @@ class DeepAgentsRuntime:
                 request_id=identity.request_id,
                 final_termination_reason="completed",
             )
-            state.response = (
-                _no_direct_taxonomy_response(
-                    result,
-                    request_id=identity.request_id,
-                )
-                or _unsupported_requirement_response(
-                    result,
-                    request_id=identity.request_id,
-                )
+            # An unenforceable requirement is a fact for the model to speak to,
+            # not a reason for the runtime to seize the turn. Deterministic code
+            # establishes that the filter is not advertised; the model decides
+            # what to say about it, constrained by the grounding editor.
+            state.response = _no_direct_taxonomy_response(
+                result,
+                request_id=identity.request_id,
             )
             if not state.response:
                 remaining_seconds = max(
@@ -4681,26 +4682,6 @@ def _catalog_repair_clarification_response(
     return ""
 
 
-def _unsupported_requirement_response(
-    result: Any,
-    *,
-    request_id: str,
-) -> str | None:
-    """Return the fixed shopper response for an unenforceable must-have."""
-
-    outcomes = _business_tool_result_contents(
-        _current_turn_messages(_result_messages(result), request_id)
-    )
-    unsupported_outcomes = [
-        content
-        for content in outcomes
-        if content.startswith(
-            UNSUPPORTED_CONSTRAINT_PREFIX
-        )
-    ]
-    if unsupported_outcomes and len(unsupported_outcomes) == len(outcomes):
-        return _UNSUPPORTED_REQUIREMENT_RESPONSE
-    return None
 
 
 def _business_tool_result_contents(messages: list[Any]) -> list[str]:

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -6650,55 +6650,6 @@ class TestDeepAgentsRuntimeRefs:
             request_id="current-request",
         ) is False
 
-    def test_unsupported_requirement_response_is_fixed_and_current_turn_scoped(
-        self,
-    ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
-
-        result = {
-            "messages": [
-                {"role": "user", "content": "REQUEST ID: earlier-request"},
-                {
-                    "role": "tool",
-                    "content": (
-                        "The requested catalog requirement cannot be enforced: "
-                        "'water_resistant' is not an advertised hard filter."
-                    ),
-                },
-                {"role": "user", "content": "REQUEST ID: current-request"},
-            ]
-        }
-
-        assert runtime_mod._unsupported_requirement_response(
-            result,
-            request_id="current-request",
-        ) is None
-
-        result["messages"].append(result["messages"][1])
-        assert runtime_mod._unsupported_requirement_response(
-            result,
-            request_id="current-request",
-        ) == runtime_mod._UNSUPPORTED_REQUIREMENT_RESPONSE
-
-        detail_then_unsupported = {
-            "messages": [
-                {"role": "user", "content": "REQUEST ID: current-request"},
-                {
-                    "role": "tool",
-                    "name": "get_product_details_tool",
-                    "content": (
-                        "PRODUCT_DETAIL_GROUNDING_NOTE: verified details.\n"
-                        "PRODUCT_REF: bag-1\nNAME: Work Bag"
-                    ),
-                },
-                result["messages"][1],
-            ]
-        }
-        assert runtime_mod._unsupported_requirement_response(
-            detail_then_unsupported,
-            request_id="current-request",
-        ) is None
-
     def test_unsupported_requirement_preserves_successful_search_evidence(
         self,
         base_config,
@@ -6741,10 +6692,6 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        assert runtime_mod._unsupported_requirement_response(
-            result,
-            request_id="current-request",
-        ) is None
         response = runtime._build_search_only_response(
             state,
             result,
@@ -8059,3 +8006,36 @@ class TestGroundingGateCountsHydratedLanes:
         """No tool, no history, no cart: nothing to check, so no model call."""
 
         assert self._gate()(self._state(), "", "") is False
+
+
+class TestUnenforceableRequirementIsModelOwned:
+    """Deterministic code establishes the fact; the model decides what to say."""
+
+    def test_runtime_no_longer_seizes_the_turn(self) -> None:
+        """The fixed refusal override is gone.
+
+        It discarded the model's composed answer and substituted a question the
+        shopper had often already answered in the same message, and it bypassed
+        the grounding editor on those turns.
+        """
+
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        assert not hasattr(runtime_mod, "_unsupported_requirement_response")
+
+    def test_tool_outcome_states_the_fact_and_forbids_refusing(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        message = runtime_mod._unsupported_requirement_message(["matte"])
+
+        assert "not an advertised hard filter" in message
+        assert "Do not refuse the request." in message
+        # it must not dictate a single conversational move
+        assert "Ask the shopper whether to treat it as a preference." not in message
+
+    def test_outcome_defers_to_what_the_shopper_already_said(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        message = runtime_mod._unsupported_requirement_message(["matte"])
+
+        assert "already told you" in message


### PR DESCRIPTION
The runtime was seizing the turn when a requirement could not be hard-filtered.

- When every tool outcome reported an unadvertised filter, the runtime **discarded the model's composed answer** and substituted a fixed question — *"would you like me to treat it as a preference?"* — often asking something the shopper had already answered in the same message. It also bypassed the grounding editor on those turns.
- Deterministic code still establishes the fact that a filter is not advertised. **Choosing whether to proceed, qualify, or ask is a conversational decision and belongs to the model.**
- The tool outcome now states the fact and defers to context rather than prescribing one move, and explicitly must not refuse.
- The dead override and the test that only exercised it are removed.

Why this one:

- Largest deterministic failure mode in the Challenger baseline: **9 of 141 turns (6.4%)** — more than scope guards, grounding failures, and execution timeouts combined. All nine were the exact fixed string; none were the model choosing those words.
- It is the companion to #131: that made the assistant honest, and a large share of the resulting unhelpfulness was hard-coded here.

Verified live — the turn that previously refused now returns:

> *"I don't have a 'matte' finish attribute available here, so I can't confirm matte black… What I **can** confirm: Ravenna Crossbody Bag — $49.99 … primary color: black, composition: leather. Finish (matte vs. glossy) isn't confirmed."*

Notes:

- The supplementary note in `_build_search_only_response` is deliberately kept — there it appends alongside product results rather than seizing the turn.
- No catalog, cart, memory, replay, or dormant weather behavior is touched.
- Suite 946 → 948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)