### PR TITLE
test(eval): record which skills and tools ran on every turn

### DIFF
--- a/tests/evaluation/eval_config.yaml
+++ b/tests/evaluation/eval_config.yaml
@@ -37,6 +37,19 @@ target_agent:
   guardrails: false
 
 run:
+  # Diagnostic fields recorded on every turn. Named explicitly: the recorded
+  # turn is the contract a judge adjudicates against, so a field belongs here
+  # when a judge needs it to verify a claim or an operator needs it to explain
+  # a failure. Requires EXPOSE_AGENT_DIAGNOSTICS=true on the target.
+  recorded_diagnostics:
+    - product_evidence
+    - product_evidence_truncated
+    - catalog_scope_outcomes
+    - tool_calls
+    - skill_files_read
+    - rejected_tool_calls
+    - duplicate_tool_calls
+    - final_termination_reason
   datasets:
     - text_shopping
     - style_guide

--- a/tests/evaluation/src/challenger.py
+++ b/tests/evaluation/src/challenger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Optional, Protocol
+from typing import Any, Mapping, Optional, Protocol, Sequence
 from urllib.parse import urlparse
 import argparse
 import base64
@@ -207,6 +207,7 @@ class TargetAgentClient:
         self._url = _join_url(config.target_agent.base_url, config.target_agent.endpoint)
         self._timeout = config.target_agent.timeout_seconds
         self._guardrails = config.target_agent.guardrails
