### PR TITLE
refactor: give the composer separated authority lanes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Top-level orchestration is via `docker-compose.yaml`; optional local NIM model c
 - Dormant, directly constructible weather wrapper:
   `chain_server/src/weather_tool.py`
 - Shared request/state models: `chain_server/src/agenttypes.py`
+- The composer receives separated authority lanes. Never merge lanes with different authority into one block: dialogue carries intent, the product index carries identity, the cart is authoritative, tool evidence establishes current facts.
 - Deterministic code may establish that a catalog filter is unadvertised; it must not decide the conversational move. Never substitute a fixed refusal for the model's composed answer.
 - The grounding editor must run whenever any hydrated authority lane exists — tool evidence, historical product identity, or cart. Dialogue is intent only and never grounds a product claim.
 - Committed commerce effects ride on the tool artifact and must be consulted before any read-only failure fallback. If the graph snapshot cannot be read, warn about the cart: absence of evidence is not evidence of absence.

--- a/STATUS.md
+++ b/STATUS.md
@@ -345,6 +345,20 @@ The newest focused gate is recorded first. Older implementation gates remain
 below as comparison points; generated quality and timing
 artifacts stay in the required local archive rather than versioned source.
 
+- Composer authority-lane separation (2026-08-03): the grounding editor
+  received dialogue and the historical product index glued into one
+  `RECENT DISCUSSION` block, so it could not tell which half may support a
+  factual claim — shopper prose sat beside genuine product identity under one
+  label. The composer now receives separated lanes, each stating what it may be
+  used for: current-turn tool evidence (facts established this turn), products
+  shown earlier (identity only, never current price/availability/attributes),
+  the authoritative cart, and conversation (shopper intent only, never a product
+  fact). The editor's rules were rewritten to match. The dead
+  `PRIOR-TURN TOOL EVIDENCE` lane is deleted: `_prior_turn_messages` always
+  returns empty because the graph is invoked with one human message per turn.
+  The agent prompt is unchanged; only the composer's input changed. The offline
+  suite moved from 948 to 953 passed with 1 xfailed.
+
 - Unenforceable-requirement ownership fix (2026-08-03): when every tool outcome
   reported an unadvertised hard filter, the runtime discarded the model's
   composed answer and substituted a fixed question — "would you like me to treat

--- a/chain_server/src/agenttypes.py
+++ b/chain_server/src/agenttypes.py
@@ -121,6 +121,10 @@ class State(BaseModel):
             "never current product-fact authority"
         )
     )
+    dialogue_context: str = Field(
+        default="",
+        description="Rendered dialogue only, excluding the product index"
+    )
     context: str = Field(
         default="",
         description="Rendered prompt text only; never parsed back into state"

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -85,7 +85,6 @@ from .message_shape import (
     _current_turn_messages,
     _extract_final_text,
     _message_type,
-    _prior_turn_messages,
     _result_messages,
     _tool_results_by_call_id,
     _value,
@@ -276,8 +275,9 @@ _SHOPPER_CONTEXT_SYSTEM_RULES = """Representative-shopper precedence and safety:
   weather lookup or weather inference from it."""
 _GROUNDING_EDITOR_SYSTEM_PROMPT = """You are a final response editor for a retail shopping assistant.
 
-Rewrite the draft response only as needed so it is grounded in TOOL EVIDENCE
-and CURRENT CART. Keep the shopper's requested task and any successful cart
+Rewrite the draft response only as needed so every factual claim is supported
+by a lane that can support it. CURRENT-TURN TOOL EVIDENCE, PRODUCTS SHOWN
+EARLIER, and CURRENT CART carry authority; CONVERSATION does not. Keep the shopper's requested task and any successful cart
 action intact.
 
 Rules:
@@ -293,8 +293,10 @@ Rules:
 - Do not add products, prices, cart actions, or product facts absent from TOOL
   EVIDENCE or CURRENT CART.
 - CURRENT-TURN TOOL EVIDENCE is the only evidence for a search or mutation in
-  this turn. PRIOR-TURN TOOL EVIDENCE may support direct references to products
-  previously shown, but it does not prove that a new search or mutation ran.
+  this turn. PRODUCTS SHOWN EARLIER may support a direct reference to something
+  already shown, but it establishes identity only: it never proves a product's
+  current price, availability, or attributes, and never proves that a search or
+  mutation ran this turn.
 - If TOOL EVIDENCE says there is no direct advertised taxonomy match for one
   requested role, do not claim a search ran for that role. Report that role's
   gap, preserve any other successful current-turn role, and ask whether to
@@ -308,11 +310,14 @@ Rules:
   and filter scope returned no products. It does not prove that a different,
   unsearched, or unadvertised product type is absent, and it never supports a
   catalog-wide availability claim.
-- Use RECENT DISCUSSION to resolve direct references such as "that" and
-  "those." A discussed product or styling anchor does not need to be in CURRENT
-  CART. RECENT DISCUSSION cannot establish whether the current search succeeded
-  or supply the current turn's candidates. Do not introduce an absent-cart
-  caveat unless the shopper asks about the cart or requests a cart mutation.
+- Use CONVERSATION to resolve direct references such as "that" and "those," and
+  to honour what the shopper has already told you. It carries intent only: it
+  can never establish a product fact, a price, availability, whether a search
+  succeeded, or what this turn's candidates are. Anything asserted only in
+  CONVERSATION and supported by no other lane must not be repeated as fact.
+  A discussed product or styling anchor does not need to be in CURRENT CART. Do
+  not introduce an absent-cart caveat unless the shopper asks about the cart or
+  requests a cart mutation.
 - Remove PRODUCT_REF, CART_LINE_ID, tool names, and internal IDs.
 - Remove internal skill, mode, evaluator, judge, cache, backend, tool-evidence,
   structured-field, and data-layer language. Use shopper-safe phrasing such as
@@ -3584,10 +3589,6 @@ class DeepAgentsRuntime:
             max_chars=max_evidence_chars,
             request_id=request_id,
         )
-        prior_evidence = _collect_message_grounding_evidence(
-            _prior_turn_messages(_result_messages(result), request_id),
-            max_chars=max_evidence_chars,
-        )
         search_only = bool(current_evidence) and _has_search_only_tool_evidence(
             result,
             request_id=request_id,
@@ -3608,19 +3609,23 @@ class DeepAgentsRuntime:
                 result,
                 request_id=request_id,
             )
-        if not _has_grounding_authority(state, current_evidence, prior_evidence):
+        if not _has_grounding_authority(state, current_evidence):
             return _scrub_internal_shopper_language(draft_response)
 
         start = time.monotonic()
+        # Separated authority lanes. Each is labelled with what it may be used
+        # for, because a lane that mixes intent with identity gives the editor
+        # no way to tell which half can support a factual claim.
         prompt = (
             f"USER QUERY:\n{state.query}\n\n"
-            f"RECENT DISCUSSION:\n{state.context or '(none)'}\n\n"
-            f"CURRENT CART:\n{_format_cart(state.cart)}\n\n"
-            f"AVAILABLE IMAGES:\n{_format_retrieved_images(state.retrieved)}\n\n"
-            "CURRENT-TURN TOOL EVIDENCE:\n"
+            "CURRENT-TURN TOOL EVIDENCE (facts established this turn):\n"
             f"{current_evidence or '(none)'}\n\n"
-            "PRIOR-TURN TOOL EVIDENCE:\n"
-            f"{prior_evidence or '(none)'}\n\n"
+            "PRODUCTS SHOWN EARLIER (identity only — not current facts):\n"
+            f"{format_historical_product_index(state.historical_product_sets) or '(none)'}\n\n"
+            f"CURRENT CART (authoritative):\n{_format_cart(state.cart)}\n\n"
+            "CONVERSATION (shopper intent only — never a product fact):\n"
+            f"{state.dialogue_context or '(none)'}\n\n"
+            f"AVAILABLE IMAGES:\n{_format_retrieved_images(state.retrieved)}\n\n"
             f"DRAFT RESPONSE:\n{draft_response}"
         )
         try:
@@ -4185,6 +4190,7 @@ Rules:
             logger.error("Failed to start durable conversation turn: %s", exc)
             state.dialogue = []
             state.historical_product_sets = []
+            state.dialogue_context = ""
             state.context = ""
             state.cart = Cart()
             state.shopper_context = None
@@ -4234,10 +4240,11 @@ Rules:
         finally:
             state.timings["memory"] = time.monotonic() - start
 
-        state.dialogue, state.context = build_dialogue_context(
+        state.dialogue, state.dialogue_context = build_dialogue_context(
             turn.recent_turns,
             max_chars=max(1000, int(self.config.memory_length)),
         )
+        state.context = state.dialogue_context
         state.previous_selected_skill_names = list(
             turn.previous_selected_skill_names
         )
@@ -5072,11 +5079,7 @@ def _committed_effect_receipt(
     return "\n".join(lines)
 
 
-def _has_grounding_authority(
-    state: State,
-    current_evidence: str,
-    prior_evidence: str,
-) -> bool:
+def _has_grounding_authority(state: State, current_evidence: str) -> bool:
     """Return whether this turn has any authority to check a draft against.
 
     Every turn hydrates memory lanes before the model runs. Gating the grounding
@@ -5092,7 +5095,6 @@ def _has_grounding_authority(
 
     return bool(
         current_evidence
-        or prior_evidence
         or state.historical_product_sets
         or state.cart.contents
     )

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -7963,7 +7963,7 @@ class TestGroundingGateCountsHydratedLanes:
         return State(user_id=1, query="q", **kw)
 
     def test_tool_evidence_alone_still_grounds(self) -> None:
-        assert self._gate()(self._state(), "SEARCH_RESULT...", "") is True
+        assert self._gate()(self._state(), "SEARCH_RESULT...") is True
 
     def test_historical_product_index_grounds_without_a_tool_call(self) -> None:
         """The regression this slice closes.
@@ -7979,14 +7979,14 @@ class TestGroundingGateCountsHydratedLanes:
             ]
         )
 
-        assert self._gate()(state, "", "") is True
+        assert self._gate()(state, "") is True
 
     def test_authoritative_cart_grounds_without_a_tool_call(self) -> None:
         from chain_server.src.agenttypes import Cart
 
         state = self._state(cart=Cart(contents=[{"item": "Work Bag", "amount": 1}]))
 
-        assert self._gate()(state, "", "") is True
+        assert self._gate()(state, "") is True
 
     def test_dialogue_alone_does_not_ground(self) -> None:
         """Dialogue carries intent, never product fact — it cannot verify a claim."""
@@ -8000,12 +8000,12 @@ class TestGroundingGateCountsHydratedLanes:
             context="RECENT CONVERSATION:\n[turn 1]\nUser: I like beige",
         )
 
-        assert self._gate()(state, "", "") is False
+        assert self._gate()(state, "") is False
 
     def test_a_genuinely_empty_turn_still_skips(self) -> None:
         """No tool, no history, no cart: nothing to check, so no model call."""
 
-        assert self._gate()(self._state(), "", "") is False
+        assert self._gate()(self._state(), "") is False
 
 
 class TestUnenforceableRequirementIsModelOwned:
@@ -8039,3 +8039,51 @@ class TestUnenforceableRequirementIsModelOwned:
         message = runtime_mod._unsupported_requirement_message(["matte"])
 
         assert "already told you" in message
+
+
+class TestComposerAuthorityLanes:
+    """The composer must receive lanes it can tell apart."""
+
+    def test_dialogue_and_product_identity_are_separate_lanes(self) -> None:
+        """They were glued under one RECENT DISCUSSION heading.
+
+        The editor could not tell which half may support a factual claim:
+        shopper prose sat beside genuine product identity under one label.
+        """
+
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        src = runtime_mod._GROUNDING_EDITOR_SYSTEM_PROMPT
+        assert "CONVERSATION" in src
+        assert "PRODUCTS SHOWN EARLIER" in src
+        assert "RECENT DISCUSSION" not in src
+
+    def test_conversation_lane_is_declared_non_authoritative(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        src = runtime_mod._GROUNDING_EDITOR_SYSTEM_PROMPT
+        assert "CONVERSATION does not" in src
+        assert "intent only" in src
+
+    def test_earlier_products_are_identity_not_current_fact(self) -> None:
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        src = runtime_mod._GROUNDING_EDITOR_SYSTEM_PROMPT
+        assert "establishes identity only" in src
+        assert "never proves a product's" in src
+
+    def test_dead_prior_turn_lane_is_gone(self) -> None:
+        """_prior_turn_messages always returns [] — one human message per turn."""
+
+        from chain_server.src import deepagents_runtime as runtime_mod
+
+        assert "PRIOR-TURN TOOL EVIDENCE" not in runtime_mod._GROUNDING_EDITOR_SYSTEM_PROMPT
+
+    def test_dialogue_context_excludes_the_product_index(self) -> None:
+        from chain_server.src.agenttypes import State
+
+        state = State(user_id=1, query="q")
+        state.dialogue_context = "RECENT CONVERSATION:\n[turn 1]\nUser: hi"
+        state.context = state.dialogue_context + "\n\nHISTORICAL PRODUCT INDEX (read-only):\n- x"
+
+        assert "HISTORICAL PRODUCT INDEX" not in state.dialogue_context


### PR DESCRIPTION
The grounding editor could not tell which of its inputs may support a factual claim.

- Dialogue and the historical product index were glued into one `RECENT DISCUSSION` block. Shopper prose sat beside genuine product identity under a single label — in the one component whose job is rejecting unsupported claims.
- The composer now receives **separated lanes, each stating what it may be used for**:
  - `CURRENT-TURN TOOL EVIDENCE (facts established this turn)`
  - `PRODUCTS SHOWN EARLIER (identity only — not current facts)`
  - `CURRENT CART (authoritative)`
  - `CONVERSATION (shopper intent only — never a product fact)`
- The editor's rules were rewritten to match, including that anything asserted only in `CONVERSATION` must not be repeated as fact.
- **Delete the `PRIOR-TURN TOOL EVIDENCE` lane.** `_prior_turn_messages` always returns empty — the graph is invoked with a single human message per turn — so that lane was permanently `(none)` and its rule was dead guidance the model read every turn.

Notes:

- **The agent prompt is unchanged**; only the composer's input changed. `state.context` still carries the combined rendering for the agent.
- This is the first half of Slice D. The second half drains the evidence codecs onto artifacts (§8j, 22 functions) and unblocks Slice I.
- Not byte-identical — the composer prompt changed deliberately, so this wants a judged run.
- No catalog, cart, memory, replay, or dormant weather behavior is touched.
- Suite 948 → 953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)