+        self._recorded_diagnostics = tuple(config.run.recorded_diagnostics)
 
     def send_turn(self, *, user_id: int, query: str, image: str) -> dict[str, Any]:
         payload = {
@@ -219,18 +220,37 @@ class TargetAgentClient:
         response = requests.post(self._url, json=payload, timeout=self._timeout)
         response.raise_for_status()
         data = response.json()
-        return {
+        record: dict[str, Any] = {
             "status_code": response.status_code,
             "response": data.get("response", ""),
             "images": data.get("images", {}) or {},
             "cart": data.get("cart", {}) or {},
             "timings": data.get("timings", {}) or {},
-            "product_evidence": _extract_product_evidence(data),
-            "product_evidence_truncated": (
-                _extract_product_evidence_truncated(data)
-            ),
-            "catalog_scope_outcomes": _extract_catalog_scope_outcomes(data),
         }
+        record.update(_recorded_diagnostics(data, self._recorded_diagnostics))
+        return record
+
+
+def _recorded_diagnostics(
+    data: Mapping[str, Any],
+    fields: Sequence[str],
+) -> dict[str, Any]:
+    """Record the configured diagnostic fields from one target response.
+
+    The runtime emits far more than was previously kept. Recording three fields
+    meant a failing turn could not be explained afterwards: which skill was
+    active, how many searches it spent, whether a call was rejected. Every
+    diagnosis was reconstructed by reproducing the conversation live.
+
+    A field the target did not send is recorded as absent rather than as an
+    empty value, so "the runtime returned nothing" stays distinguishable from
+    "the runtime was never asked".
+    """
+
+    diagnostics = data.get("agent_diagnostics")
+    if not isinstance(diagnostics, Mapping):
+        return {}
+    return {name: diagnostics[name] for name in fields if name in diagnostics}
 
 
 def _extract_product_evidence(data: Mapping[str, Any]) -> list[dict[str, Any]]:

--- a/tests/evaluation/src/config.py
+++ b/tests/evaluation/src/config.py
@@ -57,9 +57,36 @@ class TargetAgentConfig:
     guardrails: bool
 
 
+#: Recorded unless the config overrides it. Each earns its place because a
+#: judge needs it to verify a claim, or an operator needs it to explain a
+#: failure that already happened:
+#:   product_evidence        - the facts a product claim must be checked against
+#:   catalog_scope_outcomes  - what a zero-result search actually covered
+#:   tool_calls              - which tools ran, and with what arguments
+#:   skill_files_read        - which shopper skill was active
+#:   rejected_tool_calls     - calls the runtime refused
+#:   duplicate_tool_calls    - repeated retrieval within one turn
+#:   final_termination_reason- how the turn ended
+_DEFAULT_RECORDED_DIAGNOSTICS = (
+    "product_evidence",
+    "product_evidence_truncated",
+    "catalog_scope_outcomes",
+    "tool_calls",
+    "skill_files_read",
+    "rejected_tool_calls",
+    "duplicate_tool_calls",
+    "final_termination_reason",
+)
+
+
 @dataclass(frozen=True)
 class RunConfig:
     datasets: list[str]
+    #: Diagnostic fields recorded per turn. Named explicitly rather than
+    #: capturing the whole object: the recorded turn is the contract a judge
+    #: adjudicates against, and it stops being one if it becomes a dump of
+    #: whatever the runtime happens to emit.
+    recorded_diagnostics: list[str]
     scenario_limit_per_dataset: int
     random_seed: int
     save_returned_images: bool
@@ -249,8 +276,16 @@ def _load_run_config(raw: Mapping[str, Any]) -> RunConfig:
     datasets = data.get("datasets")
     if not isinstance(datasets, list) or not all(isinstance(item, str) for item in datasets):
         raise ConfigError("run.datasets must be a list of dataset names.")
+    recorded = data.get("recorded_diagnostics")
+    if recorded is None:
+        recorded = list(_DEFAULT_RECORDED_DIAGNOSTICS)
+    elif not isinstance(recorded, list) or not all(
+        isinstance(name, str) and name.strip() for name in recorded
+    ):
+        raise ConfigError("run.recorded_diagnostics must be a list of field names")
     return RunConfig(
         datasets=datasets,
+        recorded_diagnostics=[str(name).strip() for name in recorded],
         scenario_limit_per_dataset=_as_int(
             data.get("scenario_limit_per_dataset"), "run.scenario_limit_per_dataset"
         ),

--- a/tests/unit/evaluation/test_challenger.py
+++ b/tests/unit/evaluation/test_challenger.py
@@ -892,3 +892,80 @@ def test_extract_product_evidence_rejects_oversized_aggregate():
 
     assert _extract_product_evidence(data) == []
     assert _extract_product_evidence_truncated(data) is False
+
+
+class TestRecordedDiagnostics:
+    """What a turn records is the contract a judge adjudicates against.
+
+    Recording three fields meant a failing turn could not be explained
+    afterwards -- which skill was active, how many searches it spent, whether a
+    call was rejected -- so every diagnosis reproduced the conversation live.
+    """
+
+    def _response(self, **diagnostics):
+        return {
+            "response": "here are some dresses",
+            "agent_diagnostics": {
+                "product_evidence": [{"product_ref": "p1"}],
+                "tool_calls": [
+                    {"sequence": 1, "tool_name": "search_catalog_tool"}
+                ],
+                "skill_files_read": ["/shopper/product-discovery/SKILL.md"],
+                "final_termination_reason": "completed",
+                **diagnostics,
+            },
+        }
+
+    def test_configured_fields_are_recorded(self) -> None:
+        from src.challenger import _recorded_diagnostics
+
+        recorded = _recorded_diagnostics(
+            self._response(),
+            ["product_evidence", "tool_calls", "skill_files_read"],
+        )
+
+        assert recorded["tool_calls"][0]["tool_name"] == "search_catalog_tool"
+        assert recorded["skill_files_read"] == [
+            "/shopper/product-discovery/SKILL.md"
+        ]
+        assert recorded["product_evidence"] == [{"product_ref": "p1"}]
+
+    def test_unconfigured_fields_are_not_recorded(self) -> None:
+        """The turn stays a contract, not a dump of whatever was emitted."""
+
+        from src.challenger import _recorded_diagnostics
+
+        recorded = _recorded_diagnostics(self._response(), ["product_evidence"])
+
+        assert set(recorded) == {"product_evidence"}
+        assert "tool_calls" not in recorded
+
+    def test_absent_field_is_absent_not_empty(self) -> None:
+        """"the runtime sent nothing" must stay distinct from "never asked"."""
+
+        from src.challenger import _recorded_diagnostics
+
+        recorded = _recorded_diagnostics(
+            self._response(), ["product_evidence", "catalog_scope_outcomes"]
+        )
+
+        assert "catalog_scope_outcomes" not in recorded
+
+    def test_diagnostics_disabled_on_the_target_records_nothing(self) -> None:
+        """EXPOSE_AGENT_DIAGNOSTICS=false yields an empty object, not a crash.
+
+        A whole run was once scored against an empty trace, so this path is
+        asserted rather than assumed.
+        """
+
+        from src.challenger import _recorded_diagnostics
+
+        assert _recorded_diagnostics({"agent_diagnostics": {}}, ["tool_calls"]) == {}
+        assert _recorded_diagnostics({}, ["tool_calls"]) == {}
+
+    def test_default_field_list_covers_skills_and_tools(self) -> None:
+        from src.config import _DEFAULT_RECORDED_DIAGNOSTICS
+
+        assert "tool_calls" in _DEFAULT_RECORDED_DIAGNOSTICS
+        assert "skill_files_read" in _DEFAULT_RECORDED_DIAGNOSTICS
+        assert "product_evidence" in _DEFAULT_RECORDED_DIAGNOSTICS


### PR DESCRIPTION
## Summary

- **The runtime emits fourteen diagnostic fields; the challenger recorded three.** `tool_calls` and `skill_files_read` were sent in the response and dropped at the harness boundary.
- **So a failing turn could not be explained afterwards** — which shopper skill was active, how many searches it spent, whether a call was rejected or duplicated. Every diagnosis on 2026-08-03/04 was reconstructed by reproducing the conversation live.
- **Nothing new is computed.** The fields are already built, already bounded and ID-stripped, already in the payload.

## What this PR contains

- **`run.recorded_diagnostics`** in `eval_config.yaml` — the recorded fields, named explicitly. Defaults to the eight that earn their place; override to narrow or extend.
- **`_recorded_diagnostics()`** in the challenger, replacing three hard-coded extractors.
- **Absent stays absent.** A field the target did not send is not recorded as an empty value, so *"the runtime returned nothing"* stays distinguishable from *"the runtime was never asked"* — the confusion that cost a full evaluation run when diagnostics were silently disabled.
- **Five tests**, all fixture-based.

## Why named fields rather than the whole object

The recorded turn is the contract a judge adjudicates against. It stops being one if it becomes a dump of whatever the runtime happens to emit. A field belongs there when a judge needs it to verify a claim, or an operator needs it to explain a failure that already happened.

## Notes

Requires `EXPOSE_AGENT_DIAGNOSTICS=true` on the target; it is `false` by default and a shopper must never receive this data.

None of it reaches the model — diagnostics are computed after the reply exists and are never rendered into a prompt, so recording more costs no context and cannot change behaviour.
