### PR TITLE
refactor: separate the deep-agents runtime from its stateless helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,10 @@ Top-level orchestration is via `docker-compose.yaml`; optional local NIM model c
 
 ## 3) Source Map (Where to Change What)
 
-- Serving agent orchestration, registered tools, and capability-derived
-  model-visible search schema: `chain_server/src/deepagents_runtime.py`
+- Serving agent orchestration and registered tools:
+  `chain_server/src/deepagents_runtime.py`
+- Capability-derived model-visible tool schemas, and the stateless helpers the
+  runtime calls: `chain_server/src/turn_support.py`
 - Reusable model-visible catalog search rules: `chain_server/src/catalog_scope.py`
 - Shopper-skill registry, frontmatter validation, and immutable tool policy: `chain_server/src/tool_policy.py`
 - Per-turn skill activation, model-visible tool binding, and dispatch grant gate: `chain_server/src/skill_activation.py`

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -6,34 +6,21 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
-import hashlib
 import json
-import logging
 import os
 from pathlib import Path
-import re
 import time
-from collections.abc import Sequence
 from typing import Any, AsyncIterator, Literal
-import unicodedata
-import uuid
 
-from langgraph.checkpoint.memory import MemorySaver
 from langgraph.errors import GraphRecursionError
 from pydantic import (
     BaseModel,
-    ConfigDict,
     Field,
     ValidationError,
-    create_model,
-    field_validator,
-    model_validator,
 )
-from pydantic_core import PydanticCustomError
 import requests
 
-from .agenttypes import Cart, DialogueTurn, ShopperContext, State
+from .agenttypes import Cart, ShopperContext, State
 from .response_format import (
     _format_availability_result,
     _format_cart,
@@ -41,33 +28,97 @@ from .response_format import (
     _format_cart_remove_result,
     _format_cart_total,
     _format_catalog_scope_outcome,
-    _format_detail_value,
-    _format_filter_statement,
     _format_media_summary,
     _format_policy_result,
     _format_product_detail_record,
     _format_product_record,
-    _format_product_refs,
     _format_promotions_result,
     _format_retrieved_images,
     _format_search_direction_evidence,
     _format_search_filter_evidence,
-    _format_search_group,
     _format_search_guidance_evidence,
     _format_search_scope_relation_evidence,
     _format_search_taxonomy_evidence,
     _format_shopper_context,
     _format_update_cart_result,
 )
+from .turn_support import (
+    AddCartItemsToolItemInput,
+    RequestIdentity,
+    SearchCatalogToolArguments,
+    _UNSUPPORTED_SEARCH_MODE_MESSAGE,
+    _add_model_usage,
+    _advertised_scope_match,
+    _advertised_subcategories_for_selection,
+    _advertised_taxonomy_scope_issue,
+    _advertised_taxonomy_value,
+    _agent_selected_scope_is_advertised,
+    _append_product_results,
+    _build_checkpointer,
+    _cart_add_scope_failures,
+    _cart_line_by_id,
+    _catalog_execution_taxonomy_status,
+    _catalog_repair_clarification_response,
+    _catalog_search_scope,
+    _collect_token_usage,
+    _collect_tool_grounding_evidence,
+    _committed_effect_receipt,
+    _conversation_turn_status,
+    _duplicates_unavailable_product_type,
+    _empty_agent_diagnostics,
+    _exact_taxonomy_issue,
+    _format_search_only_response,
+    _generic_shopper_guidance,
+    _has_grounding_authority,
+    _has_search_only_tool_evidence,
+    _has_successful_non_search_tool_evidence,
+    _media_failure_response,
+    _merge_token_usage,
+    _multi_subcategory_candidate_limit,
+    _no_direct_taxonomy_response,
+    _normalize_cart_add_tool_items,
+    _normalize_product_text,
+    _normalized_scope_value,
+    _normalized_token_usage,
+    _partial_graph_messages,
+    _partial_product_results_response,
+    _product_detail_failure_message,
+    _product_detail_record,
+    _product_scope_key,
+    _products_with_subcategory_coverage,
+    _record_catalog_model_usage,
+    _record_language_model_failure,
+    _record_media_model_usage,
+    _record_safety_model_usage,
+    _rejected_catalog_search_response,
+    _resolved_agent_selected_product_type,
+    _safe_collect_agent_diagnostics,
+    _safe_shopper_guidance,
+    _same_product_display_name,
+    _same_product_scope,
+    _scrub_internal_shopper_language,
+    _search_catalog_tool_input_model,
+    _search_guidance_evidence,
+    _search_product_record,
+    _selected_advertised_subcategories,
+    _shopper_stated_product_scope,
+    _shopper_stated_requirement,
+    _should_short_circuit_media_failure,
+    _skill_activation_input_model,
+    _store_policies_path,
+    _taxonomy_hard_constraints,
+    _text_mentions_product_type,
+    _tool_search_mode,
+    _unsupported_requirement_message,
+    logger,
+)
 from .catalog_capabilities import (
     CatalogCapabilitiesClient,
-    effective_filter_capabilities,
     format_catalog_capabilities_for_prompt,
 )
 from .catalog_execution import execute_catalog_search
 from .catalog_request import (
     CatalogSearchIntent,
-    CatalogSearchPlan,
     build_catalog_search_plan,
 )
 from .catalog_scope import CATALOG_SEARCH_RULES
@@ -108,26 +159,16 @@ from .conversation_products import (
 from .tool_evidence import (
     ProductDetailEvidence,
     SearchEvidence,
-    detail_evidence_of,
-    evidence_of,
 )
 from .message_shape import (
     _content_to_text,
-    _current_turn_messages,
     _extract_final_text,
-    _message_type,
     _result_messages,
-    _tool_results_by_call_id,
     _value,
 )
 from .media_perception import MediaPerceptionClient
 from .skill_activation import (
     SKILL_ACTIVATION_COMPLETE,
-    SKILL_ACTIVATION_MODIFIER_REQUIRES_PRIMARY,
-    SKILL_ACTIVATION_MULTIPLE_PRIMARY,
-    SKILL_ACTIVATION_REQUIRED,
-    SKILL_ACTIVATION_TOOL_NAME,
-    SKILL_TOOL_NOT_GRANTED,
     ShopperSkillActivationError,
     ShopperSkillActivationMiddleware,
     selected_skill_names_for_turn,
@@ -139,67 +180,28 @@ from .tool_policy import (
 )
 from .tool_loop_control import (
     CONSTRAINT_REVIEW_PREFIX,
-    STOP_TOOL_USE_PREFIX,
     SEARCH_BUDGET_EXHAUSTED_PREFIX,
-    SEARCH_SCOPE_COMPLETE_PREFIX,
     SEARCH_VALIDATION_ERROR_PREFIX,
-    SERVER_CATALOG_CLARIFICATION,
-    SERVER_RESTORED_TOOL_CALL_FIELDS,
-    UNSUPPORTED_CONSTRAINT_PREFIX,
-    UNSUPPORTED_TAXONOMY_PREFIX,
     ToolLoopControlMiddleware,
-    _SERVER_REJECTED_TOOL_CALLS,
 )
 from shared.commerce_contracts import (
     AddCartItemInput,
     CatalogCapabilities,
     CheckProductAvailabilityInput,
-    CommerceError,
     GetCartInput,
     GetProductDetailsInput,
     GetStorePolicyInput,
-    ProductDetail,
     ProductSummary,
     RemoveCartItemInput,
     UpdateCartItemInput,
 )
 
 
-logger = logging.getLogger(__name__)
 _SHOPPER_SKILLS_ENV = "SHOPPER_SKILLS_ROOT"
-_SHARED_CONFIG_ROOT_ENV = "SHARED_CONFIG_ROOT"
-_STORE_POLICIES_RELATIVE_PATH = Path("chain_server/store_policies.yaml")
 
 
-def _build_checkpointer():
-    """Return the process-local LangGraph checkpointer."""
-
-    store = os.environ.get("CHECKPOINT_STORE", "memory").strip().lower()
-    if store != "memory":
-        raise ValueError(
-            "CHECKPOINT_STORE currently supports only 'memory'. "
-            f"Received: {store!r}."
-        )
-    return MemorySaver()
 
 
-def _store_policies_path() -> Path:
-    """Resolve controlled policy content outside the agent-readable skill root."""
-
-    configured_root = os.environ.get(_SHARED_CONFIG_ROOT_ENV, "").strip()
-    if configured_root:
-        return Path(configured_root) / _STORE_POLICIES_RELATIVE_PATH
-
-    deployed_path = Path("/app/shared/configs") / _STORE_POLICIES_RELATIVE_PATH
-    if deployed_path.is_file():
-        return deployed_path
-
-    return (
-        Path(__file__).resolve().parents[2]
-        / "shared"
-        / "configs"
-        / _STORE_POLICIES_RELATIVE_PATH
-    )
 
 
 try:
@@ -207,22 +209,7 @@ try:
 except Exception:  # pragma: no cover - dependency import is validated at runtime.
     _FilesystemBackend = None
 
-_NO_DIRECT_CATALOG_MATCH_EVIDENCE = (
-    "CUSTOMER_SAFE_NO_MATCH_EVIDENCE: The active catalog has no direct "
-    "advertised taxonomy match for this requested product role. "
-    "No retrieval ran and no alternative product type was selected. Say "
-    "that plainly, preserve any successful evidence for other roles, and "
-    "ask permission before searching a different advertised type. Do not "
-    "name alternatives."
-)
 
-_PRODUCT_DETAIL_EVIDENCE_NOTE = (
-    "Product details were read for these products, but the available "
-    "detail data contains only the listed facts. Do "
-    "not state material, care, dimensions, closures, fit, sizing, "
-    "colorways, or outdoor performance unless the field appears in "
-    "this evidence summary."
-)
 
 _SEARCH_RESULT_GROUNDING_NOTE = (
     "SEARCH_RESULT_GROUNDING_NOTE: Use search results for candidate names, prices, "
@@ -240,11 +227,6 @@ _SEARCH_NO_MATCH_GROUNDING_NOTE = (
     "whether products exist in a different, unsearched, or unadvertised "
     "product type."
 )
-_MAX_DIAGNOSTIC_PRODUCT_EVIDENCE = 24
-_MAX_DIAGNOSTIC_PRODUCT_FACTS = 40
-_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS = 500
-_MAX_DIAGNOSTIC_PRODUCT_EVIDENCE_CHARS = 32_000
-_PARTIAL_GRAPH_SNAPSHOT_TIMEOUT_SECONDS = 1.0
 _SEARCH_SCOPE_COMPLETE_NOTE = (
     "SEARCH_SCOPE_COMPLETE: The shopper's current request can now be answered "
     "from this search and existing turn evidence. Answer now. Do not search an "
@@ -256,28 +238,6 @@ _SEARCH_BUDGET_EXHAUSTED_NOTE = (
     f"{SEARCH_BUDGET_EXHAUSTED_PREFIX} No additional catalog searches are "
     "available this turn. Continue with any requested non-search action, or "
     "answer honestly from the grounded products already returned."
-)
-_UNSUPPORTED_SEARCH_MODE_MESSAGE = (
-    "The requested search mode is not available for the active catalog. "
-    "Ask the shopper to use an advertised mode."
-)
-_NO_DIRECT_TAXONOMY_RESPONSE = (
-    "The catalog doesn't advertise a product type that directly matches this "
-    "request. Would you like me to search a different advertised product type?"
-)
-_REJECTED_CATALOG_SEARCH_RESPONSE = (
-    "I couldn't complete a valid catalog search for that request, so I don't "
-    "have catalog results to show. Please try again or ask me to search a "
-    "different advertised product type."
-)
-_CATALOG_REPAIR_CLARIFICATION_RESPONSE = (
-    "Could you clarify the product type or requirement you want me to use?"
-)
-_UNSUPPORTED_REQUIREMENT_RESPONSE = (
-    "I can't guarantee that requirement from the catalog information available "
-    "to this assistant, so I won't present unverified matches. Would you like me "
-    "to treat it as a preference and show candidates to verify on their product "
-    "pages?"
 )
 _GROUNDING_FAILURE_RESPONSE = (
     "I couldn't safely verify the final response. Please retry; if this involved "
@@ -420,1173 +380,84 @@ Rules:
 _EXCLUDED_DEEP_AGENT_TOOLS = frozenset(
     {"write_todos", "ls", "write_file", "edit_file", "glob", "grep", "execute"}
 )
-_PRODUCT_NAME_STOPWORDS = frozenset({"a", "an", "and", "in", "of", "the", "to", "with"})
-_INTERNAL_SHOPPER_REPLACEMENTS = (
-    ("The product detail tool doesn't return", "I don't have"),
-    ("the product detail tool doesn't return", "I don't have"),
-    ("The catalog detail tool doesn't return", "I don't have"),
-    ("the catalog detail tool doesn't return", "I don't have"),
-    ("The product detail tool does not return", "I don't have"),
-    ("the product detail tool does not return", "I don't have"),
-    ("The catalog detail tool does not return", "I don't have"),
-    ("the catalog detail tool does not return", "I don't have"),
-    ("the product detail tool", "the product details I can access"),
-    ("the catalog detail tool", "the product details I can access"),
-    ("because the tool requires", "because I need"),
-    ("The tool requires", "I need"),
-    ("the tool requires", "I need"),
-)
-
-
-class CatalogTaxonomyToolInput(BaseModel):
-    """Catalog-derived taxonomy roles used by the agent search tool."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    category: list[str] = Field(
-        ...,
-        description=(
-            "Exact advertised category values required by the shopper. Use an "
-            "empty list only when subcategory supplies the text-search scope or "
-            "the search is image-only."
-        ),
-    )
-    subcategory: list[str] = Field(
-        ...,
-        description=(
-            "Exact advertised subcategory values required by the shopper. Use an "
-            "empty list when category supplies the text-search scope or the search "
-            "is image-only."
-        ),
-    )
-
-    @field_validator("category", "subcategory", mode="before")
-    @classmethod
-    def deduplicate_values(cls, value: Any) -> Any:
-        """Normalize repeated taxonomy values before cardinality validation."""
-
-        if isinstance(value, str):
-            return [value]
-        return list(dict.fromkeys(value)) if isinstance(value, list) else value
-
-
-def _singularize_product_word(word: str) -> str:
-    """Conservatively singularize one normalized product-type word."""
-
-    if word.endswith("ies") and len(word) > 3:
-        return f"{word[:-3]}y"
-    if word.endswith(("sses", "shes", "ches", "xes", "zes")):
-        return word[:-2]
-    if word.endswith("s") and not word.endswith("ss") and len(word) > 1:
-        return word[:-1]
-    return word
-
-
-def _normalize_product_text(value: str) -> str:
-    """Normalize product-type text for deterministic lexical comparison."""
-
-    normalized = unicodedata.normalize("NFKC", value).casefold()
-    normalized = normalized.replace("&", " and ").replace("/", " or ")
-    words = re.findall(r"[^\W_]+", normalized.replace("_", " "))
-    return " ".join(_singularize_product_word(word) for word in words)
-
-
-def _has_alternative_connector(value: str) -> bool:
-    """Return whether a product phrase joins explicit alternatives."""
-
-    normalized = _normalize_product_text(value)
-    return bool(re.search(r"\b(?:and|or)\b", normalized))
-
-
-def _text_mentions_product_type(text: str, product_type: str) -> bool:
-    """Return whether text names a normalized product-type form."""
-
-    normalized_text = _normalize_product_text(text)
-    padded_text = f" {normalized_text} "
-    normalized_product_type = _normalize_product_text(product_type)
-    return bool(normalized_product_type) and (
-        f" {normalized_product_type} " in padded_text
-    )
-
-
-def _requirement_word_stem(word: str) -> str:
-    """Return a conservative stem for literal requirement provenance."""
-
-    for suffix in ("ance", "ence", "ancy", "ency", "ant", "ent", "ing", "ed"):
-        if word.endswith(suffix) and len(word) > len(suffix) + 3:
-            return word[: -len(suffix)]
-    return _singularize_product_word(word)
-
-
-def _shopper_stated_requirement(query: str, requirement: str) -> bool:
-    """Return whether a proposed requirement is grounded in the current turn."""
-
-    normalized_query = unicodedata.normalize("NFKC", query).casefold()
-    query_words = {
-        _requirement_word_stem(word)
-        for word in re.findall(r"[^\W_]+", normalized_query)
-    }
-    requirement_words = {
-        _requirement_word_stem(word)
-        for word in re.findall(
-            r"[^\W_]+",
-            unicodedata.normalize("NFKC", requirement).casefold(),
-        )
-    }
-    return bool(requirement_words) and requirement_words.issubset(query_words)
-
-
-def _product_scope_key(value: str | None) -> str:
-    """Return the full normalized product phrase preserved across repair."""
-
-    return _normalize_product_text(value or "")
-
-
-def _generic_shopper_guidance(requested_product_type: str | None) -> str:
-    """Return safe guidance after an inferred attribute is removed."""
-
-    product_type = (requested_product_type or "products").replace("_", " ")
-    return f"Finding {product_type} for the shopper's request."
-
-
-_UNSUPPORTED_GUIDANCE_PATTERN = re.compile(
-    r"\b(?:waterproof|water[ -]?resistant|weather[ -]?safe|bug[ -]?safe|"
-    r"wet (?:surfaces?|grounds?|conditions?)|grass|gravel|all[ -]?day|best[ -]?in[ -]?category|"
-    r"maximally|outdoor (?:surfaces?|walking)|"
-    r"(?:handles?|suitable for|works? well (?:for|in)|secure for|stay secure for)"
-    r"[^.]{0,32}(?:rain|wet weather|outdoor))\b",
-    flags=re.IGNORECASE,
-)
-
-
-def _safe_shopper_guidance(
-    shopper_guidance: str,
-    requested_product_type: str | None,
-) -> str:
-    """Remove unsupported performance language from pre-search guidance."""
-
-    if _UNSUPPORTED_GUIDANCE_PATTERN.search(shopper_guidance):
-        return _generic_shopper_guidance(requested_product_type)
-    return shopper_guidance
-
-
-def _unsupported_requirement_message(requirements: list[str]) -> str:
-    """Return the shopper-facing failure for unsupported hard requirements."""
-
-    return (
-        "The requested catalog requirement cannot be enforced: "
-        + ", ".join(
-            f"'{requirement}' is not an advertised hard filter"
-            for requirement in requirements
-        )
-        + ". Decide from what the shopper has already told you: if they have "
-        "said what to do when it cannot be confirmed, follow that; otherwise "
-        "treat it as a ranking preference and say plainly it is unconfirmed, "
-        "or ask them. Do not refuse the request."
-    )
-
-
-def _recent_shopper_statements(
-    dialogue: Sequence[DialogueTurn],
-    *,
-    limit: int = 4,
-) -> str:
-    """Read prior shopper text from the typed lane, never from rendered prose.
-
-    Assistant text is deliberately excluded: dialogue may carry shopper intent,
-    but assistant prose is not product, policy, inventory, or cart evidence.
-    """
-
-    recent = list(dialogue)[-limit:]
-    return "\n".join(turn.shopper_text for turn in recent if turn.shopper_text)
-
-
-def _shopper_stated_product_scope(
-    query: str,
-    dialogue: Sequence[DialogueTurn],
-    product_scope_key: str,
-) -> bool:
-    """Return whether current or recent shopper text states a product scope."""
-
-    shopper_text = "\n".join(
-        value for value in (query, _recent_shopper_statements(dialogue)) if value
-    )
-    return _text_mentions_product_type(shopper_text, product_scope_key)
-
-
-def _resolved_agent_selected_product_type(
-    *,
-    query: str,
-    dialogue: Sequence[DialogueTurn],
-    requested_product_type: str | None,
-    taxonomy_status: str,
-    taxonomy: BaseModel | dict[str, Any],
-) -> str | None:
-    """Derive open-role provenance from the agent's single taxonomy choice."""
-
-    if taxonomy_status != "agent_selected_type":
-        return requested_product_type
-    scope_key = _product_scope_key(requested_product_type)
-    if scope_key and _shopper_stated_product_scope(query, dialogue, scope_key):
-        return requested_product_type
-    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
-    subcategories = payload.get("subcategory") or []
-    if len(subcategories) == 1:
-        return str(subcategories[0])
-    return requested_product_type
-
-
-def _agent_selected_scope_is_advertised(
-    requested_product_type: str | None,
-    taxonomy: BaseModel | dict[str, Any],
-) -> bool:
-    """Check that an open-role choice names its advertised taxonomy scope."""
-
-    requested = _normalize_product_text(requested_product_type or "")
-    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
-    subcategories = {
-        _normalize_product_text(value)
-        for value in (payload.get("subcategory") or [])
-    }
-    return len(subcategories) == 1 and requested in subcategories
-
-
-def _advertised_subcategories_for_selection(
-    taxonomy: BaseModel | dict[str, Any],
-    capabilities: CatalogCapabilities,
-) -> list[str]:
-    """Return advertised role choices within the selected category."""
-
-    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
-    selected_categories = payload.get("category") or []
-    categories = capabilities.taxonomy.categories
-    category_names = selected_categories or list(categories)
-    return sorted(
-        {
-            subcategory
-            for category_name in category_names
-            if (category := categories.get(category_name)) is not None
-            for subcategory in category.subcategories
-        }
-    )
-
-
-def _advertised_taxonomy_value(
-    requested_product_type: str | None,
-    capabilities: CatalogCapabilities,
-) -> str | None:
-    """Return the matching advertised taxonomy value, if one exists."""
-
-    requested = _normalize_product_text(requested_product_type or "")
-    for category_name, category in capabilities.taxonomy.categories.items():
-        if requested == _normalize_product_text(category_name):
-            return category_name
-        for subcategory_name in category.subcategories:
-            if requested == _normalize_product_text(subcategory_name):
-                return subcategory_name
-    return None
-
-
-def _advertised_scope_match(
-    requested_product_type: str | None,
-    capabilities: CatalogCapabilities,
-) -> tuple[str, str, str, str] | None:
-    """Return the longest advertised exact or suffix scope match."""
-
-    raw_requested = requested_product_type or ""
-    requested = _normalize_product_text(raw_requested)
-    suffix_match_allowed = not _has_alternative_connector(raw_requested)
-    matches: list[tuple[str, str, str, str]] = []
-    for category_name, category in capabilities.taxonomy.categories.items():
-        normalized_category = _normalize_product_text(category_name)
-        if requested == normalized_category or (
-            suffix_match_allowed
-            and requested.endswith(f" {normalized_category}")
-        ):
-            matches.append(
-                ("category", category_name, category_name, normalized_category)
-            )
-        for subcategory_name in category.subcategories:
-            normalized_subcategory = _normalize_product_text(subcategory_name)
-            if requested == normalized_subcategory or (
-                suffix_match_allowed
-                and requested.endswith(f" {normalized_subcategory}")
-            ):
-                matches.append(
-                    (
-                        "subcategory",
-                        subcategory_name,
-                        category_name,
-                        normalized_subcategory,
-                    )
-                )
-    return max(
-        matches,
-        key=lambda match: (len(match[3].split()), len(match[3])),
-        default=None,
-    )
-
-
-def _duplicates_unavailable_product_type(
-    requirements: Any,
-    requested_product_type: str | None,
-    capabilities: CatalogCapabilities,
-) -> bool:
-    """Return whether requirements only repeat an unavailable product type."""
-
-    requested = _normalize_product_text(requested_product_type or "")
-    return bool(
-        requested
-        and isinstance(requirements, list)
-        and len(requirements) == 1
-        and not _has_alternative_connector(requested_product_type or "")
-        and _advertised_scope_match(requested_product_type, capabilities) is None
-        and all(
-            isinstance(requirement, str)
-            and _normalize_product_text(requirement) == requested
-            for requirement in requirements
-        )
-    )
-
-
-def _same_product_scope(
-    first: str,
-    second: str,
-    capabilities: CatalogCapabilities,
-) -> bool:
-    """Compare full product scopes without conflating advertised siblings."""
-
-    if first == second:
-        return True
-    if _has_alternative_connector(first):
-        return False
-    first_advertised = _advertised_taxonomy_value(first, capabilities)
-    if first_advertised:
-        return False
-    advertised_match = _advertised_scope_match(first, capabilities)
-    if advertised_match:
-        return second == advertised_match[3]
-    return first.endswith(f" {second}")
-
-
-def _selected_advertised_subcategories(
-    taxonomy: BaseModel | dict[str, Any],
-    capabilities: CatalogCapabilities,
-) -> tuple[str, list[str]] | None:
-    """Return one typed multi-subcategory selection owned by one category."""
-
-    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
-    selected = list(dict.fromkeys(payload.get("subcategory") or []))
-    if len(selected) < 2:
-        return None
-    owners = [
-        category_name
-        for category_name, category in capabilities.taxonomy.categories.items()
-        if all(value in category.subcategories for value in selected)
-    ]
-    selected_categories = set(payload.get("category") or [])
-    if len(owners) != 1 or selected_categories not in (set(), {owners[0]}):
-        return None
-    return owners[0], selected
-
-
-def _multi_subcategory_candidate_limit(
-    selection: tuple[str, list[str]] | None,
-    capabilities: CatalogCapabilities,
-    default: int,
-) -> int:
-    """Fetch enough ranked candidates for a typed multi-subcategory selection."""
-
-    if selection is None:
-        return default
-    category_name, subcategories = selection
-    category = capabilities.taxonomy.categories[category_name]
-    product_count = sum(
-        category.subcategories[name].product_count for name in subcategories
-    )
-    return min(50, max(default, len(subcategories), product_count))
-
-
-def _products_with_subcategory_coverage(
-    products: list[ProductSummary],
-    selection: tuple[str, list[str]] | None,
-    limit: int,
-) -> list[ProductSummary]:
-    """Keep rank order while reserving one result per selected subcategory."""
-
-    if selection is None or len(products) <= limit:
-        return products
-    _, subcategories = selection
-    selected_indexes: set[int] = set()
-    for subcategory in subcategories:
-        normalized_subcategory = _normalize_product_text(subcategory)
-        match = next(
-            (
-                index
-                for index, product in enumerate(products)
-                if _normalize_product_text(product.category or "")
-                == normalized_subcategory
-            ),
-            None,
-        )
-        if match is not None:
-            selected_indexes.add(match)
-
-    for index in range(len(products)):
-        if len(selected_indexes) >= max(limit, len(subcategories)):
-            break
-        selected_indexes.add(index)
-    return [products[index] for index in sorted(selected_indexes)]
-
-
-def _advertised_taxonomy_scope_issue(
-    requested_product_type: str | None,
-    taxonomy_status: str,
-    taxonomy: BaseModel | dict[str, Any],
-    capabilities: CatalogCapabilities,
-) -> str | None:
-    """Enforce capability-owned relations for exact advertised scopes."""
-
-    advertised_match = _advertised_scope_match(
-        requested_product_type,
-        capabilities,
-    )
-    if advertised_match is None:
-        return None
-    scope_kind, advertised_name, category_name, _ = advertised_match
-    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
-    selected_categories = payload.get("category") or []
-    selected_subcategories = payload.get("subcategory") or []
-    normalized_category = _normalize_product_text(category_name)
-    normalized_selected_categories = {
-        _normalize_product_text(value) for value in selected_categories
-    }
-    normalized_selected_subcategories = {
-        _normalize_product_text(value) for value in selected_subcategories
-    }
-    if scope_kind == "category":
-        category = capabilities.taxonomy.categories[category_name]
-        owned_subcategories = {
-            _normalize_product_text(value) for value in category.subcategories
-        }
-        selected_owned_children = (
-            bool(normalized_selected_subcategories)
-            and normalized_selected_subcategories.issubset(owned_subcategories)
-            and normalized_selected_categories in (set(), {normalized_category})
-        )
-        if taxonomy_status == "exact_requested_type" and selected_owned_children:
-            return (
-                f"Requested product type '{requested_product_type}' binds to "
-                f"advertised category '{advertised_name}', while the selected "
-                "taxonomy contains only its advertised children. Keep those "
-                "children together for the shopper's umbrella request."
-            )
-        exact_category = (
-            taxonomy_status == "exact_requested_type"
-            and not normalized_selected_subcategories
-            and normalized_selected_categories == {normalized_category}
-        )
-        owned_children = (
-            taxonomy_status
-            in {"member_of_requested_umbrella", "agent_selected_type"}
-            and selected_owned_children
-        )
-        if exact_category or owned_children:
-            return None
-        return (
-            f"Requested product type '{requested_product_type}' binds to advertised "
-            f"category '{advertised_name}'. Select that category directly or only "
-            "its advertised children; do not substitute another category."
-        )
-    selected_matches = (
-        len(selected_subcategories) == 1
-        and _normalize_product_text(selected_subcategories[0])
-        == _normalize_product_text(advertised_name)
-        and normalized_selected_categories in (set(), {normalized_category})
-    )
-    if selected_matches and taxonomy_status in {
-        "exact_requested_type",
-        "agent_selected_type",
-    }:
-        return None
-    return (
-        f"Requested product type '{requested_product_type}' binds to advertised "
-        f"subcategory '{advertised_name}'. Select only that exact subcategory; "
-        "do not substitute an advertised sibling."
-    )
-
-
-def _catalog_execution_taxonomy_status(
-    requested_product_type: str | None,
-    taxonomy: BaseModel | dict[str, Any],
-    semantic_query: str,
-    capabilities: CatalogCapabilities,
-    *,
-    shopper_stated_scope: bool,
-) -> str:
-    """Derive the legacy execution mode without asking the model to label it."""
-
-    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
-    categories = payload.get("category") or []
-    subcategories = payload.get("subcategory") or []
-    if (
-        not semantic_query.strip()
-        and not requested_product_type
-        and not categories
-        and not subcategories
-    ):
-        return "image_only"
-    if not shopper_stated_scope:
-        return "agent_selected_type"
-
-    advertised_match = _advertised_scope_match(
-        requested_product_type,
-        capabilities,
-    )
-    if advertised_match is not None:
-        scope_kind = advertised_match[0]
-        if scope_kind == "category" and subcategories:
-            return "member_of_requested_umbrella"
-        return "exact_requested_type"
-    if len(categories) == 1 and not subcategories:
-        return "parent_category_alternative"
-    if subcategories:
-        return "member_of_requested_umbrella"
-    return "exact_requested_type"
-
-
-class SearchCatalogToolArguments(BaseModel):
-    """Stable agent-facing catalog-search arguments."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    semantic_query: str = Field(
-        ...,
-        description=(
-            "One soft or descriptive product search string for semantic ranking. "
-            "Product type may be repeated for relevance, but taxonomy and other "
-            "must-haves are enforced only by the structured fields below. Use an "
-            "empty string only for an image-only search."
-        ),
-    )
-    shopper_guidance: str = Field(
-        ...,
-        max_length=400,
-        description=(
-            "One concise, product-agnostic shopper-facing sentence written under "
-            "the active skill before search results are known. Connect this "
-            "product role to the shopper's stated goal or direct antecedent. Do "
-            "not name unselected or unavailable product types, name or describe "
-            "candidate products, assert product attributes, or mention tools, "
-            "schemas, filters, evidence, or identifiers. Use an empty string only "
-            "for image-only search."
-        ),
-    )
-    requested_product_type: str | None = Field(
-        ...,
-        description=(
-            "Shortest product noun or umbrella phrase for this focused role, "
-            "resolved from the shopper's current turn or direct antecedent. "
-            "Exclude color, material, fit, occasion, weather, and style modifiers: "
-            "'formal tops' and 'relaxed-fit tops' both use 'tops'. For a genuinely "
-            "open role selected by the agent, use the chosen advertised role noun. "
-            "If this type is not separately advertised and you select one faithful "
-            "advertised parent category, keep this shopper-named type unchanged. "
-            "This is provenance, not catalog taxonomy or a ranking query. Use null "
-            "only for image-only search."
-        ),
-    )
-    taxonomy: CatalogTaxonomyToolInput = Field(
-        ...,
-        description=(
-            "Required catalog-derived taxonomy selection. Allowed category and "
-            "subcategory values come from the active catalog capabilities. Every "
-            "selected value must be the requested product type or a child of an "
-            "umbrella the shopper actually named. For a genuinely open request, "
-            "select one advertised subcategory as the focused role. Never select "
-            "a parent or sibling as a substitute for an advertised type. If a "
-            "shopper-named type is not separately advertised but one advertised "
-            "category is its faithful broader parent, select only that category "
-            "and leave subcategory empty; results remain alternatives under their "
-            "actual catalog types. For example, skirts may satisfy bottoms; "
-            "dresses may not."
-        ),
-    )
-    required_constraints: dict[str, Any] = Field(
-        ...,
-        description=(
-            "Every non-taxonomy must-have stated for the target products in the "
-            "current shopper turn, as a structured field and value. Facts about "
-            "an antecedent or anchor guide semantic styling judgment; do not copy "
-            "them onto a complementary product unless the shopper explicitly asks "
-            "for the same value. "
-            "Use exact hard-filter properties and advertised enum values from "
-            "current Catalog capabilities. Put a directly stated requirement "
-            "those capabilities do not advertise in unadvertised_requirements. "
-            "Season, weather, occasion, "
-            "and subjective style/vibe "
-            "context remain semantic direction unless the shopper directly "
-            "requires an objective product attribute. A defining material is a "
-            "must-have: for 'Any denim skirts available?', put 'denim' in "
-            "unadvertised_requirements when composition is not a hard filter. "
-            "Product types never belong in unadvertised_requirements."
-        ),
-    )
-    scope_complete: bool = Field(
-        ...,
-        description=(
-            "True only when this search plus existing turn evidence is enough to "
-            "answer the shopper's complete current request. For a recommendation-"
-            "only one-role request this is true. Set false when an explicitly "
-            "requested product role, product-detail verification, availability "
-            "check, or cart action still must run after this search. Do not set "
-            "false merely to search alternatives or adjacent types, or because a "
-            "broader multi-turn outfit project remains unfinished. 'Start with a "
-            "beige top' and 'What bottoms go with that?' are each complete after "
-            "their own one-role search."
-        ),
-    )
-    search_mode: str | None = Field(
-        default=None,
-        description="Optional search mode from Catalog capabilities.",
-    )
-
-
-class SearchCatalogToolInput(SearchCatalogToolArguments):
-    """Runtime-validated catalog search request."""
-
-    taxonomy_status: Literal[
-        "exact_requested_type",
-        "member_of_requested_umbrella",
-        "parent_category_alternative",
-        "agent_selected_type",
-        "no_direct_catalog_match",
-        "image_only",
-    ] = Field(..., description="Server-derived catalog execution mode.")
-
-    @model_validator(mode="after")
-    def text_search_has_taxonomy_scope(self) -> "SearchCatalogToolInput":
-        if len(set(self.taxonomy.category)) > 1:
-            raise ValueError("catalog search accepts at most one category")
-        has_taxonomy = bool(
-            self.taxonomy.category or self.taxonomy.subcategory
-        )
-        has_query = bool(self.semantic_query.strip())
-        has_shopper_guidance = bool(self.shopper_guidance.strip())
-        requested_product_type = (
-            self.requested_product_type.strip()
-            if isinstance(self.requested_product_type, str)
-            else ""
-        )
-        if self.taxonomy_status in {
-            "image_only",
-            "no_direct_catalog_match",
-        }:
-            if has_shopper_guidance:
-                raise ValueError(
-                    "A non-text retrieval path requires empty shopper_guidance"
-                )
-        elif not has_shopper_guidance:
-            raise ValueError(
-                "catalog retrieval requires non-empty shopper_guidance"
-            )
-        if self.taxonomy_status != "image_only" and not requested_product_type:
-            raise ValueError(
-                "text catalog search requires requested_product_type"
-            )
-        if self.taxonomy_status == "image_only" and requested_product_type:
-            raise ValueError(
-                "image-only search requires requested_product_type=null"
-            )
-        if self.taxonomy_status == "no_direct_catalog_match":
-            if has_taxonomy:
-                raise ValueError(
-                    "a non-retrieval result requires empty taxonomy arrays"
-                )
-            if not has_query:
-                raise ValueError(
-                    "a non-retrieval result requires a requested product type"
-                )
-            constraints = (
-                self.required_constraints.model_dump(exclude_none=True)
-                if isinstance(self.required_constraints, BaseModel)
-                else self.required_constraints
-            )
-            has_constraint = any(
-                value not in (None, "", [], {})
-                for value in constraints.values()
-            )
-            if has_constraint:
-                raise ValueError(
-                    "a non-retrieval result cannot include required constraints"
-                )
-            return self
-        if self.taxonomy_status == "image_only":
-            if has_query or has_taxonomy:
-                raise ValueError(
-                    "image-only search requires an empty semantic query and taxonomy"
-                )
-            return self
-        if self.taxonomy_status == "member_of_requested_umbrella" and not (
-            self.taxonomy.subcategory
-        ):
-            raise ValueError(
-                "an umbrella search requires an advertised subcategory"
-            )
-        if self.taxonomy_status == "agent_selected_type" and not (
-            self.taxonomy.subcategory
-        ):
-            raise ValueError(
-                "an open-role search requires an advertised subcategory"
-            )
-        if self.taxonomy_status == "parent_category_alternative" and not (
-            len(self.taxonomy.category) == 1
-            and not self.taxonomy.subcategory
-        ):
-            raise ValueError(
-                "a parent-category alternative requires one advertised category "
-                "and no subcategory"
-            )
-        if has_query and not has_taxonomy:
-            raise ValueError(
-                "text catalog search requires an advertised category or subcategory"
-            )
-        if not has_query:
-            raise ValueError("text catalog search requires a semantic query")
-        return self
-
-
-def _exact_taxonomy_issue(
-    requested_product_type: str,
-    taxonomy: BaseModel | dict[str, Any],
-) -> str | None:
-    """Return a coherence issue for an exact taxonomy claim."""
-
-    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
-    categories = payload.get("category") or []
-    subcategories = payload.get("subcategory") or []
-    requested_matches_category = not subcategories and any(
-        _normalize_product_text(requested_product_type)
-        == _normalize_product_text(category)
-        for category in categories
-    )
-    if requested_matches_category:
-        return None
-
-    selected_product_types = subcategories or categories
-    if len(selected_product_types) != 1:
-        return (
-            "The selected taxonomy must faithfully represent one requested type "
-            "or every child of a shopper-requested umbrella."
-        )
-    selected_product_type = selected_product_types[0]
-    if _normalize_product_text(requested_product_type) == _normalize_product_text(
-        selected_product_type
-    ):
-        return None
-    return (
-        "A single taxonomy value must match requested_product_type. If no "
-        "advertised value faithfully represents it, ask a clarification instead"
-    )
-
-
-class _CatalogNumberConstraint(BaseModel):
-    """Inclusive numeric range accepted by catalog hard filters."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    min: float | None = None
-    max: float | None = None
-
-    @model_validator(mode="after")
-    def has_a_bound(self) -> "_CatalogNumberConstraint":
-        if self.min is None and self.max is None:
-            raise ValueError("numeric constraint requires min and/or max")
-        if self.min is not None and self.max is not None and self.min > self.max:
-            raise ValueError("numeric constraint min cannot exceed max")
-        return self
-
-
-def _search_catalog_tool_input_model(
-    capabilities: CatalogCapabilities,
-    *,
-    validate_scope: bool = True,
-) -> type[SearchCatalogToolArguments]:
-    """Create one tool schema whose enums come from the active catalog."""
-
-    taxonomy = capabilities.taxonomy
-    advertised_search_modes = tuple(dict.fromkeys(capabilities.retrieval_modes))
-    search_mode_type = (
-        Literal.__getitem__(advertised_search_modes)
-        if advertised_search_modes
-        else str
-    )
-    category_values = (
-        sorted(taxonomy.categories, key=str.casefold)
-        if taxonomy.category_field
-        else []
-    )
-    subcategory_values = (
-        sorted(
-            {
-                name
-                for category in taxonomy.categories.values()
-                for name in category.subcategories
-            },
-            key=str.casefold,
-        )
-        if taxonomy.subcategory_field
-        else []
-    )
-
-    category_type, category_field = _taxonomy_list_field(
-        category_values,
-        role="category",
-        advertised_field=taxonomy.category_field,
-    )
-    subcategory_type, subcategory_field = _taxonomy_list_field(
-        subcategory_values,
-        role="subcategory",
-        advertised_field=taxonomy.subcategory_field,
-    )
-    taxonomy_model = create_model(
-        "CatalogTaxonomySelection",
-        __base__=CatalogTaxonomyToolInput,
-        category=(category_type, category_field),
-        subcategory=(subcategory_type, subcategory_field),
-    )
-    required_constraints_model = _required_constraints_input_model(
-        capabilities,
-    )
-    return create_model(
-        "CatalogSearchInput" if validate_scope else "CatalogSearchToolArguments",
-        __base__=(
-            SearchCatalogToolInput
-            if validate_scope
-            else SearchCatalogToolArguments
-        ),
-        taxonomy=(
-            taxonomy_model,
-            Field(
-                ...,
-                description=(
-                    "Required taxonomy selection generated from the active catalog. "
-                    "Use exact enum values. A text search requires at least one "
-                    "category or subcategory; both arrays may be empty only for "
-                    "an image-only search."
-                    " Every value must be a kind of the requested scope: skirts "
-                    "may satisfy bottoms; dresses may not. For a broad request "
-                    "that names no product type, choose one exact advertised "
-                    "subcategory as the focused starting role. If a shopper-named "
-                    "type is not separately advertised but one faithful broader "
-                    "advertised parent category exists, select only that category "
-                    "and leave subcategory empty."
-                ),
-            ),
-        ),
-        required_constraints=(
-            required_constraints_model,
-            Field(
-                ...,
-                description=(
-                    "Catalog hard filters and any defining requirement the active "
-                    "catalog cannot enforce. Apply constraints only when the "
-                    "current turn states them for the target products; an anchor's "
-                    "attributes belong in semantic styling context unless the "
-                    "shopper explicitly requests the same value. Use only the "
-                    "advertised properties "
-                    "in this object; put unsupported must-haves in "
-                    "unadvertised_requirements instead of weakening them. For "
-                    "'Do you have water-resistant bags?', use "
-                    "{'unadvertised_requirements': ['water resistance']}. Do not "
-                    "put broad season, weather, occasion, or subjective style/vibe "
-                    "context here unless the shopper directly requires a product "
-                    "attribute. 'Rainy day outfit' does not require water "
-                    "resistance; 'water-resistant bags' does. Recommendation "
-                    "adjectives such as comfortable, relaxed, soft, breathable, "
-                    "lightweight, casual, dressy, bold, bright, vibrant, or "
-                    "sporty are always semantic ranking preferences, not "
-                    "objective hard filters. Before calling the tool, compare "
-                    "every target-product modifier with this advertised schema "
-                    "and include every exact matching filter value. A product type "
-                    "never belongs in unadvertised_requirements. Use an empty "
-                    "object for image-only search."
-                ),
-            ),
-        ),
-        search_mode=(
-            search_mode_type | None,
-            Field(
-                default=None,
-                description="Optional search mode advertised by the active catalog.",
-            ),
-        ),
-    )
-
-
-def _taxonomy_list_field(
-    values: list[str],
-    *,
-    role: str,
-    advertised_field: str | None,
-) -> tuple[Any, Any]:
-    field_name = advertised_field or "not advertised"
-    description = (
-        f"Exact {role} values advertised through catalog field '{field_name}'. "
-        "Use an empty list when the other taxonomy role supplies the text scope or "
-        "the search is image-only."
-    )
-    if role == "category":
-        description += " Select at most one category per catalog search."
-    if not values:
-        return list[str], Field(..., max_length=0, description=description)
-
-    literal_type = Literal.__getitem__(tuple(values))
-    max_length = 1 if role == "category" else None
-    return list[literal_type], Field(
-        ...,
-        max_length=max_length,
-        description=description,
-    )
-
-
-def _required_constraints_input_model(
-    capabilities: CatalogCapabilities,
-) -> type[BaseModel]:
-    """Create a hard-constraint schema from advertised catalog filters."""
-
-    taxonomy_fields = {
-        field_name
-        for field_name in (
-            capabilities.taxonomy.category_field,
-            capabilities.taxonomy.subcategory_field,
-        )
-        if field_name
-    }
-    fields: dict[str, tuple[Any, Any]] = {}
-    for name, capability in sorted(effective_filter_capabilities(capabilities).items()):
-        if name in taxonomy_fields:
-            continue
-        if capability.type in {"enum", "enum_list"} and capability.values:
-            value_type = Literal.__getitem__(tuple(capability.values))
-            field_type = value_type | list[value_type] | None
-        elif capability.type == "number":
-            field_type = _CatalogNumberConstraint | None
-        else:
-            field_type = str | list[str] | None
-        fields[name] = (
-            field_type,
-            Field(
-                default=None,
-                description=f"Advertised hard filter '{name}'.",
-            ),
-        )
-    fields["unadvertised_requirements"] = (
-        list[str],
-        Field(
-            default_factory=list,
-            description=(
-                "Only objective product requirements directly stated in the "
-                "current shopper turn and absent from this schema. Never infer a "
-                "requirement from season, weather, occasion, or subjective "
-                "style/vibe context: 'rainy day outfit' produces an empty list. "
-                "Use ['water resistance'] for 'water-resistant bags' because that "
-                "turn directly states the product requirement. Never omit or "
-                "soften a directly stated objective requirement. Subjective "
-                "recommendation adjectives such as comfortable, relaxed, soft, "
-                "breathable, lightweight, casual, dressy, bold, bright, vibrant, "
-                "or sporty always stay semantic; never put them in this field. "
-                "Before calling the tool, include every exact advertised filter "
-                "value that modifies the target product; do not leave this object "
-                "empty when one applies. "
-                "In an 'A or B' request, do not put the "
-                "supported advertised branch here. A product type never belongs "
-                "here."
-            ),
-        ),
-    )
-    return create_model(
-        "CatalogRequiredConstraints",
-        __config__=ConfigDict(extra="forbid"),
-        **fields,
-    )
-
-
-class _ShopperSkillActivationInput(BaseModel):
-    """Shared composition rules for dynamic shopper-skill activation."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    skill_names: list[str]
-
-    @model_validator(mode="after")
-    def primary_procedures_are_exclusive(self) -> "_ShopperSkillActivationInput":
-        selected = set(self.skill_names)
-        primary = selected.intersection(
-            {"outfit-styling", "product-discovery"}
-        )
-        if len(primary) > 1:
-            raise PydanticCustomError(
-                SKILL_ACTIVATION_MULTIPLE_PRIMARY,
-                "select exactly one primary procedure: outfit-styling or "
-                "product-discovery, never both",
-            )
-        if "budget-shopping" in selected and len(primary) != 1:
-            raise PydanticCustomError(
-                SKILL_ACTIVATION_MODIFIER_REQUIRES_PRIMARY,
-                "budget-shopping requires exactly one primary procedure: "
-                "outfit-styling or product-discovery",
-            )
-        return self
-
-
-def _skill_activation_input_model(
-    skill_names: tuple[str, ...],
-) -> type[BaseModel]:
-    """Create the semantic skill-selection schema from the active registry."""
-
-    skill_name_type = Literal.__getitem__(skill_names)
-    return create_model(
-        "ShopperSkillActivationInput",
-        __base__=_ShopperSkillActivationInput,
-        skill_names=(
-            list[skill_name_type],
-            Field(
-                ...,
-                min_length=1,
-                max_length=len(skill_names),
-                description=(
-                    "Smallest set of registered shopper skills whose descriptions "
-                    "cover the current turn's complete intent. For product search "
-                    "or styling, select exactly one primary procedure: outfit-"
-                    "styling or product-discovery, never both. Cart and policy "
-                    "intents may select their standalone skill without a primary."
-                ),
-            ),
-        ),
-    )
-
-
-def _taxonomy_hard_constraints(
-    selection: BaseModel | dict[str, Any],
-    capabilities: CatalogCapabilities,
-) -> tuple[dict[str, list[str]], list[str]]:
-    """Map generic taxonomy roles to catalog-owned hard-filter field names."""
-
-    raw = selection.model_dump() if isinstance(selection, BaseModel) else selection
-    categories = sorted(set(raw.get("category", [])), key=str.casefold)
-    subcategories = sorted(set(raw.get("subcategory", [])), key=str.casefold)
-    taxonomy = capabilities.taxonomy
-    issues: list[str] = []
-
-    for category in categories:
-        if category not in taxonomy.categories:
-            issues.append(f"category '{category}' is not advertised")
-
-    owners: dict[str, list[str]] = {
-        subcategory: sorted(
-            [
-                category_name
-                for category_name, category in taxonomy.categories.items()
-                if subcategory in category.subcategories
-            ],
-            key=str.casefold,
-        )
-        for subcategory in subcategories
-    }
-    for subcategory, subcategory_owners in owners.items():
-        if not subcategory_owners:
-            issues.append(f"subcategory '{subcategory}' is not advertised")
-        elif categories and not set(categories).intersection(subcategory_owners):
-            issues.append(
-                f"subcategory '{subcategory}' is not available in selected categories"
-            )
-
-    if categories and subcategories:
-        for category in categories:
-            advertised = taxonomy.categories.get(category)
-            if advertised is None:
-                continue
-            if not set(subcategories).intersection(advertised.subcategories):
-                issues.append(
-                    f"category '{category}' has no selected subcategory"
-                )
-
-    effective_categories = categories
-    if subcategories and not categories:
-        inferred_categories = sorted(
-            {
-                owner
-                for subcategory_owners in owners.values()
-                for owner in subcategory_owners
-            },
-            key=str.casefold,
-        )
-        if len(inferred_categories) > 1:
-            issues.append(
-                "subcategory selection has multiple owning categories; select "
-                "exactly one advertised category"
-            )
-            effective_categories = []
-        else:
-            effective_categories = inferred_categories
-
-    constraints: dict[str, list[str]] = {}
-    if effective_categories:
-        if taxonomy.category_field:
-            constraints[taxonomy.category_field] = effective_categories
-        else:
-            issues.append("the catalog does not advertise a category filter field")
-    if subcategories:
-        if taxonomy.subcategory_field:
-            constraints[taxonomy.subcategory_field] = subcategories
-        else:
-            issues.append("the catalog does not advertise a subcategory filter field")
-    return constraints, issues
-
-
-def _catalog_search_scope(
-    taxonomy: dict[str, list[str]],
-    required_constraints: dict[str, Any],
-) -> dict[str, Any]:
-    """Return the normalized hard-filter identity for one catalog search."""
-
-    return {
-        "taxonomy": _normalized_scope_value(taxonomy),
-        "required_constraints": _normalized_scope_value(required_constraints),
-    }
-
-
-def _normalized_scope_value(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {
-            key: _normalized_scope_value(item)
-            for key, item in sorted(value.items())
-        }
-    if isinstance(value, list):
-        normalized = [_normalized_scope_value(item) for item in value]
-        return sorted(normalized, key=lambda item: json.dumps(item, sort_keys=True))
-    return value
-
-
-class AddCartItemsToolItemInput(BaseModel):
-    product_ref: str = Field(
-        ...,
-        min_length=1,
-        description="PRODUCT_REF returned by search_catalog_tool in this conversation.",
-    )
-    quantity: int = Field(
-        default=1,
-        ge=1,
-        description="Quantity of this product to add.",
-    )
-    expected_display_name: str | None = Field(
-        default=None,
-        description=(
-            "Shopper-facing product name the agent intends to add. When the "
-            "shopper explicitly names the product, copy that exact product name."
-        ),
-    )
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 class AddCartItemsToolInput(BaseModel):
@@ -1634,39 +505,8 @@ class _CheckAvailabilityInput(BaseModel):
     )
 
 
-@dataclass(frozen=True)
-class RequestIdentity:
-    """Server-owned identity used to scope one assistant turn."""
-
-    session_id: str
-    conversation_id: str
-    cart_id: str
-    context_user_id: int
-    cart_user_id: int
-    request_id: str
-    shopper_profile_id: str | None = None
-
-    @property
-    def legacy_user_id(self) -> int:
-        return self.context_user_id
-
-    @property
-    def checkpoint_thread_id(self) -> str:
-        return json.dumps(
-            [self.conversation_id, self.request_id],
-            separators=(",", ":"),
-        )
 
 
-def _conversation_turn_status(termination_reason: str) -> FinalTurnStatus:
-    if termination_reason in {
-        "input_guardrail_blocked",
-        "output_guardrail_blocked",
-    }:
-        return "blocked"
-    if termination_reason == "completed":
-        return "completed"
-    return "failed"
 
 
 class DeepAgentsRuntime:
@@ -4554,1755 +3394,164 @@ Rules:
         return responses[0].get("content") == text, True
 
 
-def create_request_identity(
-    *,
-    legacy_user_id: int,
-    session_id: str | None = None,
-    conversation_id: str | None = None,
-    cart_id: str | None = None,
-    request_id: str | None = None,
-    shopper_profile_id: str | None = None,
-) -> RequestIdentity:
-    """Create scoped request identity while preserving legacy user_id behavior."""
-
-    session = session_id or f"legacy-session-{legacy_user_id}"
-    conversation = conversation_id or f"legacy-conversation-{legacy_user_id}"
-    cart = cart_id or f"legacy-cart-{legacy_user_id}"
-    return RequestIdentity(
-        session_id=session,
-        conversation_id=conversation,
-        cart_id=cart,
-        context_user_id=(
-            _stable_numeric_id("conversation", conversation_id)
-            if conversation_id
-            else legacy_user_id
-        ),
-        cart_user_id=_stable_numeric_id("cart", cart_id) if cart_id else legacy_user_id,
-        request_id=request_id or str(uuid.uuid4()),
-        shopper_profile_id=shopper_profile_id,
-    )
-
-
-def _stable_numeric_id(namespace: str, value: str) -> int:
-    digest = hashlib.sha256(f"{namespace}:{value}".encode("utf-8")).hexdigest()
-    return int(digest[:15], 16)
-
-
-def _empty_agent_diagnostics(final_termination_reason: str) -> dict[str, Any]:
-    return {
-        "skill_files_read": [],
-        "tool_calls": [],
-        "rejected_tool_calls": [],
-        "duplicate_tool_calls": [],
-        "product_evidence": [],
-        "product_evidence_truncated": False,
-        "catalog_scope_outcomes": [],
-        "final_termination_reason": final_termination_reason,
-        "partial_graph_messages": [],
-    }
-
-
-async def _partial_graph_messages(
-    agent: Any,
-    invoke_config: dict[str, Any],
-) -> tuple[list[Any], str | None]:
-    """Read the last graph state before its failed checkpoint is deleted."""
-
-    get_state = getattr(agent, "aget_state", None)
-    if get_state is None:
-        return [], "state_snapshot_unavailable"
-    try:
-        snapshot = await asyncio.wait_for(
-            get_state(invoke_config),
-            timeout=_PARTIAL_GRAPH_SNAPSHOT_TIMEOUT_SECONDS,
-        )
-    except TimeoutError:
-        logger.warning("Timed out snapshotting Deep Agents state before cleanup")
-        return [], "state_snapshot_timeout"
-    except Exception as exc:  # noqa: BLE001 - diagnostics cannot block cleanup.
-        error_type = type(exc).__name__
-        logger.warning(
-            "Could not snapshot Deep Agents state before cleanup: %s",
-            error_type,
-        )
-        return [], error_type
-
-    values = _value(snapshot, "values")
-    messages = _value(values, "messages")
-    return (messages if isinstance(messages, list) else []), None
-
-
-def _collect_agent_diagnostics(
-    messages: list[Any],
-    *,
-    request_id: str,
-    final_termination_reason: str,
-    preserve_partial_messages: bool = False,
-) -> dict[str, Any]:
-    """Collect current-turn skill, tool, and termination diagnostics."""
-
-    diagnostics = _empty_agent_diagnostics(final_termination_reason)
-    turn_messages = _current_turn_messages(messages, request_id)
-    tool_results = _tool_results_by_call_id(turn_messages)
-    skill_files_read: list[str] = []
-    successful_product_tool_calls: dict[str, str] = {}
-
-    for message in turn_messages:
-        if _message_type(message) != "ai":
-            continue
-        calls = [
-            (raw_call, None)
-            for raw_call in (_value(message, "tool_calls") or [])
-        ]
-        additional_kwargs = _value(message, "additional_kwargs") or {}
-        restored_fields_by_call: dict[str, list[str]] = {}
-        if isinstance(additional_kwargs, dict):
-            restored_calls = additional_kwargs.get(
-                SERVER_RESTORED_TOOL_CALL_FIELDS
-            )
-            if isinstance(restored_calls, list):
-                for restored_call in restored_calls[:8]:
-                    tool_call_id = str(
-                        _value(restored_call, "tool_call_id") or ""
-                    )
-                    fields = _value(restored_call, "fields")
-                    if not tool_call_id or not isinstance(fields, list):
-                        continue
-                    restored_fields_by_call[tool_call_id] = [
-                        str(field)[:64] for field in fields[:8]
-                    ]
-            calls.extend(
-                (raw_call, str(_value(raw_call, "rejection_reason") or "rejected"))
-                for raw_call in (
-                    additional_kwargs.get(_SERVER_REJECTED_TOOL_CALLS) or []
-                )
-            )
-        for raw_call, forced_rejection_reason in calls:
-            call = _normalized_tool_call(raw_call)
-            sequence = len(diagnostics["tool_calls"]) + 1
-            result_message = tool_results.get(call["tool_call_id"])
-            if forced_rejection_reason:
-                status, rejection_reason = "rejected", forced_rejection_reason
-            else:
-                status, rejection_reason = _tool_call_status(
-                    call["tool_name"],
-                    result_message,
-                )
-            entry = {
-                "sequence": sequence,
-                "tool_name": call["tool_name"],
-                "arguments": call["arguments"],
-                "status": status,
-            }
-            if rejection_reason:
-                entry["rejection_reason"] = rejection_reason
-            restored_fields = restored_fields_by_call.get(call["tool_call_id"])
-            if restored_fields:
-                entry["restored_fields"] = restored_fields
-            if rejection_reason == "duplicate_catalog_scope":
-                entry["duplicate"] = True
-                diagnostics["duplicate_tool_calls"].append(sequence)
-            if status == "rejected":
-                diagnostics["rejected_tool_calls"].append(sequence)
-            diagnostics["tool_calls"].append(entry)
-
-            if (
-                status == "completed"
-                and call["tool_call_id"]
-                and call["tool_name"]
-                in {"search_catalog_tool", "get_product_details_tool"}
-            ):
-                successful_product_tool_calls[call["tool_call_id"]] = call[
-                    "tool_name"
-                ]
-
-            for skill_path in _skill_file_paths(call, status):
-                if skill_path not in skill_files_read:
-                    skill_files_read.append(skill_path)
-
-    diagnostics["skill_files_read"] = skill_files_read
-    product_evidence, product_evidence_truncated = _diagnostic_product_evidence(
-        turn_messages,
-        successful_product_tool_calls,
-    )
-    diagnostics["product_evidence"] = product_evidence
-    diagnostics["product_evidence_truncated"] = product_evidence_truncated
-    diagnostics["catalog_scope_outcomes"] = _diagnostic_catalog_scope_outcomes(
-        turn_messages
-    )
-    if preserve_partial_messages:
-        partial, truncated = _serialize_partial_graph_messages(turn_messages)
-        diagnostics["partial_graph_messages"] = partial
-        if truncated:
-            diagnostics["partial_graph_messages_truncated"] = True
-    return diagnostics
-
-
-def _safe_collect_agent_diagnostics(
-    messages: list[Any],
-    *,
-    request_id: str,
-    final_termination_reason: str,
-    preserve_partial_messages: bool = False,
-) -> dict[str, Any]:
-    """Collect diagnostics without allowing tracing to change turn behavior."""
-
-    try:
-        return _collect_agent_diagnostics(
-            messages,
-            request_id=request_id,
-            final_termination_reason=final_termination_reason,
-            preserve_partial_messages=preserve_partial_messages,
-        )
-    except Exception as exc:  # noqa: BLE001 - diagnostics must fail independently.
-        error_type = type(exc).__name__
-        logger.warning("Could not collect Deep Agents diagnostics: %s", error_type)
-        diagnostics = _empty_agent_diagnostics(final_termination_reason)
-        diagnostics["diagnostic_collection_error"] = error_type
-        return diagnostics
-
-
-
-
-
-
-def _no_direct_taxonomy_response(
-    result: Any,
-    *,
-    request_id: str,
-) -> str | None:
-    """Return the fixed shopper response for a current-turn no-match result."""
-
-    outcomes = _business_tool_result_contents(
-        _current_turn_messages(_result_messages(result), request_id)
-    )
-    no_direct_outcomes = [
-        content
-        for content in outcomes
-        if content.startswith(
-            f"{STOP_TOOL_USE_PREFIX} No faithful advertised catalog taxonomy"
-        )
-    ]
-    repair_or_no_direct = all(
-        content.startswith(
-            (
-                SEARCH_VALIDATION_ERROR_PREFIX,
-                f"{STOP_TOOL_USE_PREFIX} No faithful advertised catalog taxonomy",
-            )
-        )
-        for content in outcomes
-    )
-    if no_direct_outcomes and repair_or_no_direct:
-        return _NO_DIRECT_TAXONOMY_RESPONSE
-    return None
-
-
-def _rejected_catalog_search_response(
-    result: Any,
-    *,
-    request_id: str,
-) -> str | None:
-    """Fail closed when every current-turn business call is a rejected search."""
-
-    messages = _current_turn_messages(_result_messages(result), request_id)
-    tool_results = _tool_results_by_call_id(messages)
-    business_calls: list[tuple[str, str]] = []
-    for message in messages:
-        if _message_type(message) != "ai":
-            continue
-        calls = [
-            (raw_call, False)
-            for raw_call in (_value(message, "tool_calls") or [])
-        ]
-        additional_kwargs = _value(message, "additional_kwargs") or {}
-        if isinstance(additional_kwargs, dict):
-            calls.extend(
-                (raw_call, True)
-                for raw_call in (
-                    additional_kwargs.get(_SERVER_REJECTED_TOOL_CALLS) or []
-                )
-            )
-        for raw_call, server_rejected in calls:
-            call = _normalized_tool_call(raw_call)
-            tool_name = call["tool_name"]
-            if tool_name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"}:
-                continue
-            status = (
-                "rejected"
-                if server_rejected
-                else _tool_call_status(
-                    tool_name,
-                    tool_results.get(call["tool_call_id"]),
-                )[0]
-            )
-            business_calls.append((tool_name, status))
-
-    if not business_calls:
-        return None
-    if _catalog_repair_clarification_response(
-        result,
-        request_id=request_id,
-    ):
-        return None
-    if all(
-        tool_name == "search_catalog_tool" and status == "rejected"
-        for tool_name, status in business_calls
-    ):
-        return _REJECTED_CATALOG_SEARCH_RESPONSE
-    return None
-
-
-def _catalog_repair_clarification_response(
-    result: Any,
-    *,
-    request_id: str,
-) -> str:
-    """Return a fixed response for a server-marked no-tool repair branch."""
-
-    messages = _current_turn_messages(_result_messages(result), request_id)
-    for message in reversed(messages):
-        if _message_type(message) != "ai" or _value(message, "tool_calls"):
-            continue
-        additional_kwargs = _value(message, "additional_kwargs") or {}
-        if not isinstance(additional_kwargs, dict) or not additional_kwargs.get(
-            SERVER_CATALOG_CLARIFICATION
-        ):
-            continue
-        return _CATALOG_REPAIR_CLARIFICATION_RESPONSE
-    return ""
-
-
-
-
-def _business_tool_result_contents(messages: list[Any]) -> list[str]:
-    """Return non-activation tool outcomes in graph order."""
-
-    outcomes: list[str] = []
-    for message in messages:
-        if _message_type(message) != "tool":
-            continue
-        name = str(_value(message, "name") or "")
-        content = _content_to_text(_value(message, "content"))
-        if name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"} or content.startswith(
-            (
-                SKILL_ACTIVATION_COMPLETE,
-                SKILL_ACTIVATION_REQUIRED,
-                SKILL_TOOL_NOT_GRANTED,
-                "SHOPPER_SKILL_ACTIVATION_FAILED:",
-            )
-        ):
-            continue
-        outcomes.append(content)
-    return outcomes
-
-
-def _has_unsupported_requirement_outcome(
-    result: Any,
-    *,
-    request_id: str,
-) -> bool:
-    """Return whether the current turn contains an unenforceable requirement."""
-
-    return any(
-        _message_type(message) == "tool"
-        and _content_to_text(_value(message, "content")).startswith(
-            UNSUPPORTED_CONSTRAINT_PREFIX
-        )
-        for message in _current_turn_messages(
-            _result_messages(result),
-            request_id,
-        )
-    )
-
-
-
-
-def _normalized_tool_call(raw_call: Any) -> dict[str, Any]:
-    arguments = _value(raw_call, "args")
-    if isinstance(arguments, str):
-        try:
-            arguments = json.loads(arguments)
-        except json.JSONDecodeError:
-            arguments = {"value": arguments}
-    if not isinstance(arguments, dict):
-        arguments = {} if arguments is None else {"value": arguments}
-    return {
-        "tool_call_id": str(_value(raw_call, "id") or ""),
-        "tool_name": str(_value(raw_call, "name") or "unknown"),
-        "arguments": _diagnostic_json_value(arguments),
-    }
-
-
-def _tool_call_status(
-    tool_name: str,
-    result_message: Any | None,
-) -> tuple[str, str | None]:
-    if result_message is None:
-        return "pending", None
-    content = _content_to_text(_value(result_message, "content"))
-    rejection_reason = _tool_rejection_reason(content)
-    if rejection_reason:
-        return "rejected", rejection_reason
-    if _value(result_message, "status") == "error":
-        return "error", None
-    if tool_name == "read_file" and content.lower().startswith(
-        ("error", "file not found")
-    ):
-        return "error", None
-    return "completed", None
-
-
-def _tool_rejection_reason(content: str) -> str | None:
-    markers = (
-        (SKILL_ACTIVATION_REQUIRED, "skill_activation_required"),
-        (SKILL_TOOL_NOT_GRANTED, "skill_tool_not_granted"),
-        ("SHOPPER_SKILL_ACTIVATION_FAILED:", "skill_activation_failed"),
-        (
-            f"{STOP_TOOL_USE_PREFIX} This catalog taxonomy and constraint scope was already searched",
-            "duplicate_catalog_scope",
-        ),
-        (f"{STOP_TOOL_USE_PREFIX} Catalog search limit reached", "catalog_search_limit"),
-        (
-            "STOP_TOOL_USE: No faithful advertised catalog taxonomy",
-            "no_advertised_taxonomy_match",
-        ),
-        (
-            f"{STOP_TOOL_USE_PREFIX} Product-detail read limit reached",
-            "product_detail_read_limit",
-        ),
-        (
-            "The catalog search request does not match current capabilities:",
-            "invalid_catalog_request",
-        ),
-        (SEARCH_VALIDATION_ERROR_PREFIX, "invalid_catalog_request"),
-        (CONSTRAINT_REVIEW_PREFIX, "constraint_review_required"),
-        (
-            UNSUPPORTED_TAXONOMY_PREFIX,
-            "unsupported_catalog_taxonomy",
-        ),
-        (
-            UNSUPPORTED_CONSTRAINT_PREFIX,
-            "unsupported_catalog_constraint",
-        ),
-        (_UNSUPPORTED_SEARCH_MODE_MESSAGE, "unsupported_search_mode"),
-    )
-    for marker, reason in markers:
-        if content.startswith(marker):
-            return reason
-    if content.startswith(STOP_TOOL_USE_PREFIX):
-        return "stop_tool_use"
-    return None
-
-
-def _skill_file_paths(call: dict[str, Any], status: str) -> list[str]:
-    if status != "completed":
-        return []
-    arguments = call["arguments"]
-    if call["tool_name"] == SKILL_ACTIVATION_TOOL_NAME:
-        names = arguments.get("skill_names") or []
-        if not isinstance(names, list):
-            return []
-        return [
-            f"/shopper/{name}/SKILL.md"
-            for name in names
-            if isinstance(name, str) and name.strip()
-        ]
-    if call["tool_name"] != "read_file":
-        return []
-    path = str(arguments.get("file_path") or arguments.get("path") or "")
-    normalized = path.replace("\\", "/")
-    if normalized.startswith("/shopper/") and normalized.endswith("/SKILL.md"):
-        return [normalized]
-    return []
-
-
-def _serialize_partial_graph_messages(
-    messages: list[Any],
-) -> tuple[list[dict[str, Any]], bool]:
-    relevant = [
-        message for message in messages if _message_type(message) in {"ai", "tool"}
-    ]
-    truncated = len(relevant) > 24
-    serialized: list[dict[str, Any]] = []
-    for message in relevant[-24:]:
-        content = _content_to_text(_value(message, "content"))
-        content_truncated = len(content) > 2000
-        payload: dict[str, Any] = {
-            "type": _message_type(message),
-            "content": content[:2000],
-        }
-        for field in ("name", "tool_call_id"):
-            value = _value(message, field)
-            if value:
-                payload[field] = str(value)
-        tool_calls = _value(message, "tool_calls")
-        if tool_calls:
-            payload["tool_calls"] = [
-                _normalized_tool_call(call) for call in tool_calls
-            ]
-        if content_truncated:
-            payload["truncated"] = True
-            truncated = True
-        serialized.append(payload)
-    return serialized, truncated
-
-
-
-
-def _diagnostic_json_value(value: Any) -> Any:
-    if isinstance(value, BaseModel):
-        return value.model_dump(mode="json")
-    if isinstance(value, dict):
-        return {
-            str(key): _diagnostic_json_value(item) for key, item in value.items()
-        }
-    if isinstance(value, (list, tuple)):
-        return [_diagnostic_json_value(item) for item in value]
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    return str(value)
-
-
-def _diagnostic_product_evidence(
-    messages: list[Any],
-    successful_tool_calls: dict[str, str],
-) -> tuple[list[dict[str, Any]], bool]:
-    """Return bounded product facts from successful current-turn tool results."""
-
-    evidence: list[dict[str, Any]] = []
-    truncated = False
-    aggregate_limit_reached = False
-    for message in messages:
-        if _message_type(message) != "tool":
-            continue
-
-        tool_call_id = str(_value(message, "tool_call_id") or "")
-        source_tool = successful_tool_calls.get(tool_call_id)
-        payload = evidence_of(message)
-        if source_tool == "search_catalog_tool":
-            if not payload or payload.get("outcome") != "results":
-                continue
-            evidence_type = "search_result"
-            search_scope = {
-                "taxonomy": _bounded_product_evidence_value(
-                    payload.get("taxonomy") or {}
-                ),
-                "confirmed_filters": _bounded_product_evidence_value(
-                    payload.get("confirmed_filters") or {}
-                ),
-            }
-            records = payload.get("products") or []
-        elif source_tool == "get_product_details_tool":
-            detail = detail_evidence_of(message)
-            if not detail:
-                continue
-            evidence_type = "product_detail"
-            search_scope = None
-            records = detail.get("products") or []
-        else:
-            continue
-
-        for product in records:
-            product_ref = product.get("product_ref")
-            product_name = product.get("name")
-            if not product_ref or not product_name:
-                continue
-            record = {
-                "product_ref": _bounded_product_evidence_value(product_ref),
-                "product_name": _bounded_product_evidence_value(product_name),
-                "source_tool": source_tool,
-                "evidence_type": evidence_type,
-                "facts": _diagnostic_product_facts(product),
-            }
-            if search_scope is not None:
-                record["search_scope"] = search_scope
-            if (
-                len(evidence) >= _MAX_DIAGNOSTIC_PRODUCT_EVIDENCE
-                or aggregate_limit_reached
-            ):
-                truncated = True
-                continue
-            candidate = [*evidence, record]
-            if len(json.dumps(candidate, sort_keys=True, default=str)) > (
-                _MAX_DIAGNOSTIC_PRODUCT_EVIDENCE_CHARS
-            ):
-                truncated = True
-                aggregate_limit_reached = True
-                continue
-            evidence.append(record)
-    return evidence, truncated
-
-
-def _diagnostic_catalog_scope_outcomes(
-    messages: list[Any],
-) -> list[dict[str, Any]]:
-    """Return bounded server-authored outcomes that contain no products."""
-
-    outcomes: list[dict[str, Any]] = []
-    allowed_fields = {
-        "outcome",
-        "requested_product_type",
-        "taxonomy",
-        "confirmed_filters",
-    }
-    for message in messages:
-        if _message_type(message) != "tool":
-            continue
-        payload = evidence_of(message)
-        outcome = (payload or {}).get("scope_outcome") or {}
-        if (
-            not outcome
-            or not set(outcome).issubset(allowed_fields)
-            or outcome.get("outcome")
-            not in {"no_direct_catalog_match", "zero_results"}
-        ):
-            continue
-        bounded = _bounded_product_evidence_value(outcome)
-        if isinstance(bounded, dict) and bounded not in outcomes:
-            outcomes.append(bounded)
-        if len(outcomes) >= 8:
-            break
-    return outcomes
-
-
-def _diagnostic_product_facts(product: dict[str, Any]) -> dict[str, Any]:
-    """Extract bounded, structured facts from one parsed product record."""
-
-    facts: dict[str, Any] = {}
-    for key in ("category", "brand", "price"):
-        value = product.get(key)
-        if value:
-            facts[key] = _bounded_product_evidence_value(value)
-    facts["image_available"] = bool(product.get("image_url"))
-
-    # Attributes the catalog confirmed on a search result. The composer is
-    # allowed to state these, so the evidence trace has to carry them: a fact an
-    # observer cannot see the support for is indistinguishable from an invented
-    # one, and gets judged as invention however accurate it is.
-    attributes = product.get("attributes")
-    if isinstance(attributes, dict):
-        for name, value in attributes.items():
-            if len(facts) >= _MAX_DIAGNOSTIC_PRODUCT_FACTS:
-                break
-            bounded_name = str(_bounded_product_evidence_value(name))
-            if bounded_name and bounded_name not in facts:
-                facts[bounded_name] = _bounded_product_evidence_value(value)
-
-    for raw_detail in product.get("details") or []:
-        if len(facts) >= _MAX_DIAGNOSTIC_PRODUCT_FACTS:
-            break
-        if not isinstance(raw_detail, str) or ":" not in raw_detail:
-            continue
-        name, value = raw_detail.split(":", 1)
-        name = name.strip()
-        value = value.strip()
-        if not name or not value:
-            continue
-        bounded_name = str(_bounded_product_evidence_value(name))
-        if bounded_name not in facts:
-            facts[bounded_name] = _bounded_product_evidence_value(value)
-    return facts
-
-
-def _bounded_product_evidence_value(value: Any, *, depth: int = 0) -> Any:
-    """Bound strings and collections copied into product evidence diagnostics."""
-
-    if isinstance(value, str):
-        return value[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]
-    if value is None or isinstance(value, (int, float, bool)):
-        return value
-    if depth >= 4:
-        return str(value)[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]
-    if isinstance(value, dict):
-        return {
-            str(key)[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]: (
-                _bounded_product_evidence_value(item, depth=depth + 1)
-            )
-            for key, item in list(value.items())[:_MAX_DIAGNOSTIC_PRODUCT_FACTS]
-        }
-    if isinstance(value, (list, tuple)):
-        return [
-            _bounded_product_evidence_value(item, depth=depth + 1)
-            for item in value[:_MAX_DIAGNOSTIC_PRODUCT_FACTS]
-        ]
-    return str(value)[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]
-
-
-
-
-def _append_product_results(state: State, products: list[ProductSummary]) -> None:
-    existing_ids = {
-        str(product.get("product_id") or "")
-        for product in state.product_results
-        if isinstance(product, dict)
-    }
-    for product in products:
-        payload = product.model_dump(mode="json")
-        product_id = str(payload.get("product_id") or "")
-        if product_id and product_id in existing_ids:
-            continue
-        state.product_results.append(payload)
-        if product_id:
-            existing_ids.add(product_id)
-
-
-def _committed_effect_receipt(
-    effects: list[dict[str, Any]],
-    cart: Cart | None,
-) -> str:
-    """Tell the shopper exactly what was committed before the turn failed."""
-
-    lines = [
-        "Something went wrong finishing that request, but a cart change was "
-        "already applied:",
-        "",
-    ]
-    for effect in effects:
-        operation = str(effect.get("operation") or "changed")
-        target = str(
-            effect.get("product_id") or effect.get("cart_line_id") or "an item"
-        )
-        quantity = effect.get("quantity")
-        detail = f" (quantity {quantity})" if isinstance(quantity, int) else ""
-        lines.append(f"- {operation}: {target}{detail}")
-    lines.append("")
-    if cart is not None:
-        lines.append(_format_cart(cart))
-        lines.append("")
-    lines.append(
-        "Please review your cart before retrying so the change is not applied "
-        "twice."
-    )
-    return "\n".join(lines)
-
-
-def _has_grounding_authority(state: State, current_evidence: str) -> bool:
-    """Return whether this turn has any authority to check a draft against.
-
-    Every turn hydrates memory lanes before the model runs. Gating the grounding
-    editor on current-turn *tool* evidence alone discards that hydrated context:
-    a follow-up or styling turn grounded in the historical product index or the
-    authoritative cart would skip grounding entirely, leaving the draft free to
-    assert product facts nothing supports.
-
-    Dialogue is deliberately excluded. It establishes shopper intent, never
-    product, policy, inventory, or cart fact, so it is not something a product
-    claim can be checked against.
-    """
-
-    return bool(
-        current_evidence
-        or state.historical_product_sets
-        or state.cart.contents
-    )
-
-
-def _partial_product_results_response(state: State) -> str:
-    products = [
-        product for product in state.product_results if isinstance(product, dict)
-    ]
-    if not products:
-        return ""
-
-    lines = [
-        "I found these grounded catalog options so far:",
-        "",
-    ]
-    seen: set[str] = set()
-    for product in products[:8]:
-        name = str(product.get("display_name") or "").strip()
-        if not name or name in seen:
-            continue
-        seen.add(name)
-        parts = [f"**{name}**"]
-        category = str(product.get("category") or "").strip()
-        if category:
-            parts.append(category)
-        price = _product_result_price(product)
-        if price:
-            parts.append(price)
-        lines.append("- " + " — ".join(parts))
-
-    if len(lines) <= 2:
-        return ""
-    lines.extend(
-        [
-            "",
-            (
-                "I do not want to overstate outdoor performance, material, care, "
-                "or fit details without a completed detail check. I can continue "
-                "from these options or narrow one piece at a time."
-            ),
-        ]
-    )
-    return "\n".join(lines)
-
-
-def _has_search_only_tool_evidence(result: Any, *, request_id: str) -> bool:
-    """Return whether current-turn commerce evidence contains only searches."""
-
-    tool_names: list[str] = []
-    has_search_result = False
-    for message in _current_turn_messages(_result_messages(result), request_id):
-        if _message_type(message) != "tool":
-            continue
-        name = str(_value(message, "name") or "")
-        returned_results = (evidence_of(message) or {}).get("outcome") == "results"
-        if not name and returned_results:
-            name = "search_catalog_tool"
-        if name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"}:
-            continue
-        tool_names.append(name)
-        if name == "search_catalog_tool" and returned_results:
-            has_search_result = True
-    return (
-        has_search_result
-        and set(tool_names) == {"search_catalog_tool"}
-    )
-
-
-def _has_successful_non_search_tool_evidence(
-    result: Any,
-    *,
-    request_id: str,
-) -> bool:
-    """Return whether another current-turn shopping tool completed."""
-
-    for message in _current_turn_messages(_result_messages(result), request_id):
-        if _message_type(message) != "tool":
-            continue
-        tool_name = str(_value(message, "name") or "")
-        if tool_name in {
-            "",
-            SKILL_ACTIVATION_TOOL_NAME,
-            "read_file",
-            "search_catalog_tool",
-        }:
-            continue
-        if _tool_call_status(tool_name, message)[0] == "completed":
-            return True
-    return False
-
-
-def _format_search_only_response(
-    state: State,
-    result: Any,
-    *,
-    request_id: str,
-    products: list[dict[str, Any]] | None = None,
-    intro: str = "",
-    heading: str = "Catalog candidates (verified name, price, and category):",
-) -> str:
-    """Render grounded search facts without interpreting display-name words."""
-
-    search_groups = _search_result_groups(result, request_id=request_id)
-    grouped_lines, grouped_names = _grouped_search_response_lines(search_groups)
-    if len(grouped_lines) > 0:
-        lines = grouped_lines
-        displayed_names = grouped_names
-    else:
-        displayed_products = (
-            products
-            if products is not None
-            else [
-                product
-                for product in state.product_results
-                if isinstance(product, dict)
-            ]
-        )
-        candidate_count = len(displayed_products)
-        if intro.strip():
-            lines = [
-                "General guidance (not product-specific facts):",
-                intro.strip(),
-                "",
-            ]
-        else:
-            noun = "candidate" if candidate_count == 1 else "candidates"
-            lines = [f"I found {candidate_count} catalog {noun}.", ""]
-        lines.extend((heading, ""))
-        displayed_names = set()
-        for product in displayed_products:
-            name = str(product.get("display_name") or "").strip()
-            if not name:
-                continue
-            displayed_names.add(name)
-            parts = [f"**{name}**"]
-            price = _product_result_price(product)
-            if price:
-                parts.append(price)
-            category = str(product.get("category") or "").strip()
-            if category:
-                parts.append(category.replace("_", " "))
-            lines.append("- " + " — ".join(parts))
-
-    parent_relations = []
-    for group in search_groups:
-        relation = group.get("scope_relation") or {}
-        requested_type = str(
-            relation.get("requested_product_type") or ""
-        ).strip()
-        category = str(relation.get("advertised_category") or "").strip()
-        normalized = {
-            "requested_product_type": requested_type,
-            "advertised_category": category,
-        }
-        if (
-            relation.get("relation") == "model_selected_parent_category"
-            and requested_type
-            and category
-            and normalized not in parent_relations
-        ):
-            parent_relations.append(normalized)
-    if parent_relations:
-        relation_lines = [
-            (
-                f"The catalog does not advertise **{relation['requested_product_type']}** "
-                "as a separate product type. I searched the broader "
-                f"**{relation['advertised_category']}** category for the closest "
-                "options; each result keeps its actual catalog category."
-            )
-            for relation in parent_relations
-        ]
-        lines = relation_lines + [""] + lines
-
-    filter_groups = _confirmed_search_filter_groups(
-        result,
-        request_id=request_id,
-        displayed_names=displayed_names,
-    )
-    if filter_groups:
-        lines.extend(("", "Catalog-confirmed filters by search:"))
-        for group in filter_groups:
-            product_names = group["product_names"]
-            scope = (
-                ", ".join(f"**{name}**" for name in product_names)
-                if product_names
-                else "Search candidates"
-            )
-            lines.append(f"- {scope}: {'; '.join(group['statements'])}.")
-    unavailable_types = _no_direct_search_types(
-        result,
-        request_id=request_id,
-    )
-    if unavailable_types:
-        lines.extend(("", "Unavailable requested catalog types:"))
-        lines.extend(
-            f"- **{product_type}** is not advertised; I did not substitute "
-            "an adjacent product type."
-            for product_type in unavailable_types
-        )
-    if _has_unsupported_requirement_outcome(
-        result,
-        request_id=request_id,
-    ):
-        lines.extend(("", _UNSUPPORTED_REQUIREMENT_RESPONSE))
-    if not _search_scope_is_complete(result, request_id=request_id):
-        lines.extend(
-            (
-                "",
-                (
-                    "This is a partial result set. I can continue with the next "
-                    "requested piece or search scope."
-                ),
-            )
-        )
-    lines.extend(
-        (
-            "",
-            (
-                "These candidates were ranked toward your requested direction. "
-                "Product-specific material, construction, length, fit, comfort, "
-                "care, or weather performance remains unverified unless listed "
-                "above as a catalog-confirmed filter."
-            ),
-        )
-    )
-    return "\n".join(lines)
-
-
-def _search_result_groups(result: Any, *, request_id: str) -> list[dict[str, Any]]:
-    """Return successful search evidence grouped by the call that produced it."""
-
-    groups: list[dict[str, Any]] = []
-    for message in _current_turn_messages(_result_messages(result), request_id):
-        if _message_type(message) != "tool":
-            continue
-        payload = evidence_of(message)
-        if not payload or payload.get("outcome") != "results":
-            continue
-        groups.append(
-            {
-                "guidance": _scrub_internal_shopper_language(
-                    str(payload.get("shopper_guidance") or "")
-                ).strip(),
-                "products": payload.get("products") or [],
-                "taxonomy": payload.get("taxonomy") or {},
-                "scope_relation": _scope_relation_payload(payload),
-            }
-        )
-    return groups
-
-
-def _grouped_search_response_lines(
-    groups: list[dict[str, Any]],
-) -> tuple[list[str], set[str]]:
-    """Render multi-search candidates without losing their guidance scope."""
-
-    if len(groups) < 2 or not all(group.get("guidance") for group in groups):
-        return [], set()
-    lines: list[str] = []
-    displayed_names: set[str] = set()
-    displayed_product_refs: set[str] = set()
-    for index, group in enumerate(groups, start=1):
-        products = [
-            product
-            for product in group.get("products") or []
-            if str(
-                product.get("product_ref")
-                or f"name:{product.get('name') or ''}"
-            )
-            not in displayed_product_refs
-        ]
-        if not products:
-            continue
-        lines.extend(_format_search_group(group, products, index=index))
-        displayed_product_refs.update(
-            str(
-                product.get("product_ref")
-                or f"name:{product.get('name') or ''}"
-            )
-            for product in products
-        )
-        displayed_names.update(str(product["name"]) for product in products)
-    if lines and not lines[-1]:
-        lines.pop()
-    return lines, displayed_names
-
-
-
-
-def _no_direct_search_types(result: Any, *, request_id: str) -> list[str]:
-    """Return current-turn product types with a server-authored no-direct outcome."""
-
-    product_types: list[str] = []
-    for message in _current_turn_messages(_result_messages(result), request_id):
-        if _message_type(message) != "tool":
-            continue
-        payload = evidence_of(message)
-        if not payload or payload.get("outcome") != "no_direct_catalog_match":
-            continue
-        outcome = payload
-        product_type = str(outcome.get("requested_product_type") or "").strip()
-        if product_type and product_type not in product_types:
-            product_types.append(product_type)
-    return product_types
-
-
-def _search_scope_is_complete(result: Any, *, request_id: str) -> bool:
-    """Return whether a current-turn search declared its requested scope complete."""
-
-    return any(
-        _message_type(message) == "tool"
-        and SEARCH_SCOPE_COMPLETE_PREFIX
-        in _content_to_text(_value(message, "content"))
-        for message in _current_turn_messages(_result_messages(result), request_id)
-    )
-
-
-def _search_guidance_evidence(result: Any, *, request_id: str) -> list[str]:
-    """Return bounded pre-search shopper guidance from successful searches."""
-
-    guidance: list[str] = []
-    for message in _current_turn_messages(_result_messages(result), request_id):
-        if _message_type(message) != "tool":
-            continue
-        payload = evidence_of(message)
-        if not payload or payload.get("outcome") != "results":
-            continue
-        text = _scrub_internal_shopper_language(
-            str(payload.get("shopper_guidance") or "")
-        ).strip()
-        if text and text not in guidance:
-            guidance.append(text)
-    return guidance
-
-
-def _confirmed_search_filter_groups(
-    result: Any,
-    *,
-    request_id: str,
-    displayed_names: set[str] | None = None,
-) -> list[dict[str, list[str]]]:
-    """Keep canonical filters scoped to products from the same search."""
-
-    groups: list[dict[str, list[str]]] = []
-    for message in _current_turn_messages(_result_messages(result), request_id):
-        if _message_type(message) != "tool":
-            continue
-        payload = evidence_of(message)
-        if not payload or payload.get("outcome") != "results":
-            continue
-        filters = payload.get("confirmed_filters") or {}
-        statements: list[str] = []
-        for name, value in filters.items():
-            statement = _format_filter_statement(name, value)
-            if statement:
-                statements.append(statement)
-        if not statements:
-            continue
-        product_names = [
-            product["name"]
-            for product in (payload.get("products") or [])
-            if product.get("name")
-        ]
-        if displayed_names is not None:
-            product_names = [
-                name for name in product_names if name in displayed_names
-            ]
-            if not product_names:
-                continue
-        groups.append(
-            {"product_names": product_names, "statements": statements}
-        )
-    return groups
-
-
-
-
-def _product_result_price(product: dict[str, Any]) -> str:
-    price = product.get("price")
-    if isinstance(price, dict):
-        amount = price.get("amount")
-        currency = str(price.get("currency") or "USD")
-    else:
-        amount = price
-        currency = "USD"
-    if not isinstance(amount, (int, float)):
-        return ""
-    return f"${float(amount):.2f} {currency}"
-
-
-def _should_short_circuit_media_failure(state: State) -> bool:
-    if not state.media or not state.media_analysis:
-        return False
-    if not any(str(item.get("type") or "").lower() == "video" for item in state.media):
-        return False
-    if not _media_analysis_unavailable(state.media_analysis):
-        return False
-    return _query_depends_on_media(state.query)
-
-
-def _record_media_model_usage(state: State, config: Any) -> None:
-    if not getattr(config, "vlm_enabled", False) or not getattr(config, "vlm_name", None):
-        _add_model_usage(state, "vlm", status="disabled", calls=0)
-        return
-
-    status = "failed" if _media_analysis_unavailable(state.media_analysis) else "used"
-    _add_model_usage(
-        state,
-        "vlm",
-        status=status,
-        calls=1,
-        detail="Attached media understanding",
-    )
-
-
-def _record_catalog_model_usage(
-    state: State,
-    plan: CatalogSearchPlan,
-    ok: bool,
-    *,
-    fallback_attempted: bool = False,
-) -> None:
-    status = "used" if ok else "failed"
-    uses_image_endpoint = bool(state.image) and plan.search_mode in {"image", "hybrid"}
-    text_embedding_calls = 1 if plan.semantic_queries else 0
-    if uses_image_endpoint and text_embedding_calls == 0:
-        # Image retrieval currently includes one deterministic text-side query
-        # alongside the image embedding, even when the shopper supplied no text.
-        text_embedding_calls = 1
-    if fallback_attempted:
-        text_embedding_calls += 1 if plan.semantic_queries else 0
-
-    if text_embedding_calls:
-        _add_model_usage(
-            state,
-            "text_embedding",
-            status=status,
-            calls=text_embedding_calls,
-            detail="Catalog text/vector retrieval",
-        )
-    if uses_image_endpoint:
-        _add_model_usage(
-            state,
-            "image_embedding",
-            status=status,
-            calls=1,
-            detail="Catalog image similarity retrieval",
-        )
-
-
-def _record_language_model_failure(state: State) -> None:
-    _add_model_usage(
-        state,
-        "app_llm",
-        status="failed",
-        calls=1,
-        detail="Planning, tool use, and response generation failed",
-    )
-
-
-def _record_safety_model_usage(state: State, mode: str, *, ok: bool = True) -> None:
-    status = "used" if ok else "failed"
-    detail = "Input and output safety checks" if ok else "Guardrails check failed open"
-    if mode == "input":
-        _add_model_usage(
-            state,
-            "content_safety",
-            status=status,
-            calls=1,
-            detail=detail,
-        )
-        _add_model_usage(
-            state,
-            "topic_control",
-            status=status,
-            calls=1,
-            detail="Input topic check" if ok else "Guardrails topic check failed open",
-        )
-        return
-
-    _add_model_usage(
-        state,
-        "content_safety",
-        status=status,
-        calls=1,
-        detail=detail,
-    )
-
-
-def _add_model_usage(
-    state: State,
-    role: str,
-    *,
-    status: str,
-    calls: int,
-    detail: str = "",
-) -> None:
-    existing = state.model_usage.get(role, {})
-    existing_calls = _safe_int(existing.get("calls"))
-    existing_status = str(existing.get("status") or "")
-    merged_status = _merged_model_usage_status(existing_status, status)
-    existing_detail = str(existing.get("detail") or "")
-    next_detail = (
-        existing_detail
-        if existing_status == merged_status and existing_detail
-        else detail or existing_detail
-    )
-    state.model_usage[role] = {
-        "status": merged_status,
-        "calls": existing_calls + max(0, calls),
-        "detail": next_detail,
-    }
-
-
-def _merged_model_usage_status(existing: str, current: str) -> str:
-    priority = {"failed": 4, "used": 3, "disabled": 2, "not_used": 1, "": 0}
-    return existing if priority.get(existing, 0) > priority.get(current, 0) else current
-
-
-def _safe_int(value: Any) -> int:
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 0
-
-
-def _media_analysis_unavailable(media_analysis: str) -> bool:
-    try:
-        parsed = json.loads(media_analysis)
-    except json.JSONDecodeError:
-        text = media_analysis
-    else:
-        if not isinstance(parsed, dict):
-            text = str(parsed)
-        else:
-            parts = [str(parsed.get("summary") or "")]
-            uncertainties = parsed.get("uncertainties")
-            if isinstance(uncertainties, list):
-                parts.extend(str(item) for item in uncertainties)
-            text = " ".join(parts)
-
-    lowered = text.lower()
-    return any(
-        phrase in lowered
-        for phrase in (
-            "not configured",
-            "unavailable",
-            "authentication failed",
-            "could not authenticate",
-            "not allowed to access",
-            "media analysis failed",
-            "vlm returned no analysis",
-        )
-    )
-
-
-def _query_depends_on_media(query: str) -> bool:
-    lowered = (query or "").strip().lower()
-    if not lowered or lowered == "the user submitted visual media without additional text.":
-        return True
-    return any(
-        phrase in lowered
-        for phrase in (
-            "this video",
-            "the video",
-            "in video",
-            "from video",
-            "attached video",
-            "she is wearing",
-            "he is wearing",
-            "they are wearing",
-            "person is wearing",
-            "like that",
-            "like this",
-            "similar to that",
-            "similar to this",
-            "what is in this",
-            "what's in this",
-            "what am i wearing",
-            "what are they wearing",
-            "describe this",
-        )
-    )
-
-
-def _media_failure_response(media_analysis: str) -> str:
-    detail = "video/image understanding is unavailable for this turn"
-    try:
-        parsed = json.loads(media_analysis)
-    except json.JSONDecodeError:
-        parsed = {}
-    if isinstance(parsed, dict):
-        summary = str(parsed.get("summary") or "").strip()
-        if summary:
-            detail = _clean_media_failure_detail(summary)
-
-    return (
-        f"I could not analyze the attached media because {detail}. "
-        "Please describe the item in text, such as color, silhouette, material, "
-        "and any visible details, and I can search the catalog from that description."
-    )
-
-
-def _clean_media_failure_detail(summary: str) -> str:
-    detail = summary.strip()
-    for prefix in (
-        "Media was attached, but ",
-        "Video was attached, but ",
-        "Image was attached, but ",
-    ):
-        if detail.startswith(prefix):
-            detail = detail[len(prefix):]
-            break
-    if detail:
-        detail = detail[0].lower() + detail[1:]
-    return detail.rstrip(". ") or "video/image understanding is unavailable for this turn"
-
-
-def _collect_token_usage(result: Any) -> dict[str, int]:
-    """Collect normalized token usage from LangChain/OpenAI message metadata."""
-
-    usage = _empty_token_usage()
-    for message in _result_messages(result):
-        record = _message_token_usage_record(message)
-        if not record:
-            continue
-
-        input_tokens = _token_int(record, ("input_tokens", "prompt_tokens", "input"))
-        output_tokens = _token_int(
-            record,
-            ("output_tokens", "completion_tokens", "output"),
-        )
-        total_tokens = _token_int(record, ("total_tokens", "total"))
-        if total_tokens is None and (input_tokens is not None or output_tokens is not None):
-            total_tokens = int(input_tokens or 0) + int(output_tokens or 0)
-
-        if input_tokens is None and output_tokens is None and total_tokens is None:
-            continue
-
-        usage["input_tokens"] += int(input_tokens or 0)
-        usage["output_tokens"] += int(output_tokens or 0)
-        usage["total_tokens"] += int(total_tokens or 0)
-        usage["model_calls"] += 1
-    return usage
-
-
-def _merge_token_usage(
-    base: dict[str, Any] | None,
-    additional: dict[str, Any] | None,
-) -> dict[str, int]:
-    merged = _normalized_token_usage(base)
-    extra = _normalized_token_usage(additional)
-    for key in merged:
-        merged[key] += extra[key]
-    return merged
-
-
-def _collect_tool_grounding_evidence(
-    result: Any,
-    *,
-    max_chars: int,
-    request_id: str | None = None,
-) -> str:
-    messages = _result_messages(result)
-    if request_id is not None:
-        messages = _current_turn_messages(messages, request_id)
-    return _collect_message_grounding_evidence(messages, max_chars=max_chars)
-
-
-def _collect_message_grounding_evidence(
-    messages: list[Any],
-    *,
-    max_chars: int,
-) -> str:
-    """Collect customer-safe evidence from actual tool-role messages."""
-
-    parts: list[str] = []
-    for message in messages:
-        content = _content_to_text(_value(message, "content"))
-        if not content:
-            continue
-        if not _is_tool_evidence_message(message, content):
-            continue
-        parts.append(_customer_safe_tool_evidence(content, message))
-
-    evidence = "\n\n---\n\n".join(parts).strip()
-    if len(evidence) <= max_chars:
-        return evidence
-    return evidence[-max_chars:]
-
-
-def _customer_safe_search_evidence(payload: dict[str, Any]) -> str:
-    """Build the composer summary from typed evidence, without parsing prose."""
-
-    taxonomy = payload.get("taxonomy") or {}
-    confirmed_filters = payload.get("confirmed_filters") or {}
-    if payload.get("outcome") == "no_direct_catalog_match":
-        return _NO_DIRECT_CATALOG_MATCH_EVIDENCE
-    if payload.get("outcome") == "zero_results":
-        lines = [
-            (
-                "CUSTOMER_SAFE_SCOPED_NO_MATCH_EVIDENCE: Zero products matched "
-                "only the exact advertised search scope below. This does not "
-                "establish that a different, unsearched, or unadvertised product "
-                "type is absent, and it does not support a catalog-wide "
-                "availability claim."
-            )
-        ]
-        if taxonomy:
-            lines.append(
-                "ADVERTISED_SEARCH_TAXONOMY: "
-                + json.dumps(taxonomy, sort_keys=True)
-            )
-        if confirmed_filters:
-            lines.append(
-                "CONFIRMED_SEARCH_FILTERS: "
-                + json.dumps(confirmed_filters, sort_keys=True)
-            )
-        relation = _scope_relation_line(payload, has_products=False)
-        if relation:
-            lines.append(relation)
-        return "\n".join(lines)
-
-    lines = [_summarize_typed_product_evidence(payload)]
-    unconfirmed = payload.get("unconfirmed_requirements") or []
-    if unconfirmed:
-        # Retrieval ranked on these; no filter enforced them. Saying so is what
-        # makes running the search safe instead of a licence to claim a match.
-        lines.append(
-            "UNCONFIRMED_REQUIREMENTS: The catalog cannot filter on "
-            + ", ".join(str(item) for item in unconfirmed)
-            + ". These products were ranked for it but none is confirmed to "
-            "meet it. Present them as candidates and say plainly that it is "
-            "unconfirmed. Do not refuse the request."
-        )
-    relation = _scope_relation_line(payload, has_products=True)
-    if relation:
-        lines.append(relation)
-    return "\n".join(lines)
-
-
-def _scope_relation_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Rebuild the scope-relation record from typed fields.
-
-    The relation is a constant whenever an advertised parent was substituted,
-    so presence of the parent is the whole condition.
-    """
-
-    category = payload.get("advertised_category")
-    requested = payload.get("requested_product_type")
-    if not category or not requested:
-        return {}
-    return {
-        "relation": "model_selected_parent_category",
-        "requested_product_type": str(requested),
-        "advertised_category": str(category),
-    }
-
-
-def _scope_relation_line(payload: dict[str, Any], *, has_products: bool) -> str:
-    """Say plainly that a broader advertised parent was searched, if it was."""
-
-    category = payload.get("advertised_category")
-    requested = payload.get("requested_product_type")
-    if not category or not requested:
-        return ""
-    if not has_products:
-        return (
-            f"REQUESTED_SCOPE_RELATION: {requested} is not separately "
-            f"advertised. The broader advertised category {category} returned "
-            "zero products for this search, so do not claim that the requested "
-            "type is absent from the whole catalog."
-        )
-    return (
-        f"REQUESTED_SCOPE_RELATION: {requested} is not separately "
-        f"advertised. The search used the broader advertised category {category}. "
-        "Present these as closest options and keep every returned product's "
-        "actual catalog category; do not relabel them as the requested type."
-    )
-
-
-def _customer_safe_tool_evidence(content: str, message: Any = None) -> str:
-    """Summarise one tool result for the composer.
-
-    Catalog evidence is read from the typed payload on the message artifact.
-    The text branches that follow handle results which carry no payload:
-    framework-generated tool errors, and tools that emit no evidence yet.
-    Nothing here parses catalog facts back out of prose.
-    """
-
-    if message is not None:
-        payload = evidence_of(message)
-        if payload is not None:
-            return _customer_safe_search_evidence(payload)
-        detail = detail_evidence_of(message)
-        if detail is not None:
-            return _render_product_evidence_summary(
-                detail.get("products") or [],
-                heading="CUSTOMER_SAFE_PRODUCT_DETAIL_EVIDENCE",
-                note=_PRODUCT_DETAIL_EVIDENCE_NOTE,
-            )
-
-    if content.startswith(SEARCH_VALIDATION_ERROR_PREFIX):
-        return (
-            "CUSTOMER_SAFE_INVALID_SEARCH_EVIDENCE: No valid catalog search "
-            "scope was established and no retrieval ran. This does not support "
-            "a product-availability or catalog-absence claim."
-        )
-    return _summarize_cart_evidence(content)
-
-
-
-def _render_product_evidence_summary(
-    products: list[dict[str, Any]],
-    *,
-    heading: str,
-    note: str,
-    confirmed_filters: dict[str, Any] | None = None,
-    taxonomy_scope: dict[str, Any] | None = None,
-    fallback_content: str | None = None,
-) -> str:
-    """Render the composer's product summary from records.
-
-    Shared by the typed-payload path and the text path so the two cannot drift
-    in wording; only where the records come from differs.
-    """
-
-    lines = [f"{heading}: {note}"]
-    if confirmed_filters:
-        lines.append(
-            "CONFIRMED_SEARCH_FILTERS: Every product below passed each filter "
-            "predicate. A one-value list confirms that value; a multi-value list "
-            "confirms only membership in the set, not which value matched: "
-            + json.dumps(confirmed_filters, sort_keys=True, default=str)
-        )
-    if taxonomy_scope:
-        lines.append(
-            "ADVERTISED_SEARCH_TAXONOMY: This search used only these advertised "
-            "taxonomy values. Lists are inclusive scopes; they do not mean every "
-            "product has every value. Do not describe an unlisted product type "
-            "as advertised: "
-            + json.dumps(taxonomy_scope, sort_keys=True, default=str)
-        )
-    if not products:
-        # The text path keeps emitting its stripped line even when that line is
-        # empty, so its output is unchanged. The typed path has no prose to fall
-        # back to and must not append a blank line in its place.
-        if fallback_content is None:
-            return "\n".join(lines)
-        return "\n".join(
-            lines + [_strip_internal_ids_from_evidence_line(fallback_content)]
-        )
-    for product in products:
-        summary_parts = [product["name"]]
-        if product.get("category"):
-            summary_parts.append(f"category: {product['category']}")
-        if product.get("price"):
-            summary_parts.append(f"price: {product['price']}")
-        if product.get("image_url"):
-            summary_parts.append("image: available")
-        attributes = product.get("attributes")
-        if isinstance(attributes, dict) and attributes:
-            summary_parts.append(
-                "confirmed: "
-                + "; ".join(
-                    f"{name.replace('_', ' ')}: {value}"
-                    for name, value in attributes.items()
-                )
-            )
-        if product.get("details"):
-            summary_parts.append("details: " + "; ".join(product["details"]))
-        lines.append("- " + " | ".join(summary_parts))
-    return "\n".join(lines)
-
-
-def _summarize_typed_product_evidence(payload: dict[str, Any]) -> str:
-    """Summarise search results for the composer straight from typed evidence."""
-
-    products = payload.get("products")
-    return _render_product_evidence_summary(
-        products if isinstance(products, list) else [],
-        heading="CUSTOMER_SAFE_SEARCH_EVIDENCE",
-            note=(
-                "Search results support product names, prices, categories, "
-                "image availability, confirmed search filters, any attribute "
-                "listed as confirmed for that specific product, and a modest "
-                "styling role. An attribute confirmed for one product is not "
-                "evidence about another. They do not support care, "
-                "construction, fit, comfort, weather, grass, gravel, heat, or "
-                "best-in-category claims, nor any attribute not listed for that "
-                "product. Treat names as display names, not attribute evidence; "
-                "group claims require the attribute confirmed on every item."
-            ),
-        confirmed_filters=payload.get("confirmed_filters") or {},
-        taxonomy_scope=payload.get("taxonomy") or {},
-    )
-
-
-
-
-
-
-
-
-
-def _summarize_cart_evidence(content: str) -> str:
-    lines = ["CUSTOMER_SAFE_CART_EVIDENCE:"]
-    for raw_line in content.splitlines():
-        cleaned = _strip_internal_ids_from_evidence_line(raw_line)
-        if cleaned:
-            lines.append(cleaned)
-    return "\n".join(lines)
-
-
-def _strip_internal_ids_from_evidence_line(line: str) -> str:
-    stripped = line.strip()
-    if not stripped:
-        return ""
-    if stripped.startswith("PRODUCT_REF:") or stripped.startswith("CART_LINE_ID:"):
-        return ""
-    if stripped.startswith("- CART_LINE_ID:") and "|" in stripped:
-        return "- " + stripped.split("|", 1)[1].strip()
-
-    marker = "(PRODUCT_REF:"
-    while marker in stripped:
-        start = stripped.find(marker)
-        end = stripped.find(")", start)
-        if end == -1:
-            stripped = stripped[:start].rstrip()
-            break
-        stripped = (stripped[:start] + stripped[end + 1 :]).strip()
-    return stripped
-
-
-def _is_tool_evidence_message(message: Any, content: str) -> bool:
-    message_type = str(_value(message, "type") or "").lower()
-    role = str(_value(message, "role") or "").lower()
-    tool_name = str(_value(message, "name") or "")
-    if tool_name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"}:
-        return False
-    if content.startswith(
-        (
-            SKILL_ACTIVATION_COMPLETE,
-            SKILL_ACTIVATION_REQUIRED,
-            SKILL_TOOL_NOT_GRANTED,
-            "SHOPPER_SKILL_ACTIVATION_FAILED:",
-        )
-    ):
-        return False
-    return message_type == "tool" or role == "tool"
-
-
-def _normalized_token_usage(raw: dict[str, Any] | None) -> dict[str, int]:
-    usage = _empty_token_usage()
-    if not isinstance(raw, dict):
-        return usage
-    for key in usage:
-        value = raw.get(key)
-        if isinstance(value, bool):
-            continue
-        if isinstance(value, (int, float)):
-            usage[key] = max(0, int(value))
-    return usage
-
-
-def _empty_token_usage() -> dict[str, int]:
-    return {
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "total_tokens": 0,
-        "model_calls": 0,
-    }
-
-
-
-
-def _message_token_usage_record(message: Any) -> Any:
-    usage_metadata = _value(message, "usage_metadata")
-    if usage_metadata:
-        return usage_metadata
-
-    response_metadata = _value(message, "response_metadata")
-    if isinstance(response_metadata, dict):
-        token_usage = response_metadata.get("token_usage")
-        if token_usage:
-            return token_usage
-
-    for key in ("token_usage", "usage"):
-        record = _value(message, key)
-        if record:
-            return record
-    return None
-
-
-
-
-def _token_int(record: Any, keys: tuple[str, ...]) -> int | None:
-    for key in keys:
-        value = _value(record, key)
-        if isinstance(value, bool):
-            continue
-        if isinstance(value, (int, float)):
-            return max(0, int(value))
-    return None
-
-
-
-
-def _tool_search_mode(value: str | None) -> str | None:
-    return value if value in {"text", "image", "hybrid"} else None
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -6322,257 +3571,20 @@ def _tool_search_mode(value: str | None) -> str | None:
 #: lane. catalog_text is the prose serialisation of the same attributes and is
 #: deliberately not forwarded -- it carries a marketing summary, and separating
 #: the two would mean parsing prose.
-_NON_ATTRIBUTE_SEARCH_KEYS = frozenset({"catalog_text", "similarity", "taxonomy"})
-
-
-def _search_attribute_facts(product: Any) -> dict[str, str]:
-    """Structured attributes the catalog confirmed for one search hit.
-
-    The catalog declares which fields are product detail and returns them with
-    every search result. They were dropped here, so the model was told to spend
-    one of its two product-detail reads to fetch what the response already
-    carried -- and when that budget ran out it reported a confirmed attribute as
-    unknown.
-    """
-
-    attributes = getattr(product, "attributes", None)
-    if not isinstance(attributes, dict):
-        return {}
-    facts: dict[str, str] = {}
-    for name, value in sorted(attributes.items()):
-        if name in _NON_ATTRIBUTE_SEARCH_KEYS:
-            continue
-        text = _format_detail_value(value).strip()
-        if text:
-            facts[str(name)] = text
-    return facts
-
-
-def _search_product_record(product: Any) -> dict[str, Any]:
-    """Project one search hit into the record both the model text and the
-    composer summary are rendered from.
-
-    Previously the model-visible text was the only rendering and the composer
-    parsed it back into this same shape. Building the record once removes the
-    round trip, and keeps the two renderings unable to disagree.
-    """
-
-    return {
-        "product_ref": str(product.product_id),
-        "name": str(product.display_name),
-        "category": str(getattr(product, "category", "") or ""),
-        "price": (
-            f"${product.price.amount:.2f} {product.price.currency}"
-            if product.price
-            else ""
-        ),
-        "image_url": str(product.image_url or ""),
-        "attributes": _search_attribute_facts(product),
-    }
-
-
-def _format_product(product: Any) -> str:
-    return _format_product_record(_search_product_record(product))
-
-
-
-
-def _product_detail_record(product: ProductDetail) -> dict[str, Any]:
-    """Project one product-detail read into the record the text renders from."""
-
-    return {
-        "product_ref": str(product.product_id),
-        "name": str(product.display_name),
-        "category": str(product.category or ""),
-        "brand": str(product.brand or ""),
-        "price": (
-            f"${product.price.amount:.2f} {product.price.currency}"
-            if product.price
-            else ""
-        ),
-        "image_url": str(product.image_url or ""),
-        "details": [
-            f"{name.replace('_', ' ')}: {_format_detail_value(value)}"
-            for name, value in sorted((product.attributes or {}).items())
-        ],
-    }
-
-
-def _format_product_details(product: ProductDetail) -> str:
-    return _format_product_detail_record(_product_detail_record(product))
-
-
-
-
-
-
-def _normalize_cart_add_tool_items(
-    items: list[AddCartItemsToolItemInput] | list[dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    normalized: dict[str, dict[str, Any]] = {}
-    for item in items or []:
-        try:
-            parsed = (
-                item
-                if isinstance(item, AddCartItemsToolItemInput)
-                else AddCartItemsToolItemInput.model_validate(item)
-            )
-            quantity = max(1, int(parsed.quantity or 1))
-        except (TypeError, ValueError, ValidationError) as exc:
-            raise ValueError("each item must include a PRODUCT_REF and quantity") from exc
-        entry = normalized.setdefault(
-            parsed.product_ref,
-            {
-                "quantity": 0,
-                "expected_display_name": (
-                    parsed.expected_display_name.strip()
-                    if parsed.expected_display_name
-                    else ""
-                ),
-            },
-        )
-        entry["quantity"] += quantity
-        if not entry["expected_display_name"] and parsed.expected_display_name:
-            entry["expected_display_name"] = parsed.expected_display_name.strip()
-    return normalized
-
-
-def _cart_add_scope_failures(
-    user_query: str,
-    requested_products: list[tuple[str, ProductSummary]],
-    available_products: Any,
-) -> list[str]:
-    explicitly_named = _explicitly_named_products(user_query, available_products)
-    if not explicitly_named:
-        return []
-
-    explicit_names = {
-        _normalize_product_name(product.display_name) for product in explicitly_named
-    }
-    failures = []
-    for product_ref, product in requested_products:
-        if _normalize_product_name(product.display_name) in explicit_names:
-            continue
-        failures.append(
-            f"- PRODUCT_REF '{product_ref}': selected '{product.display_name}' is "
-            "outside the current explicit add request. The current request names: "
-            f"{_format_product_refs(explicitly_named)}. Retry with matching "
-            "PRODUCT_REF values only, or ask a clarification."
-        )
-    return failures
-
-
-def _explicitly_named_products(
-    text: str,
-    available_products: Any,
-) -> list[ProductSummary]:
-    normalized_text = _normalize_product_name(text)
-    if not normalized_text:
-        return []
-
-    padded_text = f" {normalized_text} "
-    matches: list[ProductSummary] = []
-    seen: set[str] = set()
-    products = list(available_products)
-    for product in products:
-        normalized_name = _normalize_product_name(product.display_name)
-        if not normalized_name:
-            continue
-        if f" {normalized_name} " not in padded_text:
-            continue
-        key = product.product_id or product.display_name
-        if key in seen:
-            continue
-        seen.add(key)
-        matches.append(product)
-
-    query_tokens = set(_product_name_tokens(text))
-    for product in products:
-        key = product.product_id or product.display_name
-        if key in seen:
-            continue
-        product_tokens = _product_name_tokens(product.display_name)
-        required_overlap = 3 if len(product_tokens) > 3 and matches else 2
-        if not _product_name_tokens_match(
-            query_tokens,
-            product_tokens,
-            required_overlap=required_overlap,
-        ):
-            continue
-        seen.add(key)
-        matches.append(product)
-    return matches
 
 
-def _same_product_display_name(expected: str, actual: str) -> bool:
-    return _normalize_product_name(expected) == _normalize_product_name(actual)
 
 
-def _product_detail_failure_message(
-    error: CommerceError | None,
-    *,
-    cart_validation: bool,
-) -> str:
-    if error is not None and error.code == "product_not_found":
-        return (
-            "The product is no longer present in the active catalog. "
-            "Search again before adding it."
-            if cart_validation
-            else (
-                "That product is no longer available in the active catalog. "
-                "Search the catalog again before using its details."
-            )
-        )
-    if error is not None and error.retryable:
-        return (
-            "The catalog is temporarily unavailable, so the cart was not changed. "
-            "Please try again."
-            if cart_validation
-            else "Product details are temporarily unavailable. Please try again."
-        )
-    return (
-        "The product could not be verified, so the cart was not changed. "
-        "Search again before adding it."
-        if cart_validation
-        else "Product details could not be verified. Search the catalog again."
-    )
 
 
-def _normalize_product_name(value: str) -> str:
-    chars = []
-    for char in str(value or "").casefold():
-        chars.append(char if char.isalnum() else " ")
-    return " ".join("".join(chars).split())
 
 
-def _product_name_tokens(value: str) -> list[str]:
-    return [
-        token
-        for token in _normalize_product_name(value).split()
-        if token not in _PRODUCT_NAME_STOPWORDS
-    ]
 
 
-def _product_name_tokens_match(
-    query_tokens: set[str],
-    product_tokens: list[str],
-    *,
-    required_overlap: int,
-) -> bool:
-    if len(product_tokens) < 2:
-        return False
-    overlap = query_tokens.intersection(product_tokens)
-    required = min(required_overlap, len(set(product_tokens)))
-    return len(overlap) >= required
 
 
 
 
-def _scrub_internal_shopper_language(text: str) -> str:
-    scrubbed = text or ""
-    for internal, replacement in _INTERNAL_SHOPPER_REPLACEMENTS:
-        scrubbed = scrubbed.replace(internal, replacement)
-    return scrubbed
 
 
 
@@ -6599,13 +3611,25 @@ def _scrub_internal_shopper_language(text: str) -> str:
 
 
 
-def _cart_line_by_id(cart_line_id: str, cart: Cart) -> dict[str, Any] | None:
-    if not cart.contents:
-        return None
-    target = (cart_line_id or "").strip()
-    if not target:
-        return None
-    for item in cart.contents:
-        if str(item.get("cart_line_id") or "").strip() == target:
-            return item
-    return None
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import asyncio
 import json
 import os
@@ -110,7 +112,6 @@ from .turn_support import (
     _text_mentions_product_type,
     _tool_search_mode,
     _unsupported_requirement_message,
-    logger,
 )
 from .catalog_capabilities import (
     CatalogCapabilitiesClient,
@@ -195,6 +196,8 @@ from shared.commerce_contracts import (
     RemoveCartItemInput,
     UpdateCartItemInput,
 )
+
+logger = logging.getLogger(__name__)
 
 
 _SHOPPER_SKILLS_ENV = "SHOPPER_SKILLS_ROOT"

--- a/chain_server/src/main.py
+++ b/chain_server/src/main.py
@@ -23,7 +23,8 @@ import re
 
 from .agenttypes import SHOPPER_PROFILE_ID_PATTERN, State, Cart
 from .config import load_config
-from .deepagents_runtime import DeepAgentsRuntime, create_request_identity
+from .deepagents_runtime import DeepAgentsRuntime
+from .turn_support import create_request_identity
 from .media_perception import MEDIA_ONLY_QUERY
 from .shopper_profiles import (
     ShopperProfile,

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -1,0 +1,3392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn-support helpers: the stateless half of the deep-agents runtime.
+
+`deepagents_runtime.py` held its orchestration class and every helper that class
+calls in one 6,600-line file. This module is the helpers -- catalog scope
+reasoning, evidence shaping, response assembly, diagnostics, and the pydantic
+schemas for tool arguments. None of them touches `self`, the graph, or a live
+service; each takes data and returns data, so they can be read and tested
+without standing up a runtime.
+
+They move as a single module rather than as themed ones because the call graph
+between those themes is cyclic -- evidence calls scope, scope calls shared
+helpers, and those call back into diagnostics and response assembly. Splitting
+further means breaking those cycles, which is a design change rather than a
+move, so it is left to a separate change instead of being smuggled into this one.
+
+Moved verbatim from `deepagents_runtime.py`; no definition was edited.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import re
+from collections.abc import Sequence
+from typing import Any, Literal
+import unicodedata
+import uuid
+from langgraph.checkpoint.memory import MemorySaver
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    create_model,
+    field_validator,
+    model_validator,
+)
+from pydantic_core import PydanticCustomError
+from .agenttypes import Cart, DialogueTurn, State
+from .response_format import (
+    _format_cart,
+    _format_detail_value,
+    _format_filter_statement,
+    _format_product_detail_record,
+    _format_product_record,
+    _format_product_refs,
+    _format_search_group,
+)
+from .catalog_capabilities import (
+    effective_filter_capabilities,
+)
+from .catalog_request import (
+    CatalogSearchPlan,
+)
+from .conversation_memory import (
+    FinalTurnStatus,
+)
+from .tool_evidence import (
+    detail_evidence_of,
+    evidence_of,
+)
+from .message_shape import (
+    _content_to_text,
+    _current_turn_messages,
+    _message_type,
+    _result_messages,
+    _tool_results_by_call_id,
+    _value,
+)
+from .skill_activation import (
+    SKILL_ACTIVATION_COMPLETE,
+    SKILL_ACTIVATION_MODIFIER_REQUIRES_PRIMARY,
+    SKILL_ACTIVATION_MULTIPLE_PRIMARY,
+    SKILL_ACTIVATION_REQUIRED,
+    SKILL_ACTIVATION_TOOL_NAME,
+    SKILL_TOOL_NOT_GRANTED,
+)
+from .tool_loop_control import (
+    CONSTRAINT_REVIEW_PREFIX,
+    STOP_TOOL_USE_PREFIX,
+    SEARCH_SCOPE_COMPLETE_PREFIX,
+    SEARCH_VALIDATION_ERROR_PREFIX,
+    SERVER_CATALOG_CLARIFICATION,
+    SERVER_RESTORED_TOOL_CALL_FIELDS,
+    UNSUPPORTED_CONSTRAINT_PREFIX,
+    UNSUPPORTED_TAXONOMY_PREFIX,
+    _SERVER_REJECTED_TOOL_CALLS,
+)
+from shared.commerce_contracts import (
+    CatalogCapabilities,
+    CommerceError,
+    ProductDetail,
+    ProductSummary,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+_SHARED_CONFIG_ROOT_ENV = "SHARED_CONFIG_ROOT"
+
+
+_STORE_POLICIES_RELATIVE_PATH = Path("chain_server/store_policies.yaml")
+
+
+def _build_checkpointer():
+    """Return the process-local LangGraph checkpointer."""
+
+    store = os.environ.get("CHECKPOINT_STORE", "memory").strip().lower()
+    if store != "memory":
+        raise ValueError(
+            "CHECKPOINT_STORE currently supports only 'memory'. "
+            f"Received: {store!r}."
+        )
+    return MemorySaver()
+
+
+def _store_policies_path() -> Path:
+    """Resolve controlled policy content outside the agent-readable skill root."""
+
+    configured_root = os.environ.get(_SHARED_CONFIG_ROOT_ENV, "").strip()
+    if configured_root:
+        return Path(configured_root) / _STORE_POLICIES_RELATIVE_PATH
+
+    deployed_path = Path("/app/shared/configs") / _STORE_POLICIES_RELATIVE_PATH
+    if deployed_path.is_file():
+        return deployed_path
+
+    return (
+        Path(__file__).resolve().parents[2]
+        / "shared"
+        / "configs"
+        / _STORE_POLICIES_RELATIVE_PATH
+    )
+
+
+_NO_DIRECT_CATALOG_MATCH_EVIDENCE = (
+    "CUSTOMER_SAFE_NO_MATCH_EVIDENCE: The active catalog has no direct "
+    "advertised taxonomy match for this requested product role. "
+    "No retrieval ran and no alternative product type was selected. Say "
+    "that plainly, preserve any successful evidence for other roles, and "
+    "ask permission before searching a different advertised type. Do not "
+    "name alternatives."
+)
+
+
+_PRODUCT_DETAIL_EVIDENCE_NOTE = (
+    "Product details were read for these products, but the available "
+    "detail data contains only the listed facts. Do "
+    "not state material, care, dimensions, closures, fit, sizing, "
+    "colorways, or outdoor performance unless the field appears in "
+    "this evidence summary."
+)
+
+
+_MAX_DIAGNOSTIC_PRODUCT_EVIDENCE = 24
+
+
+_MAX_DIAGNOSTIC_PRODUCT_FACTS = 40
+
+
+_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS = 500
+
+
+_MAX_DIAGNOSTIC_PRODUCT_EVIDENCE_CHARS = 32_000
+
+
+_PARTIAL_GRAPH_SNAPSHOT_TIMEOUT_SECONDS = 1.0
+
+
+_UNSUPPORTED_SEARCH_MODE_MESSAGE = (
+    "The requested search mode is not available for the active catalog. "
+    "Ask the shopper to use an advertised mode."
+)
+
+
+_NO_DIRECT_TAXONOMY_RESPONSE = (
+    "The catalog doesn't advertise a product type that directly matches this "
+    "request. Would you like me to search a different advertised product type?"
+)
+
+
+_REJECTED_CATALOG_SEARCH_RESPONSE = (
+    "I couldn't complete a valid catalog search for that request, so I don't "
+    "have catalog results to show. Please try again or ask me to search a "
+    "different advertised product type."
+)
+
+
+_CATALOG_REPAIR_CLARIFICATION_RESPONSE = (
+    "Could you clarify the product type or requirement you want me to use?"
+)
+
+
+_UNSUPPORTED_REQUIREMENT_RESPONSE = (
+    "I can't guarantee that requirement from the catalog information available "
+    "to this assistant, so I won't present unverified matches. Would you like me "
+    "to treat it as a preference and show candidates to verify on their product "
+    "pages?"
+)
+
+
+_PRODUCT_NAME_STOPWORDS = frozenset({"a", "an", "and", "in", "of", "the", "to", "with"})
+
+
+_INTERNAL_SHOPPER_REPLACEMENTS = (
+    ("The product detail tool doesn't return", "I don't have"),
+    ("the product detail tool doesn't return", "I don't have"),
+    ("The catalog detail tool doesn't return", "I don't have"),
+    ("the catalog detail tool doesn't return", "I don't have"),
+    ("The product detail tool does not return", "I don't have"),
+    ("the product detail tool does not return", "I don't have"),
+    ("The catalog detail tool does not return", "I don't have"),
+    ("the catalog detail tool does not return", "I don't have"),
+    ("the product detail tool", "the product details I can access"),
+    ("the catalog detail tool", "the product details I can access"),
+    ("because the tool requires", "because I need"),
+    ("The tool requires", "I need"),
+    ("the tool requires", "I need"),
+)
+
+
+class CatalogTaxonomyToolInput(BaseModel):
+    """Catalog-derived taxonomy roles used by the agent search tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    category: list[str] = Field(
+        ...,
+        description=(
+            "Exact advertised category values required by the shopper. Use an "
+            "empty list only when subcategory supplies the text-search scope or "
+            "the search is image-only."
+        ),
+    )
+    subcategory: list[str] = Field(
+        ...,
+        description=(
+            "Exact advertised subcategory values required by the shopper. Use an "
+            "empty list when category supplies the text-search scope or the search "
+            "is image-only."
+        ),
+    )
+
+    @field_validator("category", "subcategory", mode="before")
+    @classmethod
+    def deduplicate_values(cls, value: Any) -> Any:
+        """Normalize repeated taxonomy values before cardinality validation."""
+
+        if isinstance(value, str):
+            return [value]
+        return list(dict.fromkeys(value)) if isinstance(value, list) else value
+
+
+def _singularize_product_word(word: str) -> str:
+    """Conservatively singularize one normalized product-type word."""
+
+    if word.endswith("ies") and len(word) > 3:
+        return f"{word[:-3]}y"
+    if word.endswith(("sses", "shes", "ches", "xes", "zes")):
+        return word[:-2]
+    if word.endswith("s") and not word.endswith("ss") and len(word) > 1:
+        return word[:-1]
+    return word
+
+
+def _normalize_product_text(value: str) -> str:
+    """Normalize product-type text for deterministic lexical comparison."""
+
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    normalized = normalized.replace("&", " and ").replace("/", " or ")
+    words = re.findall(r"[^\W_]+", normalized.replace("_", " "))
+    return " ".join(_singularize_product_word(word) for word in words)
+
+
+def _has_alternative_connector(value: str) -> bool:
+    """Return whether a product phrase joins explicit alternatives."""
+
+    normalized = _normalize_product_text(value)
+    return bool(re.search(r"\b(?:and|or)\b", normalized))
+
+
+def _text_mentions_product_type(text: str, product_type: str) -> bool:
+    """Return whether text names a normalized product-type form."""
+
+    normalized_text = _normalize_product_text(text)
+    padded_text = f" {normalized_text} "
+    normalized_product_type = _normalize_product_text(product_type)
+    return bool(normalized_product_type) and (
+        f" {normalized_product_type} " in padded_text
+    )
+
+
+def _requirement_word_stem(word: str) -> str:
+    """Return a conservative stem for literal requirement provenance."""
+
+    for suffix in ("ance", "ence", "ancy", "ency", "ant", "ent", "ing", "ed"):
+        if word.endswith(suffix) and len(word) > len(suffix) + 3:
+            return word[: -len(suffix)]
+    return _singularize_product_word(word)
+
+
+def _shopper_stated_requirement(query: str, requirement: str) -> bool:
+    """Return whether a proposed requirement is grounded in the current turn."""
+
+    normalized_query = unicodedata.normalize("NFKC", query).casefold()
+    query_words = {
+        _requirement_word_stem(word)
+        for word in re.findall(r"[^\W_]+", normalized_query)
+    }
+    requirement_words = {
+        _requirement_word_stem(word)
+        for word in re.findall(
+            r"[^\W_]+",
+            unicodedata.normalize("NFKC", requirement).casefold(),
+        )
+    }
+    return bool(requirement_words) and requirement_words.issubset(query_words)
+
+
+def _product_scope_key(value: str | None) -> str:
+    """Return the full normalized product phrase preserved across repair."""
+
+    return _normalize_product_text(value or "")
+
+
+def _generic_shopper_guidance(requested_product_type: str | None) -> str:
+    """Return safe guidance after an inferred attribute is removed."""
+
+    product_type = (requested_product_type or "products").replace("_", " ")
+    return f"Finding {product_type} for the shopper's request."
+
+
+_UNSUPPORTED_GUIDANCE_PATTERN = re.compile(
+    r"\b(?:waterproof|water[ -]?resistant|weather[ -]?safe|bug[ -]?safe|"
+    r"wet (?:surfaces?|grounds?|conditions?)|grass|gravel|all[ -]?day|best[ -]?in[ -]?category|"
+    r"maximally|outdoor (?:surfaces?|walking)|"
+    r"(?:handles?|suitable for|works? well (?:for|in)|secure for|stay secure for)"
+    r"[^.]{0,32}(?:rain|wet weather|outdoor))\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _safe_shopper_guidance(
+    shopper_guidance: str,
+    requested_product_type: str | None,
+) -> str:
+    """Remove unsupported performance language from pre-search guidance."""
+
+    if _UNSUPPORTED_GUIDANCE_PATTERN.search(shopper_guidance):
+        return _generic_shopper_guidance(requested_product_type)
+    return shopper_guidance
+
+
+def _unsupported_requirement_message(requirements: list[str]) -> str:
+    """Return the shopper-facing failure for unsupported hard requirements."""
+
+    return (
+        "The requested catalog requirement cannot be enforced: "
+        + ", ".join(
+            f"'{requirement}' is not an advertised hard filter"
+            for requirement in requirements
+        )
+        + ". Decide from what the shopper has already told you: if they have "
+        "said what to do when it cannot be confirmed, follow that; otherwise "
+        "treat it as a ranking preference and say plainly it is unconfirmed, "
+        "or ask them. Do not refuse the request."
+    )
+
+
+def _recent_shopper_statements(
+    dialogue: Sequence[DialogueTurn],
+    *,
+    limit: int = 4,
+) -> str:
+    """Read prior shopper text from the typed lane, never from rendered prose.
+
+    Assistant text is deliberately excluded: dialogue may carry shopper intent,
+    but assistant prose is not product, policy, inventory, or cart evidence.
+    """
+
+    recent = list(dialogue)[-limit:]
+    return "\n".join(turn.shopper_text for turn in recent if turn.shopper_text)
+
+
+def _shopper_stated_product_scope(
+    query: str,
+    dialogue: Sequence[DialogueTurn],
+    product_scope_key: str,
+) -> bool:
+    """Return whether current or recent shopper text states a product scope."""
+
+    shopper_text = "\n".join(
+        value for value in (query, _recent_shopper_statements(dialogue)) if value
+    )
+    return _text_mentions_product_type(shopper_text, product_scope_key)
+
+
+def _resolved_agent_selected_product_type(
+    *,
+    query: str,
+    dialogue: Sequence[DialogueTurn],
+    requested_product_type: str | None,
+    taxonomy_status: str,
+    taxonomy: BaseModel | dict[str, Any],
+) -> str | None:
+    """Derive open-role provenance from the agent's single taxonomy choice."""
+
+    if taxonomy_status != "agent_selected_type":
+        return requested_product_type
+    scope_key = _product_scope_key(requested_product_type)
+    if scope_key and _shopper_stated_product_scope(query, dialogue, scope_key):
+        return requested_product_type
+    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
+    subcategories = payload.get("subcategory") or []
+    if len(subcategories) == 1:
+        return str(subcategories[0])
+    return requested_product_type
+
+
+def _agent_selected_scope_is_advertised(
+    requested_product_type: str | None,
+    taxonomy: BaseModel | dict[str, Any],
+) -> bool:
+    """Check that an open-role choice names its advertised taxonomy scope."""
+
+    requested = _normalize_product_text(requested_product_type or "")
+    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
+    subcategories = {
+        _normalize_product_text(value)
+        for value in (payload.get("subcategory") or [])
+    }
+    return len(subcategories) == 1 and requested in subcategories
+
+
+def _advertised_subcategories_for_selection(
+    taxonomy: BaseModel | dict[str, Any],
+    capabilities: CatalogCapabilities,
+) -> list[str]:
+    """Return advertised role choices within the selected category."""
+
+    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
+    selected_categories = payload.get("category") or []
+    categories = capabilities.taxonomy.categories
+    category_names = selected_categories or list(categories)
+    return sorted(
+        {
+            subcategory
+            for category_name in category_names
+            if (category := categories.get(category_name)) is not None
+            for subcategory in category.subcategories
+        }
+    )
+
+
+def _advertised_taxonomy_value(
+    requested_product_type: str | None,
+    capabilities: CatalogCapabilities,
+) -> str | None:
+    """Return the matching advertised taxonomy value, if one exists."""
+
+    requested = _normalize_product_text(requested_product_type or "")
+    for category_name, category in capabilities.taxonomy.categories.items():
+        if requested == _normalize_product_text(category_name):
+            return category_name
+        for subcategory_name in category.subcategories:
+            if requested == _normalize_product_text(subcategory_name):
+                return subcategory_name
+    return None
+
+
+def _advertised_scope_match(
+    requested_product_type: str | None,
+    capabilities: CatalogCapabilities,
+) -> tuple[str, str, str, str] | None:
+    """Return the longest advertised exact or suffix scope match."""
+
+    raw_requested = requested_product_type or ""
+    requested = _normalize_product_text(raw_requested)
+    suffix_match_allowed = not _has_alternative_connector(raw_requested)
+    matches: list[tuple[str, str, str, str]] = []
+    for category_name, category in capabilities.taxonomy.categories.items():
+        normalized_category = _normalize_product_text(category_name)
+        if requested == normalized_category or (
+            suffix_match_allowed
+            and requested.endswith(f" {normalized_category}")
+        ):
+            matches.append(
+                ("category", category_name, category_name, normalized_category)
+            )
+        for subcategory_name in category.subcategories:
+            normalized_subcategory = _normalize_product_text(subcategory_name)
+            if requested == normalized_subcategory or (
+                suffix_match_allowed
+                and requested.endswith(f" {normalized_subcategory}")
+            ):
+                matches.append(
+                    (
+                        "subcategory",
+                        subcategory_name,
+                        category_name,
+                        normalized_subcategory,
+                    )
+                )
+    return max(
+        matches,
+        key=lambda match: (len(match[3].split()), len(match[3])),
+        default=None,
+    )
+
+
+def _duplicates_unavailable_product_type(
+    requirements: Any,
+    requested_product_type: str | None,
+    capabilities: CatalogCapabilities,
+) -> bool:
+    """Return whether requirements only repeat an unavailable product type."""
+
+    requested = _normalize_product_text(requested_product_type or "")
+    return bool(
+        requested
+        and isinstance(requirements, list)
+        and len(requirements) == 1
+        and not _has_alternative_connector(requested_product_type or "")
+        and _advertised_scope_match(requested_product_type, capabilities) is None
+        and all(
+            isinstance(requirement, str)
+            and _normalize_product_text(requirement) == requested
+            for requirement in requirements
+        )
+    )
+
+
+def _same_product_scope(
+    first: str,
+    second: str,
+    capabilities: CatalogCapabilities,
+) -> bool:
+    """Compare full product scopes without conflating advertised siblings."""
+
+    if first == second:
+        return True
+    if _has_alternative_connector(first):
+        return False
+    first_advertised = _advertised_taxonomy_value(first, capabilities)
+    if first_advertised:
+        return False
+    advertised_match = _advertised_scope_match(first, capabilities)
+    if advertised_match:
+        return second == advertised_match[3]
+    return first.endswith(f" {second}")
+
+
+def _selected_advertised_subcategories(
+    taxonomy: BaseModel | dict[str, Any],
+    capabilities: CatalogCapabilities,
+) -> tuple[str, list[str]] | None:
+    """Return one typed multi-subcategory selection owned by one category."""
+
+    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
+    selected = list(dict.fromkeys(payload.get("subcategory") or []))
+    if len(selected) < 2:
+        return None
+    owners = [
+        category_name
+        for category_name, category in capabilities.taxonomy.categories.items()
+        if all(value in category.subcategories for value in selected)
+    ]
+    selected_categories = set(payload.get("category") or [])
+    if len(owners) != 1 or selected_categories not in (set(), {owners[0]}):
+        return None
+    return owners[0], selected
+
+
+def _multi_subcategory_candidate_limit(
+    selection: tuple[str, list[str]] | None,
+    capabilities: CatalogCapabilities,
+    default: int,
+) -> int:
+    """Fetch enough ranked candidates for a typed multi-subcategory selection."""
+
+    if selection is None:
+        return default
+    category_name, subcategories = selection
+    category = capabilities.taxonomy.categories[category_name]
+    product_count = sum(
+        category.subcategories[name].product_count for name in subcategories
+    )
+    return min(50, max(default, len(subcategories), product_count))
+
+
+def _products_with_subcategory_coverage(
+    products: list[ProductSummary],
+    selection: tuple[str, list[str]] | None,
+    limit: int,
+) -> list[ProductSummary]:
+    """Keep rank order while reserving one result per selected subcategory."""
+
+    if selection is None or len(products) <= limit:
+        return products
+    _, subcategories = selection
+    selected_indexes: set[int] = set()
+    for subcategory in subcategories:
+        normalized_subcategory = _normalize_product_text(subcategory)
+        match = next(
+            (
+                index
+                for index, product in enumerate(products)
+                if _normalize_product_text(product.category or "")
+                == normalized_subcategory
+            ),
+            None,
+        )
+        if match is not None:
+            selected_indexes.add(match)
+
+    for index in range(len(products)):
+        if len(selected_indexes) >= max(limit, len(subcategories)):
+            break
+        selected_indexes.add(index)
+    return [products[index] for index in sorted(selected_indexes)]
+
+
+def _advertised_taxonomy_scope_issue(
+    requested_product_type: str | None,
+    taxonomy_status: str,
+    taxonomy: BaseModel | dict[str, Any],
+    capabilities: CatalogCapabilities,
+) -> str | None:
+    """Enforce capability-owned relations for exact advertised scopes."""
+
+    advertised_match = _advertised_scope_match(
+        requested_product_type,
+        capabilities,
+    )
+    if advertised_match is None:
+        return None
+    scope_kind, advertised_name, category_name, _ = advertised_match
+    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
+    selected_categories = payload.get("category") or []
+    selected_subcategories = payload.get("subcategory") or []
+    normalized_category = _normalize_product_text(category_name)
+    normalized_selected_categories = {
+        _normalize_product_text(value) for value in selected_categories
+    }
+    normalized_selected_subcategories = {
+        _normalize_product_text(value) for value in selected_subcategories
+    }
+    if scope_kind == "category":
+        category = capabilities.taxonomy.categories[category_name]
+        owned_subcategories = {
+            _normalize_product_text(value) for value in category.subcategories
+        }
+        selected_owned_children = (
+            bool(normalized_selected_subcategories)
+            and normalized_selected_subcategories.issubset(owned_subcategories)
+            and normalized_selected_categories in (set(), {normalized_category})
+        )
+        if taxonomy_status == "exact_requested_type" and selected_owned_children:
+            return (
+                f"Requested product type '{requested_product_type}' binds to "
+                f"advertised category '{advertised_name}', while the selected "
+                "taxonomy contains only its advertised children. Keep those "
+                "children together for the shopper's umbrella request."
+            )
+        exact_category = (
+            taxonomy_status == "exact_requested_type"
+            and not normalized_selected_subcategories
+            and normalized_selected_categories == {normalized_category}
+        )
+        owned_children = (
+            taxonomy_status
+            in {"member_of_requested_umbrella", "agent_selected_type"}
+            and selected_owned_children
+        )
+        if exact_category or owned_children:
+            return None
+        return (
+            f"Requested product type '{requested_product_type}' binds to advertised "
+            f"category '{advertised_name}'. Select that category directly or only "
+            "its advertised children; do not substitute another category."
+        )
+    selected_matches = (
+        len(selected_subcategories) == 1
+        and _normalize_product_text(selected_subcategories[0])
+        == _normalize_product_text(advertised_name)
+        and normalized_selected_categories in (set(), {normalized_category})
+    )
+    if selected_matches and taxonomy_status in {
+        "exact_requested_type",
+        "agent_selected_type",
+    }:
+        return None
+    return (
+        f"Requested product type '{requested_product_type}' binds to advertised "
+        f"subcategory '{advertised_name}'. Select only that exact subcategory; "
+        "do not substitute an advertised sibling."
+    )
+
+
+def _catalog_execution_taxonomy_status(
+    requested_product_type: str | None,
+    taxonomy: BaseModel | dict[str, Any],
+    semantic_query: str,
+    capabilities: CatalogCapabilities,
+    *,
+    shopper_stated_scope: bool,
+) -> str:
+    """Derive the legacy execution mode without asking the model to label it."""
+
+    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
+    categories = payload.get("category") or []
+    subcategories = payload.get("subcategory") or []
+    if (
+        not semantic_query.strip()
+        and not requested_product_type
+        and not categories
+        and not subcategories
+    ):
+        return "image_only"
+    if not shopper_stated_scope:
+        return "agent_selected_type"
+
+    advertised_match = _advertised_scope_match(
+        requested_product_type,
+        capabilities,
+    )
+    if advertised_match is not None:
+        scope_kind = advertised_match[0]
+        if scope_kind == "category" and subcategories:
+            return "member_of_requested_umbrella"
+        return "exact_requested_type"
+    if len(categories) == 1 and not subcategories:
+        return "parent_category_alternative"
+    if subcategories:
+        return "member_of_requested_umbrella"
+    return "exact_requested_type"
+
+
+class SearchCatalogToolArguments(BaseModel):
+    """Stable agent-facing catalog-search arguments."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    semantic_query: str = Field(
+        ...,
+        description=(
+            "One soft or descriptive product search string for semantic ranking. "
+            "Product type may be repeated for relevance, but taxonomy and other "
+            "must-haves are enforced only by the structured fields below. Use an "
+            "empty string only for an image-only search."
+        ),
+    )
+    shopper_guidance: str = Field(
+        ...,
+        max_length=400,
+        description=(
+            "One concise, product-agnostic shopper-facing sentence written under "
+            "the active skill before search results are known. Connect this "
+            "product role to the shopper's stated goal or direct antecedent. Do "
+            "not name unselected or unavailable product types, name or describe "
+            "candidate products, assert product attributes, or mention tools, "
+            "schemas, filters, evidence, or identifiers. Use an empty string only "
+            "for image-only search."
+        ),
+    )
+    requested_product_type: str | None = Field(
+        ...,
+        description=(
+            "Shortest product noun or umbrella phrase for this focused role, "
+            "resolved from the shopper's current turn or direct antecedent. "
+            "Exclude color, material, fit, occasion, weather, and style modifiers: "
+            "'formal tops' and 'relaxed-fit tops' both use 'tops'. For a genuinely "
+            "open role selected by the agent, use the chosen advertised role noun. "
+            "If this type is not separately advertised and you select one faithful "
+            "advertised parent category, keep this shopper-named type unchanged. "
+            "This is provenance, not catalog taxonomy or a ranking query. Use null "
+            "only for image-only search."
+        ),
+    )
+    taxonomy: CatalogTaxonomyToolInput = Field(
+        ...,
+        description=(
+            "Required catalog-derived taxonomy selection. Allowed category and "
+            "subcategory values come from the active catalog capabilities. Every "
+            "selected value must be the requested product type or a child of an "
+            "umbrella the shopper actually named. For a genuinely open request, "
+            "select one advertised subcategory as the focused role. Never select "
+            "a parent or sibling as a substitute for an advertised type. If a "
+            "shopper-named type is not separately advertised but one advertised "
+            "category is its faithful broader parent, select only that category "
+            "and leave subcategory empty; results remain alternatives under their "
+            "actual catalog types. For example, skirts may satisfy bottoms; "
+            "dresses may not."
+        ),
+    )
+    required_constraints: dict[str, Any] = Field(
+        ...,
+        description=(
+            "Every non-taxonomy must-have stated for the target products in the "
+            "current shopper turn, as a structured field and value. Facts about "
+            "an antecedent or anchor guide semantic styling judgment; do not copy "
+            "them onto a complementary product unless the shopper explicitly asks "
+            "for the same value. "
+            "Use exact hard-filter properties and advertised enum values from "
+            "current Catalog capabilities. Put a directly stated requirement "
+            "those capabilities do not advertise in unadvertised_requirements. "
+            "Season, weather, occasion, "
+            "and subjective style/vibe "
+            "context remain semantic direction unless the shopper directly "
+            "requires an objective product attribute. A defining material is a "
+            "must-have: for 'Any denim skirts available?', put 'denim' in "
+            "unadvertised_requirements when composition is not a hard filter. "
+            "Product types never belong in unadvertised_requirements."
+        ),
+    )
+    scope_complete: bool = Field(
+        ...,
+        description=(
+            "True only when this search plus existing turn evidence is enough to "
+            "answer the shopper's complete current request. For a recommendation-"
+            "only one-role request this is true. Set false when an explicitly "
+            "requested product role, product-detail verification, availability "
+            "check, or cart action still must run after this search. Do not set "
+            "false merely to search alternatives or adjacent types, or because a "
+            "broader multi-turn outfit project remains unfinished. 'Start with a "
+            "beige top' and 'What bottoms go with that?' are each complete after "
+            "their own one-role search."
+        ),
+    )
+    search_mode: str | None = Field(
+        default=None,
+        description="Optional search mode from Catalog capabilities.",
+    )
+
+
+class SearchCatalogToolInput(SearchCatalogToolArguments):
+    """Runtime-validated catalog search request."""
+
+    taxonomy_status: Literal[
+        "exact_requested_type",
+        "member_of_requested_umbrella",
+        "parent_category_alternative",
+        "agent_selected_type",
+        "no_direct_catalog_match",
+        "image_only",
+    ] = Field(..., description="Server-derived catalog execution mode.")
+
+    @model_validator(mode="after")
+    def text_search_has_taxonomy_scope(self) -> "SearchCatalogToolInput":
+        if len(set(self.taxonomy.category)) > 1:
+            raise ValueError("catalog search accepts at most one category")
+        has_taxonomy = bool(
+            self.taxonomy.category or self.taxonomy.subcategory
+        )
+        has_query = bool(self.semantic_query.strip())
+        has_shopper_guidance = bool(self.shopper_guidance.strip())
+        requested_product_type = (
+            self.requested_product_type.strip()
+            if isinstance(self.requested_product_type, str)
+            else ""
+        )
+        if self.taxonomy_status in {
+            "image_only",
+            "no_direct_catalog_match",
+        }:
+            if has_shopper_guidance:
+                raise ValueError(
+                    "A non-text retrieval path requires empty shopper_guidance"
+                )
+        elif not has_shopper_guidance:
+            raise ValueError(
+                "catalog retrieval requires non-empty shopper_guidance"
+            )
+        if self.taxonomy_status != "image_only" and not requested_product_type:
+            raise ValueError(
+                "text catalog search requires requested_product_type"
+            )
+        if self.taxonomy_status == "image_only" and requested_product_type:
+            raise ValueError(
+                "image-only search requires requested_product_type=null"
+            )
+        if self.taxonomy_status == "no_direct_catalog_match":
+            if has_taxonomy:
+                raise ValueError(
+                    "a non-retrieval result requires empty taxonomy arrays"
+                )
+            if not has_query:
+                raise ValueError(
+                    "a non-retrieval result requires a requested product type"
+                )
+            constraints = (
+                self.required_constraints.model_dump(exclude_none=True)
+                if isinstance(self.required_constraints, BaseModel)
+                else self.required_constraints
+            )
+            has_constraint = any(
+                value not in (None, "", [], {})
+                for value in constraints.values()
+            )
+            if has_constraint:
+                raise ValueError(
+                    "a non-retrieval result cannot include required constraints"
+                )
+            return self
+        if self.taxonomy_status == "image_only":
+            if has_query or has_taxonomy:
+                raise ValueError(
+                    "image-only search requires an empty semantic query and taxonomy"
+                )
+            return self
+        if self.taxonomy_status == "member_of_requested_umbrella" and not (
+            self.taxonomy.subcategory
+        ):
+            raise ValueError(
+                "an umbrella search requires an advertised subcategory"
+            )
+        if self.taxonomy_status == "agent_selected_type" and not (
+            self.taxonomy.subcategory
+        ):
+            raise ValueError(
+                "an open-role search requires an advertised subcategory"
+            )
+        if self.taxonomy_status == "parent_category_alternative" and not (
+            len(self.taxonomy.category) == 1
+            and not self.taxonomy.subcategory
+        ):
+            raise ValueError(
+                "a parent-category alternative requires one advertised category "
+                "and no subcategory"
+            )
+        if has_query and not has_taxonomy:
+            raise ValueError(
+                "text catalog search requires an advertised category or subcategory"
+            )
+        if not has_query:
+            raise ValueError("text catalog search requires a semantic query")
+        return self
+
+
+def _exact_taxonomy_issue(
+    requested_product_type: str,
+    taxonomy: BaseModel | dict[str, Any],
+) -> str | None:
+    """Return a coherence issue for an exact taxonomy claim."""
+
+    payload = taxonomy.model_dump() if isinstance(taxonomy, BaseModel) else taxonomy
+    categories = payload.get("category") or []
+    subcategories = payload.get("subcategory") or []
+    requested_matches_category = not subcategories and any(
+        _normalize_product_text(requested_product_type)
+        == _normalize_product_text(category)
+        for category in categories
+    )
+    if requested_matches_category:
+        return None
+
+    selected_product_types = subcategories or categories
+    if len(selected_product_types) != 1:
+        return (
+            "The selected taxonomy must faithfully represent one requested type "
+            "or every child of a shopper-requested umbrella."
+        )
+    selected_product_type = selected_product_types[0]
+    if _normalize_product_text(requested_product_type) == _normalize_product_text(
+        selected_product_type
+    ):
+        return None
+    return (
+        "A single taxonomy value must match requested_product_type. If no "
+        "advertised value faithfully represents it, ask a clarification instead"
+    )
+
+
+class _CatalogNumberConstraint(BaseModel):
+    """Inclusive numeric range accepted by catalog hard filters."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    min: float | None = None
+    max: float | None = None
+
+    @model_validator(mode="after")
+    def has_a_bound(self) -> "_CatalogNumberConstraint":
+        if self.min is None and self.max is None:
+            raise ValueError("numeric constraint requires min and/or max")
+        if self.min is not None and self.max is not None and self.min > self.max:
+            raise ValueError("numeric constraint min cannot exceed max")
+        return self
+
+
+def _search_catalog_tool_input_model(
+    capabilities: CatalogCapabilities,
+    *,
+    validate_scope: bool = True,
+) -> type[SearchCatalogToolArguments]:
+    """Create one tool schema whose enums come from the active catalog."""
+
+    taxonomy = capabilities.taxonomy
+    advertised_search_modes = tuple(dict.fromkeys(capabilities.retrieval_modes))
+    search_mode_type = (
+        Literal.__getitem__(advertised_search_modes)
+        if advertised_search_modes
+        else str
+    )
+    category_values = (
+        sorted(taxonomy.categories, key=str.casefold)
+        if taxonomy.category_field
+        else []
+    )
+    subcategory_values = (
+        sorted(
+            {
+                name
+                for category in taxonomy.categories.values()
+                for name in category.subcategories
+            },
+            key=str.casefold,
+        )
+        if taxonomy.subcategory_field
+        else []
+    )
+
+    category_type, category_field = _taxonomy_list_field(
+        category_values,
+        role="category",
+        advertised_field=taxonomy.category_field,
+    )
+    subcategory_type, subcategory_field = _taxonomy_list_field(
+        subcategory_values,
+        role="subcategory",
+        advertised_field=taxonomy.subcategory_field,
+    )
+    taxonomy_model = create_model(
+        "CatalogTaxonomySelection",
+        __base__=CatalogTaxonomyToolInput,
+        category=(category_type, category_field),
+        subcategory=(subcategory_type, subcategory_field),
+    )
+    required_constraints_model = _required_constraints_input_model(
+        capabilities,
+    )
+    return create_model(
+        "CatalogSearchInput" if validate_scope else "CatalogSearchToolArguments",
+        __base__=(
+            SearchCatalogToolInput
+            if validate_scope
+            else SearchCatalogToolArguments
+        ),
+        taxonomy=(
+            taxonomy_model,
+            Field(
+                ...,
+                description=(
+                    "Required taxonomy selection generated from the active catalog. "
+                    "Use exact enum values. A text search requires at least one "
+                    "category or subcategory; both arrays may be empty only for "
+                    "an image-only search."
+                    " Every value must be a kind of the requested scope: skirts "
+                    "may satisfy bottoms; dresses may not. For a broad request "
+                    "that names no product type, choose one exact advertised "
+                    "subcategory as the focused starting role. If a shopper-named "
+                    "type is not separately advertised but one faithful broader "
+                    "advertised parent category exists, select only that category "
+                    "and leave subcategory empty."
+                ),
+            ),
+        ),
+        required_constraints=(
+            required_constraints_model,
+            Field(
+                ...,
+                description=(
+                    "Catalog hard filters and any defining requirement the active "
+                    "catalog cannot enforce. Apply constraints only when the "
+                    "current turn states them for the target products; an anchor's "
+                    "attributes belong in semantic styling context unless the "
+                    "shopper explicitly requests the same value. Use only the "
+                    "advertised properties "
+                    "in this object; put unsupported must-haves in "
+                    "unadvertised_requirements instead of weakening them. For "
+                    "'Do you have water-resistant bags?', use "
+                    "{'unadvertised_requirements': ['water resistance']}. Do not "
+                    "put broad season, weather, occasion, or subjective style/vibe "
+                    "context here unless the shopper directly requires a product "
+                    "attribute. 'Rainy day outfit' does not require water "
+                    "resistance; 'water-resistant bags' does. Recommendation "
+                    "adjectives such as comfortable, relaxed, soft, breathable, "
+                    "lightweight, casual, dressy, bold, bright, vibrant, or "
+                    "sporty are always semantic ranking preferences, not "
+                    "objective hard filters. Before calling the tool, compare "
+                    "every target-product modifier with this advertised schema "
+                    "and include every exact matching filter value. A product type "
+                    "never belongs in unadvertised_requirements. Use an empty "
+                    "object for image-only search."
+                ),
+            ),
+        ),
+        search_mode=(
+            search_mode_type | None,
+            Field(
+                default=None,
+                description="Optional search mode advertised by the active catalog.",
+            ),
+        ),
+    )
+
+
+def _taxonomy_list_field(
+    values: list[str],
+    *,
+    role: str,
+    advertised_field: str | None,
+) -> tuple[Any, Any]:
+    field_name = advertised_field or "not advertised"
+    description = (
+        f"Exact {role} values advertised through catalog field '{field_name}'. "
+        "Use an empty list when the other taxonomy role supplies the text scope or "
+        "the search is image-only."
+    )
+    if role == "category":
+        description += " Select at most one category per catalog search."
+    if not values:
+        return list[str], Field(..., max_length=0, description=description)
+
+    literal_type = Literal.__getitem__(tuple(values))
+    max_length = 1 if role == "category" else None
+    return list[literal_type], Field(
+        ...,
+        max_length=max_length,
+        description=description,
+    )
+
+
+def _required_constraints_input_model(
+    capabilities: CatalogCapabilities,
+) -> type[BaseModel]:
+    """Create a hard-constraint schema from advertised catalog filters."""
+
+    taxonomy_fields = {
+        field_name
+        for field_name in (
+            capabilities.taxonomy.category_field,
+            capabilities.taxonomy.subcategory_field,
+        )
+        if field_name
+    }
+    fields: dict[str, tuple[Any, Any]] = {}
+    for name, capability in sorted(effective_filter_capabilities(capabilities).items()):
+        if name in taxonomy_fields:
+            continue
+        if capability.type in {"enum", "enum_list"} and capability.values:
+            value_type = Literal.__getitem__(tuple(capability.values))
+            field_type = value_type | list[value_type] | None
+        elif capability.type == "number":
+            field_type = _CatalogNumberConstraint | None
+        else:
+            field_type = str | list[str] | None
+        fields[name] = (
+            field_type,
+            Field(
+                default=None,
+                description=f"Advertised hard filter '{name}'.",
+            ),
+        )
+    fields["unadvertised_requirements"] = (
+        list[str],
+        Field(
+            default_factory=list,
+            description=(
+                "Only objective product requirements directly stated in the "
+                "current shopper turn and absent from this schema. Never infer a "
+                "requirement from season, weather, occasion, or subjective "
+                "style/vibe context: 'rainy day outfit' produces an empty list. "
+                "Use ['water resistance'] for 'water-resistant bags' because that "
+                "turn directly states the product requirement. Never omit or "
+                "soften a directly stated objective requirement. Subjective "
+                "recommendation adjectives such as comfortable, relaxed, soft, "
+                "breathable, lightweight, casual, dressy, bold, bright, vibrant, "
+                "or sporty always stay semantic; never put them in this field. "
+                "Before calling the tool, include every exact advertised filter "
+                "value that modifies the target product; do not leave this object "
+                "empty when one applies. "
+                "In an 'A or B' request, do not put the "
+                "supported advertised branch here. A product type never belongs "
+                "here."
+            ),
+        ),
+    )
+    return create_model(
+        "CatalogRequiredConstraints",
+        __config__=ConfigDict(extra="forbid"),
+        **fields,
+    )
+
+
+class _ShopperSkillActivationInput(BaseModel):
+    """Shared composition rules for dynamic shopper-skill activation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    skill_names: list[str]
+
+    @model_validator(mode="after")
+    def primary_procedures_are_exclusive(self) -> "_ShopperSkillActivationInput":
+        selected = set(self.skill_names)
+        primary = selected.intersection(
+            {"outfit-styling", "product-discovery"}
+        )
+        if len(primary) > 1:
+            raise PydanticCustomError(
+                SKILL_ACTIVATION_MULTIPLE_PRIMARY,
+                "select exactly one primary procedure: outfit-styling or "
+                "product-discovery, never both",
+            )
+        if "budget-shopping" in selected and len(primary) != 1:
+            raise PydanticCustomError(
+                SKILL_ACTIVATION_MODIFIER_REQUIRES_PRIMARY,
+                "budget-shopping requires exactly one primary procedure: "
+                "outfit-styling or product-discovery",
+            )
+        return self
+
+
+def _skill_activation_input_model(
+    skill_names: tuple[str, ...],
+) -> type[BaseModel]:
+    """Create the semantic skill-selection schema from the active registry."""
+
+    skill_name_type = Literal.__getitem__(skill_names)
+    return create_model(
+        "ShopperSkillActivationInput",
+        __base__=_ShopperSkillActivationInput,
+        skill_names=(
+            list[skill_name_type],
+            Field(
+                ...,
+                min_length=1,
+                max_length=len(skill_names),
+                description=(
+                    "Smallest set of registered shopper skills whose descriptions "
+                    "cover the current turn's complete intent. For product search "
+                    "or styling, select exactly one primary procedure: outfit-"
+                    "styling or product-discovery, never both. Cart and policy "
+                    "intents may select their standalone skill without a primary."
+                ),
+            ),
+        ),
+    )
+
+
+def _taxonomy_hard_constraints(
+    selection: BaseModel | dict[str, Any],
+    capabilities: CatalogCapabilities,
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Map generic taxonomy roles to catalog-owned hard-filter field names."""
+
+    raw = selection.model_dump() if isinstance(selection, BaseModel) else selection
+    categories = sorted(set(raw.get("category", [])), key=str.casefold)
+    subcategories = sorted(set(raw.get("subcategory", [])), key=str.casefold)
+    taxonomy = capabilities.taxonomy
+    issues: list[str] = []
+
+    for category in categories:
+        if category not in taxonomy.categories:
+            issues.append(f"category '{category}' is not advertised")
+
+    owners: dict[str, list[str]] = {
+        subcategory: sorted(
+            [
+                category_name
+                for category_name, category in taxonomy.categories.items()
+                if subcategory in category.subcategories
+            ],
+            key=str.casefold,
+        )
+        for subcategory in subcategories
+    }
+    for subcategory, subcategory_owners in owners.items():
+        if not subcategory_owners:
+            issues.append(f"subcategory '{subcategory}' is not advertised")
+        elif categories and not set(categories).intersection(subcategory_owners):
+            issues.append(
+                f"subcategory '{subcategory}' is not available in selected categories"
+            )
+
+    if categories and subcategories:
+        for category in categories:
+            advertised = taxonomy.categories.get(category)
+            if advertised is None:
+                continue
+            if not set(subcategories).intersection(advertised.subcategories):
+                issues.append(
+                    f"category '{category}' has no selected subcategory"
+                )
+
+    effective_categories = categories
+    if subcategories and not categories:
+        inferred_categories = sorted(
+            {
+                owner
+                for subcategory_owners in owners.values()
+                for owner in subcategory_owners
+            },
+            key=str.casefold,
+        )
+        if len(inferred_categories) > 1:
+            issues.append(
+                "subcategory selection has multiple owning categories; select "
+                "exactly one advertised category"
+            )
+            effective_categories = []
+        else:
+            effective_categories = inferred_categories
+
+    constraints: dict[str, list[str]] = {}
+    if effective_categories:
+        if taxonomy.category_field:
+            constraints[taxonomy.category_field] = effective_categories
+        else:
+            issues.append("the catalog does not advertise a category filter field")
+    if subcategories:
+        if taxonomy.subcategory_field:
+            constraints[taxonomy.subcategory_field] = subcategories
+        else:
+            issues.append("the catalog does not advertise a subcategory filter field")
+    return constraints, issues
+
+
+def _catalog_search_scope(
+    taxonomy: dict[str, list[str]],
+    required_constraints: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the normalized hard-filter identity for one catalog search."""
+
+    return {
+        "taxonomy": _normalized_scope_value(taxonomy),
+        "required_constraints": _normalized_scope_value(required_constraints),
+    }
+
+
+def _normalized_scope_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _normalized_scope_value(item)
+            for key, item in sorted(value.items())
+        }
+    if isinstance(value, list):
+        normalized = [_normalized_scope_value(item) for item in value]
+        return sorted(normalized, key=lambda item: json.dumps(item, sort_keys=True))
+    return value
+
+
+class AddCartItemsToolItemInput(BaseModel):
+    product_ref: str = Field(
+        ...,
+        min_length=1,
+        description="PRODUCT_REF returned by search_catalog_tool in this conversation.",
+    )
+    quantity: int = Field(
+        default=1,
+        ge=1,
+        description="Quantity of this product to add.",
+    )
+    expected_display_name: str | None = Field(
+        default=None,
+        description=(
+            "Shopper-facing product name the agent intends to add. When the "
+            "shopper explicitly names the product, copy that exact product name."
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class RequestIdentity:
+    """Server-owned identity used to scope one assistant turn."""
+
+    session_id: str
+    conversation_id: str
+    cart_id: str
+    context_user_id: int
+    cart_user_id: int
+    request_id: str
+    shopper_profile_id: str | None = None
+
+    @property
+    def legacy_user_id(self) -> int:
+        return self.context_user_id
+
+    @property
+    def checkpoint_thread_id(self) -> str:
+        return json.dumps(
+            [self.conversation_id, self.request_id],
+            separators=(",", ":"),
+        )
+
+
+def _conversation_turn_status(termination_reason: str) -> FinalTurnStatus:
+    if termination_reason in {
+        "input_guardrail_blocked",
+        "output_guardrail_blocked",
+    }:
+        return "blocked"
+    if termination_reason == "completed":
+        return "completed"
+    return "failed"
+
+
+def create_request_identity(
+    *,
+    legacy_user_id: int,
+    session_id: str | None = None,
+    conversation_id: str | None = None,
+    cart_id: str | None = None,
+    request_id: str | None = None,
+    shopper_profile_id: str | None = None,
+) -> RequestIdentity:
+    """Create scoped request identity while preserving legacy user_id behavior."""
+
+    session = session_id or f"legacy-session-{legacy_user_id}"
+    conversation = conversation_id or f"legacy-conversation-{legacy_user_id}"
+    cart = cart_id or f"legacy-cart-{legacy_user_id}"
+    return RequestIdentity(
+        session_id=session,
+        conversation_id=conversation,
+        cart_id=cart,
+        context_user_id=(
+            _stable_numeric_id("conversation", conversation_id)
+            if conversation_id
+            else legacy_user_id
+        ),
+        cart_user_id=_stable_numeric_id("cart", cart_id) if cart_id else legacy_user_id,
+        request_id=request_id or str(uuid.uuid4()),
+        shopper_profile_id=shopper_profile_id,
+    )
+
+
+def _stable_numeric_id(namespace: str, value: str) -> int:
+    digest = hashlib.sha256(f"{namespace}:{value}".encode("utf-8")).hexdigest()
+    return int(digest[:15], 16)
+
+
+def _empty_agent_diagnostics(final_termination_reason: str) -> dict[str, Any]:
+    return {
+        "skill_files_read": [],
+        "tool_calls": [],
+        "rejected_tool_calls": [],
+        "duplicate_tool_calls": [],
+        "product_evidence": [],
+        "product_evidence_truncated": False,
+        "catalog_scope_outcomes": [],
+        "final_termination_reason": final_termination_reason,
+        "partial_graph_messages": [],
+    }
+
+
+async def _partial_graph_messages(
+    agent: Any,
+    invoke_config: dict[str, Any],
+) -> tuple[list[Any], str | None]:
+    """Read the last graph state before its failed checkpoint is deleted."""
+
+    get_state = getattr(agent, "aget_state", None)
+    if get_state is None:
+        return [], "state_snapshot_unavailable"
+    try:
+        snapshot = await asyncio.wait_for(
+            get_state(invoke_config),
+            timeout=_PARTIAL_GRAPH_SNAPSHOT_TIMEOUT_SECONDS,
+        )
+    except TimeoutError:
+        logger.warning("Timed out snapshotting Deep Agents state before cleanup")
+        return [], "state_snapshot_timeout"
+    except Exception as exc:  # noqa: BLE001 - diagnostics cannot block cleanup.
+        error_type = type(exc).__name__
+        logger.warning(
+            "Could not snapshot Deep Agents state before cleanup: %s",
+            error_type,
+        )
+        return [], error_type
+
+    values = _value(snapshot, "values")
+    messages = _value(values, "messages")
+    return (messages if isinstance(messages, list) else []), None
+
+
+def _collect_agent_diagnostics(
+    messages: list[Any],
+    *,
+    request_id: str,
+    final_termination_reason: str,
+    preserve_partial_messages: bool = False,
+) -> dict[str, Any]:
+    """Collect current-turn skill, tool, and termination diagnostics."""
+
+    diagnostics = _empty_agent_diagnostics(final_termination_reason)
+    turn_messages = _current_turn_messages(messages, request_id)
+    tool_results = _tool_results_by_call_id(turn_messages)
+    skill_files_read: list[str] = []
+    successful_product_tool_calls: dict[str, str] = {}
+
+    for message in turn_messages:
+        if _message_type(message) != "ai":
+            continue
+        calls = [
+            (raw_call, None)
+            for raw_call in (_value(message, "tool_calls") or [])
+        ]
+        additional_kwargs = _value(message, "additional_kwargs") or {}
+        restored_fields_by_call: dict[str, list[str]] = {}
+        if isinstance(additional_kwargs, dict):
+            restored_calls = additional_kwargs.get(
+                SERVER_RESTORED_TOOL_CALL_FIELDS
+            )
+            if isinstance(restored_calls, list):
+                for restored_call in restored_calls[:8]:
+                    tool_call_id = str(
+                        _value(restored_call, "tool_call_id") or ""
+                    )
+                    fields = _value(restored_call, "fields")
+                    if not tool_call_id or not isinstance(fields, list):
+                        continue
+                    restored_fields_by_call[tool_call_id] = [
+                        str(field)[:64] for field in fields[:8]
+                    ]
+            calls.extend(
+                (raw_call, str(_value(raw_call, "rejection_reason") or "rejected"))
+                for raw_call in (
+                    additional_kwargs.get(_SERVER_REJECTED_TOOL_CALLS) or []
+                )
+            )
+        for raw_call, forced_rejection_reason in calls:
+            call = _normalized_tool_call(raw_call)
+            sequence = len(diagnostics["tool_calls"]) + 1
+            result_message = tool_results.get(call["tool_call_id"])
+            if forced_rejection_reason:
+                status, rejection_reason = "rejected", forced_rejection_reason
+            else:
+                status, rejection_reason = _tool_call_status(
+                    call["tool_name"],
+                    result_message,
+                )
+            entry = {
+                "sequence": sequence,
+                "tool_name": call["tool_name"],
+                "arguments": call["arguments"],
+                "status": status,
+            }
+            if rejection_reason:
+                entry["rejection_reason"] = rejection_reason
+            restored_fields = restored_fields_by_call.get(call["tool_call_id"])
+            if restored_fields:
+                entry["restored_fields"] = restored_fields
+            if rejection_reason == "duplicate_catalog_scope":
+                entry["duplicate"] = True
+                diagnostics["duplicate_tool_calls"].append(sequence)
+            if status == "rejected":
+                diagnostics["rejected_tool_calls"].append(sequence)
+            diagnostics["tool_calls"].append(entry)
+
+            if (
+                status == "completed"
+                and call["tool_call_id"]
+                and call["tool_name"]
+                in {"search_catalog_tool", "get_product_details_tool"}
+            ):
+                successful_product_tool_calls[call["tool_call_id"]] = call[
+                    "tool_name"
+                ]
+
+            for skill_path in _skill_file_paths(call, status):
+                if skill_path not in skill_files_read:
+                    skill_files_read.append(skill_path)
+
+    diagnostics["skill_files_read"] = skill_files_read
+    product_evidence, product_evidence_truncated = _diagnostic_product_evidence(
+        turn_messages,
+        successful_product_tool_calls,
+    )
+    diagnostics["product_evidence"] = product_evidence
+    diagnostics["product_evidence_truncated"] = product_evidence_truncated
+    diagnostics["catalog_scope_outcomes"] = _diagnostic_catalog_scope_outcomes(
+        turn_messages
+    )
+    if preserve_partial_messages:
+        partial, truncated = _serialize_partial_graph_messages(turn_messages)
+        diagnostics["partial_graph_messages"] = partial
+        if truncated:
+            diagnostics["partial_graph_messages_truncated"] = True
+    return diagnostics
+
+
+def _safe_collect_agent_diagnostics(
+    messages: list[Any],
+    *,
+    request_id: str,
+    final_termination_reason: str,
+    preserve_partial_messages: bool = False,
+) -> dict[str, Any]:
+    """Collect diagnostics without allowing tracing to change turn behavior."""
+
+    try:
+        return _collect_agent_diagnostics(
+            messages,
+            request_id=request_id,
+            final_termination_reason=final_termination_reason,
+            preserve_partial_messages=preserve_partial_messages,
+        )
+    except Exception as exc:  # noqa: BLE001 - diagnostics must fail independently.
+        error_type = type(exc).__name__
+        logger.warning("Could not collect Deep Agents diagnostics: %s", error_type)
+        diagnostics = _empty_agent_diagnostics(final_termination_reason)
+        diagnostics["diagnostic_collection_error"] = error_type
+        return diagnostics
+
+
+def _no_direct_taxonomy_response(
+    result: Any,
+    *,
+    request_id: str,
+) -> str | None:
+    """Return the fixed shopper response for a current-turn no-match result."""
+
+    outcomes = _business_tool_result_contents(
+        _current_turn_messages(_result_messages(result), request_id)
+    )
+    no_direct_outcomes = [
+        content
+        for content in outcomes
+        if content.startswith(
+            f"{STOP_TOOL_USE_PREFIX} No faithful advertised catalog taxonomy"
+        )
+    ]
+    repair_or_no_direct = all(
+        content.startswith(
+            (
+                SEARCH_VALIDATION_ERROR_PREFIX,
+                f"{STOP_TOOL_USE_PREFIX} No faithful advertised catalog taxonomy",
+            )
+        )
+        for content in outcomes
+    )
+    if no_direct_outcomes and repair_or_no_direct:
+        return _NO_DIRECT_TAXONOMY_RESPONSE
+    return None
+
+
+def _rejected_catalog_search_response(
+    result: Any,
+    *,
+    request_id: str,
+) -> str | None:
+    """Fail closed when every current-turn business call is a rejected search."""
+
+    messages = _current_turn_messages(_result_messages(result), request_id)
+    tool_results = _tool_results_by_call_id(messages)
+    business_calls: list[tuple[str, str]] = []
+    for message in messages:
+        if _message_type(message) != "ai":
+            continue
+        calls = [
+            (raw_call, False)
+            for raw_call in (_value(message, "tool_calls") or [])
+        ]
+        additional_kwargs = _value(message, "additional_kwargs") or {}
+        if isinstance(additional_kwargs, dict):
+            calls.extend(
+                (raw_call, True)
+                for raw_call in (
+                    additional_kwargs.get(_SERVER_REJECTED_TOOL_CALLS) or []
+                )
+            )
+        for raw_call, server_rejected in calls:
+            call = _normalized_tool_call(raw_call)
+            tool_name = call["tool_name"]
+            if tool_name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"}:
+                continue
+            status = (
+                "rejected"
+                if server_rejected
+                else _tool_call_status(
+                    tool_name,
+                    tool_results.get(call["tool_call_id"]),
+                )[0]
+            )
+            business_calls.append((tool_name, status))
+
+    if not business_calls:
+        return None
+    if _catalog_repair_clarification_response(
+        result,
+        request_id=request_id,
+    ):
+        return None
+    if all(
+        tool_name == "search_catalog_tool" and status == "rejected"
+        for tool_name, status in business_calls
+    ):
+        return _REJECTED_CATALOG_SEARCH_RESPONSE
+    return None
+
+
+def _catalog_repair_clarification_response(
+    result: Any,
+    *,
+    request_id: str,
+) -> str:
+    """Return a fixed response for a server-marked no-tool repair branch."""
+
+    messages = _current_turn_messages(_result_messages(result), request_id)
+    for message in reversed(messages):
+        if _message_type(message) != "ai" or _value(message, "tool_calls"):
+            continue
+        additional_kwargs = _value(message, "additional_kwargs") or {}
+        if not isinstance(additional_kwargs, dict) or not additional_kwargs.get(
+            SERVER_CATALOG_CLARIFICATION
+        ):
+            continue
+        return _CATALOG_REPAIR_CLARIFICATION_RESPONSE
+    return ""
+
+
+def _business_tool_result_contents(messages: list[Any]) -> list[str]:
+    """Return non-activation tool outcomes in graph order."""
+
+    outcomes: list[str] = []
+    for message in messages:
+        if _message_type(message) != "tool":
+            continue
+        name = str(_value(message, "name") or "")
+        content = _content_to_text(_value(message, "content"))
+        if name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"} or content.startswith(
+            (
+                SKILL_ACTIVATION_COMPLETE,
+                SKILL_ACTIVATION_REQUIRED,
+                SKILL_TOOL_NOT_GRANTED,
+                "SHOPPER_SKILL_ACTIVATION_FAILED:",
+            )
+        ):
+            continue
+        outcomes.append(content)
+    return outcomes
+
+
+def _has_unsupported_requirement_outcome(
+    result: Any,
+    *,
+    request_id: str,
+) -> bool:
+    """Return whether the current turn contains an unenforceable requirement."""
+
+    return any(
+        _message_type(message) == "tool"
+        and _content_to_text(_value(message, "content")).startswith(
+            UNSUPPORTED_CONSTRAINT_PREFIX
+        )
+        for message in _current_turn_messages(
+            _result_messages(result),
+            request_id,
+        )
+    )
+
+
+def _normalized_tool_call(raw_call: Any) -> dict[str, Any]:
+    arguments = _value(raw_call, "args")
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            arguments = {"value": arguments}
+    if not isinstance(arguments, dict):
+        arguments = {} if arguments is None else {"value": arguments}
+    return {
+        "tool_call_id": str(_value(raw_call, "id") or ""),
+        "tool_name": str(_value(raw_call, "name") or "unknown"),
+        "arguments": _diagnostic_json_value(arguments),
+    }
+
+
+def _tool_call_status(
+    tool_name: str,
+    result_message: Any | None,
+) -> tuple[str, str | None]:
+    if result_message is None:
+        return "pending", None
+    content = _content_to_text(_value(result_message, "content"))
+    rejection_reason = _tool_rejection_reason(content)
+    if rejection_reason:
+        return "rejected", rejection_reason
+    if _value(result_message, "status") == "error":
+        return "error", None
+    if tool_name == "read_file" and content.lower().startswith(
+        ("error", "file not found")
+    ):
+        return "error", None
+    return "completed", None
+
+
+def _tool_rejection_reason(content: str) -> str | None:
+    markers = (
+        (SKILL_ACTIVATION_REQUIRED, "skill_activation_required"),
+        (SKILL_TOOL_NOT_GRANTED, "skill_tool_not_granted"),
+        ("SHOPPER_SKILL_ACTIVATION_FAILED:", "skill_activation_failed"),
+        (
+            f"{STOP_TOOL_USE_PREFIX} This catalog taxonomy and constraint scope was already searched",
+            "duplicate_catalog_scope",
+        ),
+        (f"{STOP_TOOL_USE_PREFIX} Catalog search limit reached", "catalog_search_limit"),
+        (
+            "STOP_TOOL_USE: No faithful advertised catalog taxonomy",
+            "no_advertised_taxonomy_match",
+        ),
+        (
+            f"{STOP_TOOL_USE_PREFIX} Product-detail read limit reached",
+            "product_detail_read_limit",
+        ),
+        (
+            "The catalog search request does not match current capabilities:",
+            "invalid_catalog_request",
+        ),
+        (SEARCH_VALIDATION_ERROR_PREFIX, "invalid_catalog_request"),
+        (CONSTRAINT_REVIEW_PREFIX, "constraint_review_required"),
+        (
+            UNSUPPORTED_TAXONOMY_PREFIX,
+            "unsupported_catalog_taxonomy",
+        ),
+        (
+            UNSUPPORTED_CONSTRAINT_PREFIX,
+            "unsupported_catalog_constraint",
+        ),
+        (_UNSUPPORTED_SEARCH_MODE_MESSAGE, "unsupported_search_mode"),
+    )
+    for marker, reason in markers:
+        if content.startswith(marker):
+            return reason
+    if content.startswith(STOP_TOOL_USE_PREFIX):
+        return "stop_tool_use"
+    return None
+
+
+def _skill_file_paths(call: dict[str, Any], status: str) -> list[str]:
+    if status != "completed":
+        return []
+    arguments = call["arguments"]
+    if call["tool_name"] == SKILL_ACTIVATION_TOOL_NAME:
+        names = arguments.get("skill_names") or []
+        if not isinstance(names, list):
+            return []
+        return [
+            f"/shopper/{name}/SKILL.md"
+            for name in names
+            if isinstance(name, str) and name.strip()
+        ]
+    if call["tool_name"] != "read_file":
+        return []
+    path = str(arguments.get("file_path") or arguments.get("path") or "")
+    normalized = path.replace("\\", "/")
+    if normalized.startswith("/shopper/") and normalized.endswith("/SKILL.md"):
+        return [normalized]
+    return []
+
+
+def _serialize_partial_graph_messages(
+    messages: list[Any],
+) -> tuple[list[dict[str, Any]], bool]:
+    relevant = [
+        message for message in messages if _message_type(message) in {"ai", "tool"}
+    ]
+    truncated = len(relevant) > 24
+    serialized: list[dict[str, Any]] = []
+    for message in relevant[-24:]:
+        content = _content_to_text(_value(message, "content"))
+        content_truncated = len(content) > 2000
+        payload: dict[str, Any] = {
+            "type": _message_type(message),
+            "content": content[:2000],
+        }
+        for field in ("name", "tool_call_id"):
+            value = _value(message, field)
+            if value:
+                payload[field] = str(value)
+        tool_calls = _value(message, "tool_calls")
+        if tool_calls:
+            payload["tool_calls"] = [
+                _normalized_tool_call(call) for call in tool_calls
+            ]
+        if content_truncated:
+            payload["truncated"] = True
+            truncated = True
+        serialized.append(payload)
+    return serialized, truncated
+
+
+def _diagnostic_json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {
+            str(key): _diagnostic_json_value(item) for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_diagnostic_json_value(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _diagnostic_product_evidence(
+    messages: list[Any],
+    successful_tool_calls: dict[str, str],
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return bounded product facts from successful current-turn tool results."""
+
+    evidence: list[dict[str, Any]] = []
+    truncated = False
+    aggregate_limit_reached = False
+    for message in messages:
+        if _message_type(message) != "tool":
+            continue
+
+        tool_call_id = str(_value(message, "tool_call_id") or "")
+        source_tool = successful_tool_calls.get(tool_call_id)
+        payload = evidence_of(message)
+        if source_tool == "search_catalog_tool":
+            if not payload or payload.get("outcome") != "results":
+                continue
+            evidence_type = "search_result"
+            search_scope = {
+                "taxonomy": _bounded_product_evidence_value(
+                    payload.get("taxonomy") or {}
+                ),
+                "confirmed_filters": _bounded_product_evidence_value(
+                    payload.get("confirmed_filters") or {}
+                ),
+            }
+            records = payload.get("products") or []
+        elif source_tool == "get_product_details_tool":
+            detail = detail_evidence_of(message)
+            if not detail:
+                continue
+            evidence_type = "product_detail"
+            search_scope = None
+            records = detail.get("products") or []
+        else:
+            continue
+
+        for product in records:
+            product_ref = product.get("product_ref")
+            product_name = product.get("name")
+            if not product_ref or not product_name:
+                continue
+            record = {
+                "product_ref": _bounded_product_evidence_value(product_ref),
+                "product_name": _bounded_product_evidence_value(product_name),
+                "source_tool": source_tool,
+                "evidence_type": evidence_type,
+                "facts": _diagnostic_product_facts(product),
+            }
+            if search_scope is not None:
+                record["search_scope"] = search_scope
+            if (
+                len(evidence) >= _MAX_DIAGNOSTIC_PRODUCT_EVIDENCE
+                or aggregate_limit_reached
+            ):
+                truncated = True
+                continue
+            candidate = [*evidence, record]
+            if len(json.dumps(candidate, sort_keys=True, default=str)) > (
+                _MAX_DIAGNOSTIC_PRODUCT_EVIDENCE_CHARS
+            ):
+                truncated = True
+                aggregate_limit_reached = True
+                continue
+            evidence.append(record)
+    return evidence, truncated
+
+
+def _diagnostic_catalog_scope_outcomes(
+    messages: list[Any],
+) -> list[dict[str, Any]]:
+    """Return bounded server-authored outcomes that contain no products."""
+
+    outcomes: list[dict[str, Any]] = []
+    allowed_fields = {
+        "outcome",
+        "requested_product_type",
+        "taxonomy",
+        "confirmed_filters",
+    }
+    for message in messages:
+        if _message_type(message) != "tool":
+            continue
+        payload = evidence_of(message)
+        outcome = (payload or {}).get("scope_outcome") or {}
+        if (
+            not outcome
+            or not set(outcome).issubset(allowed_fields)
+            or outcome.get("outcome")
+            not in {"no_direct_catalog_match", "zero_results"}
+        ):
+            continue
+        bounded = _bounded_product_evidence_value(outcome)
+        if isinstance(bounded, dict) and bounded not in outcomes:
+            outcomes.append(bounded)
+        if len(outcomes) >= 8:
+            break
+    return outcomes
+
+
+def _diagnostic_product_facts(product: dict[str, Any]) -> dict[str, Any]:
+    """Extract bounded, structured facts from one parsed product record."""
+
+    facts: dict[str, Any] = {}
+    for key in ("category", "brand", "price"):
+        value = product.get(key)
+        if value:
+            facts[key] = _bounded_product_evidence_value(value)
+    facts["image_available"] = bool(product.get("image_url"))
+
+    # Attributes the catalog confirmed on a search result. The composer is
+    # allowed to state these, so the evidence trace has to carry them: a fact an
+    # observer cannot see the support for is indistinguishable from an invented
+    # one, and gets judged as invention however accurate it is.
+    attributes = product.get("attributes")
+    if isinstance(attributes, dict):
+        for name, value in attributes.items():
+            if len(facts) >= _MAX_DIAGNOSTIC_PRODUCT_FACTS:
+                break
+            bounded_name = str(_bounded_product_evidence_value(name))
+            if bounded_name and bounded_name not in facts:
+                facts[bounded_name] = _bounded_product_evidence_value(value)
+
+    for raw_detail in product.get("details") or []:
+        if len(facts) >= _MAX_DIAGNOSTIC_PRODUCT_FACTS:
+            break
+        if not isinstance(raw_detail, str) or ":" not in raw_detail:
+            continue
+        name, value = raw_detail.split(":", 1)
+        name = name.strip()
+        value = value.strip()
+        if not name or not value:
+            continue
+        bounded_name = str(_bounded_product_evidence_value(name))
+        if bounded_name not in facts:
+            facts[bounded_name] = _bounded_product_evidence_value(value)
+    return facts
+
+
+def _bounded_product_evidence_value(value: Any, *, depth: int = 0) -> Any:
+    """Bound strings and collections copied into product evidence diagnostics."""
+
+    if isinstance(value, str):
+        return value[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    if depth >= 4:
+        return str(value)[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]
+    if isinstance(value, dict):
+        return {
+            str(key)[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]: (
+                _bounded_product_evidence_value(item, depth=depth + 1)
+            )
+            for key, item in list(value.items())[:_MAX_DIAGNOSTIC_PRODUCT_FACTS]
+        }
+    if isinstance(value, (list, tuple)):
+        return [
+            _bounded_product_evidence_value(item, depth=depth + 1)
+            for item in value[:_MAX_DIAGNOSTIC_PRODUCT_FACTS]
+        ]
+    return str(value)[:_MAX_DIAGNOSTIC_PRODUCT_STRING_CHARS]
+
+
+def _append_product_results(state: State, products: list[ProductSummary]) -> None:
+    existing_ids = {
+        str(product.get("product_id") or "")
+        for product in state.product_results
+        if isinstance(product, dict)
+    }
+    for product in products:
+        payload = product.model_dump(mode="json")
+        product_id = str(payload.get("product_id") or "")
+        if product_id and product_id in existing_ids:
+            continue
+        state.product_results.append(payload)
+        if product_id:
+            existing_ids.add(product_id)
+
+
+def _committed_effect_receipt(
+    effects: list[dict[str, Any]],
+    cart: Cart | None,
+) -> str:
+    """Tell the shopper exactly what was committed before the turn failed."""
+
+    lines = [
+        "Something went wrong finishing that request, but a cart change was "
+        "already applied:",
+        "",
+    ]
+    for effect in effects:
+        operation = str(effect.get("operation") or "changed")
+        target = str(
+            effect.get("product_id") or effect.get("cart_line_id") or "an item"
+        )
+        quantity = effect.get("quantity")
+        detail = f" (quantity {quantity})" if isinstance(quantity, int) else ""
+        lines.append(f"- {operation}: {target}{detail}")
+    lines.append("")
+    if cart is not None:
+        lines.append(_format_cart(cart))
+        lines.append("")
+    lines.append(
+        "Please review your cart before retrying so the change is not applied "
+        "twice."
+    )
+    return "\n".join(lines)
+
+
+def _has_grounding_authority(state: State, current_evidence: str) -> bool:
+    """Return whether this turn has any authority to check a draft against.
+
+    Every turn hydrates memory lanes before the model runs. Gating the grounding
+    editor on current-turn *tool* evidence alone discards that hydrated context:
+    a follow-up or styling turn grounded in the historical product index or the
+    authoritative cart would skip grounding entirely, leaving the draft free to
+    assert product facts nothing supports.
+
+    Dialogue is deliberately excluded. It establishes shopper intent, never
+    product, policy, inventory, or cart fact, so it is not something a product
+    claim can be checked against.
+    """
+
+    return bool(
+        current_evidence
+        or state.historical_product_sets
+        or state.cart.contents
+    )
+
+
+def _partial_product_results_response(state: State) -> str:
+    products = [
+        product for product in state.product_results if isinstance(product, dict)
+    ]
+    if not products:
+        return ""
+
+    lines = [
+        "I found these grounded catalog options so far:",
+        "",
+    ]
+    seen: set[str] = set()
+    for product in products[:8]:
+        name = str(product.get("display_name") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        parts = [f"**{name}**"]
+        category = str(product.get("category") or "").strip()
+        if category:
+            parts.append(category)
+        price = _product_result_price(product)
+        if price:
+            parts.append(price)
+        lines.append("- " + " — ".join(parts))
+
+    if len(lines) <= 2:
+        return ""
+    lines.extend(
+        [
+            "",
+            (
+                "I do not want to overstate outdoor performance, material, care, "
+                "or fit details without a completed detail check. I can continue "
+                "from these options or narrow one piece at a time."
+            ),
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _has_search_only_tool_evidence(result: Any, *, request_id: str) -> bool:
+    """Return whether current-turn commerce evidence contains only searches."""
+
+    tool_names: list[str] = []
+    has_search_result = False
+    for message in _current_turn_messages(_result_messages(result), request_id):
+        if _message_type(message) != "tool":
+            continue
+        name = str(_value(message, "name") or "")
+        returned_results = (evidence_of(message) or {}).get("outcome") == "results"
+        if not name and returned_results:
+            name = "search_catalog_tool"
+        if name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"}:
+            continue
+        tool_names.append(name)
+        if name == "search_catalog_tool" and returned_results:
+            has_search_result = True
+    return (
+        has_search_result
+        and set(tool_names) == {"search_catalog_tool"}
+    )
+
+
+def _has_successful_non_search_tool_evidence(
+    result: Any,
+    *,
+    request_id: str,
+) -> bool:
+    """Return whether another current-turn shopping tool completed."""
+
+    for message in _current_turn_messages(_result_messages(result), request_id):
+        if _message_type(message) != "tool":
+            continue
+        tool_name = str(_value(message, "name") or "")
+        if tool_name in {
+            "",
+            SKILL_ACTIVATION_TOOL_NAME,
+            "read_file",
+            "search_catalog_tool",
+        }:
+            continue
+        if _tool_call_status(tool_name, message)[0] == "completed":
+            return True
+    return False
+
+
+def _format_search_only_response(
+    state: State,
+    result: Any,
+    *,
+    request_id: str,
+    products: list[dict[str, Any]] | None = None,
+    intro: str = "",
+    heading: str = "Catalog candidates (verified name, price, and category):",
+) -> str:
+    """Render grounded search facts without interpreting display-name words."""
+
+    search_groups = _search_result_groups(result, request_id=request_id)
+    grouped_lines, grouped_names = _grouped_search_response_lines(search_groups)
+    if len(grouped_lines) > 0:
+        lines = grouped_lines
+        displayed_names = grouped_names
+    else:
+        displayed_products = (
+            products
+            if products is not None
+            else [
+                product
+                for product in state.product_results
+                if isinstance(product, dict)
+            ]
+        )
+        candidate_count = len(displayed_products)
+        if intro.strip():
+            lines = [
+                "General guidance (not product-specific facts):",
+                intro.strip(),
+                "",
+            ]
+        else:
+            noun = "candidate" if candidate_count == 1 else "candidates"
+            lines = [f"I found {candidate_count} catalog {noun}.", ""]
+        lines.extend((heading, ""))
+        displayed_names = set()
+        for product in displayed_products:
+            name = str(product.get("display_name") or "").strip()
+            if not name:
+                continue
+            displayed_names.add(name)
+            parts = [f"**{name}**"]
+            price = _product_result_price(product)
+            if price:
+                parts.append(price)
+            category = str(product.get("category") or "").strip()
+            if category:
+                parts.append(category.replace("_", " "))
+            lines.append("- " + " — ".join(parts))
+
+    parent_relations = []
+    for group in search_groups:
+        relation = group.get("scope_relation") or {}
+        requested_type = str(
+            relation.get("requested_product_type") or ""
+        ).strip()
+        category = str(relation.get("advertised_category") or "").strip()
+        normalized = {
+            "requested_product_type": requested_type,
+            "advertised_category": category,
+        }
+        if (
+            relation.get("relation") == "model_selected_parent_category"
+            and requested_type
+            and category
+            and normalized not in parent_relations
+        ):
+            parent_relations.append(normalized)
+    if parent_relations:
+        relation_lines = [
+            (
+                f"The catalog does not advertise **{relation['requested_product_type']}** "
+                "as a separate product type. I searched the broader "
+                f"**{relation['advertised_category']}** category for the closest "
+                "options; each result keeps its actual catalog category."
+            )
+            for relation in parent_relations
+        ]
+        lines = relation_lines + [""] + lines
+
+    filter_groups = _confirmed_search_filter_groups(
+        result,
+        request_id=request_id,
+        displayed_names=displayed_names,
+    )
+    if filter_groups:
+        lines.extend(("", "Catalog-confirmed filters by search:"))
+        for group in filter_groups:
+            product_names = group["product_names"]
+            scope = (
+                ", ".join(f"**{name}**" for name in product_names)
+                if product_names
+                else "Search candidates"
+            )
+            lines.append(f"- {scope}: {'; '.join(group['statements'])}.")
+    unavailable_types = _no_direct_search_types(
+        result,
+        request_id=request_id,
+    )
+    if unavailable_types:
+        lines.extend(("", "Unavailable requested catalog types:"))
+        lines.extend(
+            f"- **{product_type}** is not advertised; I did not substitute "
+            "an adjacent product type."
+            for product_type in unavailable_types
+        )
+    if _has_unsupported_requirement_outcome(
+        result,
+        request_id=request_id,
+    ):
+        lines.extend(("", _UNSUPPORTED_REQUIREMENT_RESPONSE))
+    if not _search_scope_is_complete(result, request_id=request_id):
+        lines.extend(
+            (
+                "",
+                (
+                    "This is a partial result set. I can continue with the next "
+                    "requested piece or search scope."
+                ),
+            )
+        )
+    lines.extend(
+        (
+            "",
+            (
+                "These candidates were ranked toward your requested direction. "
+                "Product-specific material, construction, length, fit, comfort, "
+                "care, or weather performance remains unverified unless listed "
+                "above as a catalog-confirmed filter."
+            ),
+        )
+    )
+    return "\n".join(lines)
+
+
+def _search_result_groups(result: Any, *, request_id: str) -> list[dict[str, Any]]:
+    """Return successful search evidence grouped by the call that produced it."""
+
+    groups: list[dict[str, Any]] = []
+    for message in _current_turn_messages(_result_messages(result), request_id):
+        if _message_type(message) != "tool":
+            continue
+        payload = evidence_of(message)
+        if not payload or payload.get("outcome") != "results":
+            continue
+        groups.append(
+            {
+                "guidance": _scrub_internal_shopper_language(
+                    str(payload.get("shopper_guidance") or "")
+                ).strip(),
+                "products": payload.get("products") or [],
+                "taxonomy": payload.get("taxonomy") or {},
+                "scope_relation": _scope_relation_payload(payload),
+            }
+        )
+    return groups
+
+
+def _grouped_search_response_lines(
+    groups: list[dict[str, Any]],
+) -> tuple[list[str], set[str]]:
+    """Render multi-search candidates without losing their guidance scope."""
+
+    if len(groups) < 2 or not all(group.get("guidance") for group in groups):
+        return [], set()
+    lines: list[str] = []
+    displayed_names: set[str] = set()
+    displayed_product_refs: set[str] = set()
+    for index, group in enumerate(groups, start=1):
+        products = [
+            product
+            for product in group.get("products") or []
+            if str(
+                product.get("product_ref")
+                or f"name:{product.get('name') or ''}"
+            )
+            not in displayed_product_refs
+        ]
+        if not products:
+            continue
+        lines.extend(_format_search_group(group, products, index=index))
+        displayed_product_refs.update(
+            str(
+                product.get("product_ref")
+                or f"name:{product.get('name') or ''}"
+            )
+            for product in products
+        )
+        displayed_names.update(str(product["name"]) for product in products)
+    if lines and not lines[-1]:
+        lines.pop()
+    return lines, displayed_names
+
+
+def _no_direct_search_types(result: Any, *, request_id: str) -> list[str]:
+    """Return current-turn product types with a server-authored no-direct outcome."""
+
+    product_types: list[str] = []
+    for message in _current_turn_messages(_result_messages(result), request_id):
+        if _message_type(message) != "tool":
+            continue
+        payload = evidence_of(message)
+        if not payload or payload.get("outcome") != "no_direct_catalog_match":
+            continue
+        outcome = payload
+        product_type = str(outcome.get("requested_product_type") or "").strip()
+        if product_type and product_type not in product_types:
+            product_types.append(product_type)
+    return product_types
+
+
+def _search_scope_is_complete(result: Any, *, request_id: str) -> bool:
+    """Return whether a current-turn search declared its requested scope complete."""
+
+    return any(
+        _message_type(message) == "tool"
+        and SEARCH_SCOPE_COMPLETE_PREFIX
+        in _content_to_text(_value(message, "content"))
+        for message in _current_turn_messages(_result_messages(result), request_id)
+    )
+
+
+def _search_guidance_evidence(result: Any, *, request_id: str) -> list[str]:
+    """Return bounded pre-search shopper guidance from successful searches."""
+
+    guidance: list[str] = []
+    for message in _current_turn_messages(_result_messages(result), request_id):
+        if _message_type(message) != "tool":
+            continue
+        payload = evidence_of(message)
+        if not payload or payload.get("outcome") != "results":
+            continue
+        text = _scrub_internal_shopper_language(
+            str(payload.get("shopper_guidance") or "")
+        ).strip()
+        if text and text not in guidance:
+            guidance.append(text)
+    return guidance
+
+
+def _confirmed_search_filter_groups(
+    result: Any,
+    *,
+    request_id: str,
+    displayed_names: set[str] | None = None,
+) -> list[dict[str, list[str]]]:
+    """Keep canonical filters scoped to products from the same search."""
+
+    groups: list[dict[str, list[str]]] = []
+    for message in _current_turn_messages(_result_messages(result), request_id):
+        if _message_type(message) != "tool":
+            continue
+        payload = evidence_of(message)
+        if not payload or payload.get("outcome") != "results":
+            continue
+        filters = payload.get("confirmed_filters") or {}
+        statements: list[str] = []
+        for name, value in filters.items():
+            statement = _format_filter_statement(name, value)
+            if statement:
+                statements.append(statement)
+        if not statements:
+            continue
+        product_names = [
+            product["name"]
+            for product in (payload.get("products") or [])
+            if product.get("name")
+        ]
+        if displayed_names is not None:
+            product_names = [
+                name for name in product_names if name in displayed_names
+            ]
+            if not product_names:
+                continue
+        groups.append(
+            {"product_names": product_names, "statements": statements}
+        )
+    return groups
+
+
+def _product_result_price(product: dict[str, Any]) -> str:
+    price = product.get("price")
+    if isinstance(price, dict):
+        amount = price.get("amount")
+        currency = str(price.get("currency") or "USD")
+    else:
+        amount = price
+        currency = "USD"
+    if not isinstance(amount, (int, float)):
+        return ""
+    return f"${float(amount):.2f} {currency}"
+
+
+def _should_short_circuit_media_failure(state: State) -> bool:
+    if not state.media or not state.media_analysis:
+        return False
+    if not any(str(item.get("type") or "").lower() == "video" for item in state.media):
+        return False
+    if not _media_analysis_unavailable(state.media_analysis):
+        return False
+    return _query_depends_on_media(state.query)
+
+
+def _record_media_model_usage(state: State, config: Any) -> None:
+    if not getattr(config, "vlm_enabled", False) or not getattr(config, "vlm_name", None):
+        _add_model_usage(state, "vlm", status="disabled", calls=0)
+        return
+
+    status = "failed" if _media_analysis_unavailable(state.media_analysis) else "used"
+    _add_model_usage(
+        state,
+        "vlm",
+        status=status,
+        calls=1,
+        detail="Attached media understanding",
+    )
+
+
+def _record_catalog_model_usage(
+    state: State,
+    plan: CatalogSearchPlan,
+    ok: bool,
+    *,
+    fallback_attempted: bool = False,
+) -> None:
+    status = "used" if ok else "failed"
+    uses_image_endpoint = bool(state.image) and plan.search_mode in {"image", "hybrid"}
+    text_embedding_calls = 1 if plan.semantic_queries else 0
+    if uses_image_endpoint and text_embedding_calls == 0:
+        # Image retrieval currently includes one deterministic text-side query
+        # alongside the image embedding, even when the shopper supplied no text.
+        text_embedding_calls = 1
+    if fallback_attempted:
+        text_embedding_calls += 1 if plan.semantic_queries else 0
+
+    if text_embedding_calls:
+        _add_model_usage(
+            state,
+            "text_embedding",
+            status=status,
+            calls=text_embedding_calls,
+            detail="Catalog text/vector retrieval",
+        )
+    if uses_image_endpoint:
+        _add_model_usage(
+            state,
+            "image_embedding",
+            status=status,
+            calls=1,
+            detail="Catalog image similarity retrieval",
+        )
+
+
+def _record_language_model_failure(state: State) -> None:
+    _add_model_usage(
+        state,
+        "app_llm",
+        status="failed",
+        calls=1,
+        detail="Planning, tool use, and response generation failed",
+    )
+
+
+def _record_safety_model_usage(state: State, mode: str, *, ok: bool = True) -> None:
+    status = "used" if ok else "failed"
+    detail = "Input and output safety checks" if ok else "Guardrails check failed open"
+    if mode == "input":
+        _add_model_usage(
+            state,
+            "content_safety",
+            status=status,
+            calls=1,
+            detail=detail,
+        )
+        _add_model_usage(
+            state,
+            "topic_control",
+            status=status,
+            calls=1,
+            detail="Input topic check" if ok else "Guardrails topic check failed open",
+        )
+        return
+
+    _add_model_usage(
+        state,
+        "content_safety",
+        status=status,
+        calls=1,
+        detail=detail,
+    )
+
+
+def _add_model_usage(
+    state: State,
+    role: str,
+    *,
+    status: str,
+    calls: int,
+    detail: str = "",
+) -> None:
+    existing = state.model_usage.get(role, {})
+    existing_calls = _safe_int(existing.get("calls"))
+    existing_status = str(existing.get("status") or "")
+    merged_status = _merged_model_usage_status(existing_status, status)
+    existing_detail = str(existing.get("detail") or "")
+    next_detail = (
+        existing_detail
+        if existing_status == merged_status and existing_detail
+        else detail or existing_detail
+    )
+    state.model_usage[role] = {
+        "status": merged_status,
+        "calls": existing_calls + max(0, calls),
+        "detail": next_detail,
+    }
+
+
+def _merged_model_usage_status(existing: str, current: str) -> str:
+    priority = {"failed": 4, "used": 3, "disabled": 2, "not_used": 1, "": 0}
+    return existing if priority.get(existing, 0) > priority.get(current, 0) else current
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _media_analysis_unavailable(media_analysis: str) -> bool:
+    try:
+        parsed = json.loads(media_analysis)
+    except json.JSONDecodeError:
+        text = media_analysis
+    else:
+        if not isinstance(parsed, dict):
+            text = str(parsed)
+        else:
+            parts = [str(parsed.get("summary") or "")]
+            uncertainties = parsed.get("uncertainties")
+            if isinstance(uncertainties, list):
+                parts.extend(str(item) for item in uncertainties)
+            text = " ".join(parts)
+
+    lowered = text.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "not configured",
+            "unavailable",
+            "authentication failed",
+            "could not authenticate",
+            "not allowed to access",
+            "media analysis failed",
+            "vlm returned no analysis",
+        )
+    )
+
+
+def _query_depends_on_media(query: str) -> bool:
+    lowered = (query or "").strip().lower()
+    if not lowered or lowered == "the user submitted visual media without additional text.":
+        return True
+    return any(
+        phrase in lowered
+        for phrase in (
+            "this video",
+            "the video",
+            "in video",
+            "from video",
+            "attached video",
+            "she is wearing",
+            "he is wearing",
+            "they are wearing",
+            "person is wearing",
+            "like that",
+            "like this",
+            "similar to that",
+            "similar to this",
+            "what is in this",
+            "what's in this",
+            "what am i wearing",
+            "what are they wearing",
+            "describe this",
+        )
+    )
+
+
+def _media_failure_response(media_analysis: str) -> str:
+    detail = "video/image understanding is unavailable for this turn"
+    try:
+        parsed = json.loads(media_analysis)
+    except json.JSONDecodeError:
+        parsed = {}
+    if isinstance(parsed, dict):
+        summary = str(parsed.get("summary") or "").strip()
+        if summary:
+            detail = _clean_media_failure_detail(summary)
+
+    return (
+        f"I could not analyze the attached media because {detail}. "
+        "Please describe the item in text, such as color, silhouette, material, "
+        "and any visible details, and I can search the catalog from that description."
+    )
+
+
+def _clean_media_failure_detail(summary: str) -> str:
+    detail = summary.strip()
+    for prefix in (
+        "Media was attached, but ",
+        "Video was attached, but ",
+        "Image was attached, but ",
+    ):
+        if detail.startswith(prefix):
+            detail = detail[len(prefix):]
+            break
+    if detail:
+        detail = detail[0].lower() + detail[1:]
+    return detail.rstrip(". ") or "video/image understanding is unavailable for this turn"
+
+
+def _collect_token_usage(result: Any) -> dict[str, int]:
+    """Collect normalized token usage from LangChain/OpenAI message metadata."""
+
+    usage = _empty_token_usage()
+    for message in _result_messages(result):
+        record = _message_token_usage_record(message)
+        if not record:
+            continue
+
+        input_tokens = _token_int(record, ("input_tokens", "prompt_tokens", "input"))
+        output_tokens = _token_int(
+            record,
+            ("output_tokens", "completion_tokens", "output"),
+        )
+        total_tokens = _token_int(record, ("total_tokens", "total"))
+        if total_tokens is None and (input_tokens is not None or output_tokens is not None):
+            total_tokens = int(input_tokens or 0) + int(output_tokens or 0)
+
+        if input_tokens is None and output_tokens is None and total_tokens is None:
+            continue
+
+        usage["input_tokens"] += int(input_tokens or 0)
+        usage["output_tokens"] += int(output_tokens or 0)
+        usage["total_tokens"] += int(total_tokens or 0)
+        usage["model_calls"] += 1
+    return usage
+
+
+def _merge_token_usage(
+    base: dict[str, Any] | None,
+    additional: dict[str, Any] | None,
+) -> dict[str, int]:
+    merged = _normalized_token_usage(base)
+    extra = _normalized_token_usage(additional)
+    for key in merged:
+        merged[key] += extra[key]
+    return merged
+
+
+def _collect_tool_grounding_evidence(
+    result: Any,
+    *,
+    max_chars: int,
+    request_id: str | None = None,
+) -> str:
+    messages = _result_messages(result)
+    if request_id is not None:
+        messages = _current_turn_messages(messages, request_id)
+    return _collect_message_grounding_evidence(messages, max_chars=max_chars)
+
+
+def _collect_message_grounding_evidence(
+    messages: list[Any],
+    *,
+    max_chars: int,
+) -> str:
+    """Collect customer-safe evidence from actual tool-role messages."""
+
+    parts: list[str] = []
+    for message in messages:
+        content = _content_to_text(_value(message, "content"))
+        if not content:
+            continue
+        if not _is_tool_evidence_message(message, content):
+            continue
+        parts.append(_customer_safe_tool_evidence(content, message))
+
+    evidence = "\n\n---\n\n".join(parts).strip()
+    if len(evidence) <= max_chars:
+        return evidence
+    return evidence[-max_chars:]
+
+
+def _customer_safe_search_evidence(payload: dict[str, Any]) -> str:
+    """Build the composer summary from typed evidence, without parsing prose."""
+
+    taxonomy = payload.get("taxonomy") or {}
+    confirmed_filters = payload.get("confirmed_filters") or {}
+    if payload.get("outcome") == "no_direct_catalog_match":
+        return _NO_DIRECT_CATALOG_MATCH_EVIDENCE
+    if payload.get("outcome") == "zero_results":
+        lines = [
+            (
+                "CUSTOMER_SAFE_SCOPED_NO_MATCH_EVIDENCE: Zero products matched "
+                "only the exact advertised search scope below. This does not "
+                "establish that a different, unsearched, or unadvertised product "
+                "type is absent, and it does not support a catalog-wide "
+                "availability claim."
+            )
+        ]
+        if taxonomy:
+            lines.append(
+                "ADVERTISED_SEARCH_TAXONOMY: "
+                + json.dumps(taxonomy, sort_keys=True)
+            )
+        if confirmed_filters:
+            lines.append(
+                "CONFIRMED_SEARCH_FILTERS: "
+                + json.dumps(confirmed_filters, sort_keys=True)
+            )
+        relation = _scope_relation_line(payload, has_products=False)
+        if relation:
+            lines.append(relation)
+        return "\n".join(lines)
+
+    lines = [_summarize_typed_product_evidence(payload)]
+    unconfirmed = payload.get("unconfirmed_requirements") or []
+    if unconfirmed:
+        # Retrieval ranked on these; no filter enforced them. Saying so is what
+        # makes running the search safe instead of a licence to claim a match.
+        lines.append(
+            "UNCONFIRMED_REQUIREMENTS: The catalog cannot filter on "
+            + ", ".join(str(item) for item in unconfirmed)
+            + ". These products were ranked for it but none is confirmed to "
+            "meet it. Present them as candidates and say plainly that it is "
+            "unconfirmed. Do not refuse the request."
+        )
+    relation = _scope_relation_line(payload, has_products=True)
+    if relation:
+        lines.append(relation)
+    return "\n".join(lines)
+
+
+def _scope_relation_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Rebuild the scope-relation record from typed fields.
+
+    The relation is a constant whenever an advertised parent was substituted,
+    so presence of the parent is the whole condition.
+    """
+
+    category = payload.get("advertised_category")
+    requested = payload.get("requested_product_type")
+    if not category or not requested:
+        return {}
+    return {
+        "relation": "model_selected_parent_category",
+        "requested_product_type": str(requested),
+        "advertised_category": str(category),
+    }
+
+
+def _scope_relation_line(payload: dict[str, Any], *, has_products: bool) -> str:
+    """Say plainly that a broader advertised parent was searched, if it was."""
+
+    category = payload.get("advertised_category")
+    requested = payload.get("requested_product_type")
+    if not category or not requested:
+        return ""
+    if not has_products:
+        return (
+            f"REQUESTED_SCOPE_RELATION: {requested} is not separately "
+            f"advertised. The broader advertised category {category} returned "
+            "zero products for this search, so do not claim that the requested "
+            "type is absent from the whole catalog."
+        )
+    return (
+        f"REQUESTED_SCOPE_RELATION: {requested} is not separately "
+        f"advertised. The search used the broader advertised category {category}. "
+        "Present these as closest options and keep every returned product's "
+        "actual catalog category; do not relabel them as the requested type."
+    )
+
+
+def _customer_safe_tool_evidence(content: str, message: Any = None) -> str:
+    """Summarise one tool result for the composer.
+
+    Catalog evidence is read from the typed payload on the message artifact.
+    The text branches that follow handle results which carry no payload:
+    framework-generated tool errors, and tools that emit no evidence yet.
+    Nothing here parses catalog facts back out of prose.
+    """
+
+    if message is not None:
+        payload = evidence_of(message)
+        if payload is not None:
+            return _customer_safe_search_evidence(payload)
+        detail = detail_evidence_of(message)
+        if detail is not None:
+            return _render_product_evidence_summary(
+                detail.get("products") or [],
+                heading="CUSTOMER_SAFE_PRODUCT_DETAIL_EVIDENCE",
+                note=_PRODUCT_DETAIL_EVIDENCE_NOTE,
+            )
+
+    if content.startswith(SEARCH_VALIDATION_ERROR_PREFIX):
+        return (
+            "CUSTOMER_SAFE_INVALID_SEARCH_EVIDENCE: No valid catalog search "
+            "scope was established and no retrieval ran. This does not support "
+            "a product-availability or catalog-absence claim."
+        )
+    return _summarize_cart_evidence(content)
+
+
+def _render_product_evidence_summary(
+    products: list[dict[str, Any]],
+    *,
+    heading: str,
+    note: str,
+    confirmed_filters: dict[str, Any] | None = None,
+    taxonomy_scope: dict[str, Any] | None = None,
+    fallback_content: str | None = None,
+) -> str:
+    """Render the composer's product summary from records.
+
+    Shared by the typed-payload path and the text path so the two cannot drift
+    in wording; only where the records come from differs.
+    """
+
+    lines = [f"{heading}: {note}"]
+    if confirmed_filters:
+        lines.append(
+            "CONFIRMED_SEARCH_FILTERS: Every product below passed each filter "
+            "predicate. A one-value list confirms that value; a multi-value list "
+            "confirms only membership in the set, not which value matched: "
+            + json.dumps(confirmed_filters, sort_keys=True, default=str)
+        )
+    if taxonomy_scope:
+        lines.append(
+            "ADVERTISED_SEARCH_TAXONOMY: This search used only these advertised "
+            "taxonomy values. Lists are inclusive scopes; they do not mean every "
+            "product has every value. Do not describe an unlisted product type "
+            "as advertised: "
+            + json.dumps(taxonomy_scope, sort_keys=True, default=str)
+        )
+    if not products:
+        # The text path keeps emitting its stripped line even when that line is
+        # empty, so its output is unchanged. The typed path has no prose to fall
+        # back to and must not append a blank line in its place.
+        if fallback_content is None:
+            return "\n".join(lines)
+        return "\n".join(
+            lines + [_strip_internal_ids_from_evidence_line(fallback_content)]
+        )
+    for product in products:
+        summary_parts = [product["name"]]
+        if product.get("category"):
+            summary_parts.append(f"category: {product['category']}")
+        if product.get("price"):
+            summary_parts.append(f"price: {product['price']}")
+        if product.get("image_url"):
+            summary_parts.append("image: available")
+        attributes = product.get("attributes")
+        if isinstance(attributes, dict) and attributes:
+            summary_parts.append(
+                "confirmed: "
+                + "; ".join(
+                    f"{name.replace('_', ' ')}: {value}"
+                    for name, value in attributes.items()
+                )
+            )
+        if product.get("details"):
+            summary_parts.append("details: " + "; ".join(product["details"]))
+        lines.append("- " + " | ".join(summary_parts))
+    return "\n".join(lines)
+
+
+def _summarize_typed_product_evidence(payload: dict[str, Any]) -> str:
+    """Summarise search results for the composer straight from typed evidence."""
+
+    products = payload.get("products")
+    return _render_product_evidence_summary(
+        products if isinstance(products, list) else [],
+        heading="CUSTOMER_SAFE_SEARCH_EVIDENCE",
+            note=(
+                "Search results support product names, prices, categories, "
+                "image availability, confirmed search filters, any attribute "
+                "listed as confirmed for that specific product, and a modest "
+                "styling role. An attribute confirmed for one product is not "
+                "evidence about another. They do not support care, "
+                "construction, fit, comfort, weather, grass, gravel, heat, or "
+                "best-in-category claims, nor any attribute not listed for that "
+                "product. Treat names as display names, not attribute evidence; "
+                "group claims require the attribute confirmed on every item."
+            ),
+        confirmed_filters=payload.get("confirmed_filters") or {},
+        taxonomy_scope=payload.get("taxonomy") or {},
+    )
+
+
+def _summarize_cart_evidence(content: str) -> str:
+    lines = ["CUSTOMER_SAFE_CART_EVIDENCE:"]
+    for raw_line in content.splitlines():
+        cleaned = _strip_internal_ids_from_evidence_line(raw_line)
+        if cleaned:
+            lines.append(cleaned)
+    return "\n".join(lines)
+
+
+def _strip_internal_ids_from_evidence_line(line: str) -> str:
+    stripped = line.strip()
+    if not stripped:
+        return ""
+    if stripped.startswith("PRODUCT_REF:") or stripped.startswith("CART_LINE_ID:"):
+        return ""
+    if stripped.startswith("- CART_LINE_ID:") and "|" in stripped:
+        return "- " + stripped.split("|", 1)[1].strip()
+
+    marker = "(PRODUCT_REF:"
+    while marker in stripped:
+        start = stripped.find(marker)
+        end = stripped.find(")", start)
+        if end == -1:
+            stripped = stripped[:start].rstrip()
+            break
+        stripped = (stripped[:start] + stripped[end + 1 :]).strip()
+    return stripped
+
+
+def _is_tool_evidence_message(message: Any, content: str) -> bool:
+    message_type = str(_value(message, "type") or "").lower()
+    role = str(_value(message, "role") or "").lower()
+    tool_name = str(_value(message, "name") or "")
+    if tool_name in {SKILL_ACTIVATION_TOOL_NAME, "read_file"}:
+        return False
+    if content.startswith(
+        (
+            SKILL_ACTIVATION_COMPLETE,
+            SKILL_ACTIVATION_REQUIRED,
+            SKILL_TOOL_NOT_GRANTED,
+            "SHOPPER_SKILL_ACTIVATION_FAILED:",
+        )
+    ):
+        return False
+    return message_type == "tool" or role == "tool"
+
+
+def _normalized_token_usage(raw: dict[str, Any] | None) -> dict[str, int]:
+    usage = _empty_token_usage()
+    if not isinstance(raw, dict):
+        return usage
+    for key in usage:
+        value = raw.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            usage[key] = max(0, int(value))
+    return usage
+
+
+def _empty_token_usage() -> dict[str, int]:
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "model_calls": 0,
+    }
+
+
+def _message_token_usage_record(message: Any) -> Any:
+    usage_metadata = _value(message, "usage_metadata")
+    if usage_metadata:
+        return usage_metadata
+
+    response_metadata = _value(message, "response_metadata")
+    if isinstance(response_metadata, dict):
+        token_usage = response_metadata.get("token_usage")
+        if token_usage:
+            return token_usage
+
+    for key in ("token_usage", "usage"):
+        record = _value(message, key)
+        if record:
+            return record
+    return None
+
+
+def _token_int(record: Any, keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        value = _value(record, key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            return max(0, int(value))
+    return None
+
+
+def _tool_search_mode(value: str | None) -> str | None:
+    return value if value in {"text", "image", "hybrid"} else None
+
+
+_NON_ATTRIBUTE_SEARCH_KEYS = frozenset({"catalog_text", "similarity", "taxonomy"})
+
+
+def _search_attribute_facts(product: Any) -> dict[str, str]:
+    """Structured attributes the catalog confirmed for one search hit.
+
+    The catalog declares which fields are product detail and returns them with
+    every search result. They were dropped here, so the model was told to spend
+    one of its two product-detail reads to fetch what the response already
+    carried -- and when that budget ran out it reported a confirmed attribute as
+    unknown.
+    """
+
+    attributes = getattr(product, "attributes", None)
+    if not isinstance(attributes, dict):
+        return {}
+    facts: dict[str, str] = {}
+    for name, value in sorted(attributes.items()):
+        if name in _NON_ATTRIBUTE_SEARCH_KEYS:
+            continue
+        text = _format_detail_value(value).strip()
+        if text:
+            facts[str(name)] = text
+    return facts
+
+
+def _search_product_record(product: Any) -> dict[str, Any]:
+    """Project one search hit into the record both the model text and the
+    composer summary are rendered from.
+
+    Previously the model-visible text was the only rendering and the composer
+    parsed it back into this same shape. Building the record once removes the
+    round trip, and keeps the two renderings unable to disagree.
+    """
+
+    return {
+        "product_ref": str(product.product_id),
+        "name": str(product.display_name),
+        "category": str(getattr(product, "category", "") or ""),
+        "price": (
+            f"${product.price.amount:.2f} {product.price.currency}"
+            if product.price
+            else ""
+        ),
+        "image_url": str(product.image_url or ""),
+        "attributes": _search_attribute_facts(product),
+    }
+
+
+def _format_product(product: Any) -> str:
+    return _format_product_record(_search_product_record(product))
+
+
+def _product_detail_record(product: ProductDetail) -> dict[str, Any]:
+    """Project one product-detail read into the record the text renders from."""
+
+    return {
+        "product_ref": str(product.product_id),
+        "name": str(product.display_name),
+        "category": str(product.category or ""),
+        "brand": str(product.brand or ""),
+        "price": (
+            f"${product.price.amount:.2f} {product.price.currency}"
+            if product.price
+            else ""
+        ),
+        "image_url": str(product.image_url or ""),
+        "details": [
+            f"{name.replace('_', ' ')}: {_format_detail_value(value)}"
+            for name, value in sorted((product.attributes or {}).items())
+        ],
+    }
+
+
+def _format_product_details(product: ProductDetail) -> str:
+    return _format_product_detail_record(_product_detail_record(product))
+
+
+def _normalize_cart_add_tool_items(
+    items: list[AddCartItemsToolItemInput] | list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    normalized: dict[str, dict[str, Any]] = {}
+    for item in items or []:
+        try:
+            parsed = (
+                item
+                if isinstance(item, AddCartItemsToolItemInput)
+                else AddCartItemsToolItemInput.model_validate(item)
+            )
+            quantity = max(1, int(parsed.quantity or 1))
+        except (TypeError, ValueError, ValidationError) as exc:
+            raise ValueError("each item must include a PRODUCT_REF and quantity") from exc
+        entry = normalized.setdefault(
+            parsed.product_ref,
+            {
+                "quantity": 0,
+                "expected_display_name": (
+                    parsed.expected_display_name.strip()
+                    if parsed.expected_display_name
+                    else ""
+                ),
+            },
+        )
+        entry["quantity"] += quantity
+        if not entry["expected_display_name"] and parsed.expected_display_name:
+            entry["expected_display_name"] = parsed.expected_display_name.strip()
+    return normalized
+
+
+def _cart_add_scope_failures(
+    user_query: str,
+    requested_products: list[tuple[str, ProductSummary]],
+    available_products: Any,
+) -> list[str]:
+    explicitly_named = _explicitly_named_products(user_query, available_products)
+    if not explicitly_named:
+        return []
+
+    explicit_names = {
+        _normalize_product_name(product.display_name) for product in explicitly_named
+    }
+    failures = []
+    for product_ref, product in requested_products:
+        if _normalize_product_name(product.display_name) in explicit_names:
+            continue
+        failures.append(
+            f"- PRODUCT_REF '{product_ref}': selected '{product.display_name}' is "
+            "outside the current explicit add request. The current request names: "
+            f"{_format_product_refs(explicitly_named)}. Retry with matching "
+            "PRODUCT_REF values only, or ask a clarification."
+        )
+    return failures
+
+
+def _explicitly_named_products(
+    text: str,
+    available_products: Any,
+) -> list[ProductSummary]:
+    normalized_text = _normalize_product_name(text)
+    if not normalized_text:
+        return []
+
+    padded_text = f" {normalized_text} "
+    matches: list[ProductSummary] = []
+    seen: set[str] = set()
+    products = list(available_products)
+    for product in products:
+        normalized_name = _normalize_product_name(product.display_name)
+        if not normalized_name:
+            continue
+        if f" {normalized_name} " not in padded_text:
+            continue
+        key = product.product_id or product.display_name
+        if key in seen:
+            continue
+        seen.add(key)
+        matches.append(product)
+
+    query_tokens = set(_product_name_tokens(text))
+    for product in products:
+        key = product.product_id or product.display_name
+        if key in seen:
+            continue
+        product_tokens = _product_name_tokens(product.display_name)
+        required_overlap = 3 if len(product_tokens) > 3 and matches else 2
+        if not _product_name_tokens_match(
+            query_tokens,
+            product_tokens,
+            required_overlap=required_overlap,
+        ):
+            continue
+        seen.add(key)
+        matches.append(product)
+    return matches
+
+
+def _same_product_display_name(expected: str, actual: str) -> bool:
+    return _normalize_product_name(expected) == _normalize_product_name(actual)
+
+
+def _product_detail_failure_message(
+    error: CommerceError | None,
+    *,
+    cart_validation: bool,
+) -> str:
+    if error is not None and error.code == "product_not_found":
+        return (
+            "The product is no longer present in the active catalog. "
+            "Search again before adding it."
+            if cart_validation
+            else (
+                "That product is no longer available in the active catalog. "
+                "Search the catalog again before using its details."
+            )
+        )
+    if error is not None and error.retryable:
+        return (
+            "The catalog is temporarily unavailable, so the cart was not changed. "
+            "Please try again."
+            if cart_validation
+            else "Product details are temporarily unavailable. Please try again."
+        )
+    return (
+        "The product could not be verified, so the cart was not changed. "
+        "Search again before adding it."
+        if cart_validation
+        else "Product details could not be verified. Search the catalog again."
+    )
+
+
+def _normalize_product_name(value: str) -> str:
+    chars = []
+    for char in str(value or "").casefold():
+        chars.append(char if char.isalnum() else " ")
+    return " ".join("".join(chars).split())
+
+
+def _product_name_tokens(value: str) -> list[str]:
+    return [
+        token
+        for token in _normalize_product_name(value).split()
+        if token not in _PRODUCT_NAME_STOPWORDS
+    ]
+
+
+def _product_name_tokens_match(
+    query_tokens: set[str],
+    product_tokens: list[str],
+    *,
+    required_overlap: int,
+) -> bool:
+    if len(product_tokens) < 2:
+        return False
+    overlap = query_tokens.intersection(product_tokens)
+    required = min(required_overlap, len(set(product_tokens)))
+    return len(overlap) >= required
+
+
+def _scrub_internal_shopper_language(text: str) -> str:
+    scrubbed = text or ""
+    for internal, replacement in _INTERNAL_SHOPPER_REPLACEMENTS:
+        scrubbed = scrubbed.replace(internal, replacement)
+    return scrubbed
+
+
+def _cart_line_by_id(cart_line_id: str, cart: Cart) -> dict[str, Any] | None:
+    if not cart.contents:
+        return None
+    target = (cart_line_id or "").strip()
+    if not target:
+        return None
+    for item in cart.contents:
+        if str(item.get("cart_line_id") or "").strip() == target:
+            return item
+    return None

--- a/docs/SHOPPER_AGENT_ARCHITECTURE.md
+++ b/docs/SHOPPER_AGENT_ARCHITECTURE.md
@@ -114,7 +114,7 @@ The detailed contracts and implementation live in:
 - [Capability publisher](../catalog_retriever/src/capabilities.py)
 - [Catalog retriever](../catalog_retriever/src/retriever.py)
 - [Chain capability cache](../chain_server/src/catalog_capabilities.py)
-- [Model-visible catalog search schema and tool construction](../chain_server/src/deepagents_runtime.py)
+- [Model-visible catalog search schema](../chain_server/src/turn_support.py)
 - [Reusable model-visible catalog search rules](../chain_server/src/catalog_scope.py)
 
 ## 2. One Shopper Turn

--- a/tests/unit/chain_server/test_catalog_scope.py
+++ b/tests/unit/chain_server/test_catalog_scope.py
@@ -5,7 +5,7 @@
 
 
 def test_model_catalog_search_has_no_semantic_relation_label() -> None:
-    from chain_server.src.deepagents_runtime import SearchCatalogToolArguments
+    from chain_server.src.turn_support import SearchCatalogToolArguments
 
     assert "taxonomy_status" not in SearchCatalogToolArguments.model_fields
 

--- a/tests/unit/chain_server/test_deepagents_observability.py
+++ b/tests/unit/chain_server/test_deepagents_observability.py
@@ -20,6 +20,8 @@ from .tool_evidence_fixtures import (
 )
 from chain_server.src.deepagents_runtime import (
     DeepAgentsRuntime,
+)
+from chain_server.src.turn_support import (
     RequestIdentity,
     _collect_agent_diagnostics,
 )

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -627,7 +627,7 @@ class TestStreamEndpoint:
 
 class TestRequestIdentity:
     def test_missing_explicit_ids_keep_legacy_user_scope(self) -> None:
-        from chain_server.src.deepagents_runtime import create_request_identity
+        from chain_server.src.turn_support import create_request_identity
 
         identity = create_request_identity(legacy_user_id=42)
 
@@ -640,7 +640,7 @@ class TestRequestIdentity:
         assert identity.shopper_profile_id is None
 
     def test_explicit_request_id_is_preserved(self) -> None:
-        from chain_server.src.deepagents_runtime import create_request_identity
+        from chain_server.src.turn_support import create_request_identity
 
         identity = create_request_identity(
             legacy_user_id=42,
@@ -650,7 +650,7 @@ class TestRequestIdentity:
         assert identity.request_id == "request-a"
 
     def test_selected_shopper_is_part_of_request_identity(self) -> None:
-        from chain_server.src.deepagents_runtime import create_request_identity
+        from chain_server.src.turn_support import create_request_identity
 
         identity = create_request_identity(
             legacy_user_id=42,
@@ -661,7 +661,7 @@ class TestRequestIdentity:
         assert identity.shopper_profile_id == "shopper_morgan"
 
     def test_missing_request_id_generates_a_new_value(self) -> None:
-        from chain_server.src.deepagents_runtime import create_request_identity
+        from chain_server.src.turn_support import create_request_identity
 
         first = create_request_identity(legacy_user_id=42)
         second = create_request_identity(legacy_user_id=42)
@@ -669,7 +669,7 @@ class TestRequestIdentity:
         assert first.request_id != second.request_id
 
     def test_checkpoint_thread_is_request_scoped(self) -> None:
-        from chain_server.src.deepagents_runtime import create_request_identity
+        from chain_server.src.turn_support import create_request_identity
 
         first = create_request_identity(
             legacy_user_id=42,
@@ -700,7 +700,7 @@ class TestRequestIdentity:
         )
 
     def test_cart_scope_can_survive_across_conversations(self) -> None:
-        from chain_server.src.deepagents_runtime import create_request_identity
+        from chain_server.src.turn_support import create_request_identity
 
         first = create_request_identity(
             legacy_user_id=1,
@@ -723,7 +723,7 @@ class TestRequestIdentity:
         assert first.cart_user_id != different_cart.cart_user_id
 
     def test_missing_cart_id_keeps_cart_on_legacy_user_scope(self) -> None:
-        from chain_server.src.deepagents_runtime import create_request_identity
+        from chain_server.src.turn_support import create_request_identity
 
         identity = create_request_identity(
             legacy_user_id=42,
@@ -742,14 +742,14 @@ class TestCheckpointerConfiguration:
         store: str | None,
     ) -> None:
         from langgraph.checkpoint.memory import MemorySaver
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         if store is None:
             monkeypatch.delenv("CHECKPOINT_STORE", raising=False)
         else:
             monkeypatch.setenv("CHECKPOINT_STORE", store)
 
-        assert isinstance(runtime_mod._build_checkpointer(), MemorySaver)
+        assert isinstance(runtime_mod_support._build_checkpointer(), MemorySaver)
 
     @pytest.mark.parametrize("store", ["", "redsi", "redis", "valkey"])
     def test_invalid_store_fails_fast(
@@ -757,7 +757,7 @@ class TestCheckpointerConfiguration:
         monkeypatch: pytest.MonkeyPatch,
         store: str,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         monkeypatch.setenv("CHECKPOINT_STORE", store)
 
@@ -765,11 +765,12 @@ class TestCheckpointerConfiguration:
             ValueError,
             match="CHECKPOINT_STORE currently supports only 'memory'",
         ):
-            runtime_mod._build_checkpointer()
+            runtime_mod_support._build_checkpointer()
 
     @pytest.mark.asyncio
     async def test_async_checkpointer_deletes_turn_checkpoint(self, base_config) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         deleted_threads = []
 
@@ -779,7 +780,7 @@ class TestCheckpointerConfiguration:
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
         runtime._checkpointer = FakeAsyncCheckpointer()
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -855,9 +856,10 @@ class TestSystemPrompt:
         base_config,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -912,13 +914,13 @@ class TestSystemPrompt:
             )
 
     def test_search_guidance_drops_unsupported_performance_language(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        assert runtime_mod._safe_shopper_guidance(
+        assert runtime_mod_support._safe_shopper_guidance(
             "Boots that can handle wet surfaces.",
             "boots",
         ) == "Finding boots for the shopper's request."
-        assert runtime_mod._safe_shopper_guidance(
+        assert runtime_mod_support._safe_shopper_guidance(
             "Bottoms that balance a beige top.",
             "bottoms",
         ) == "Bottoms that balance a beige top."
@@ -928,7 +930,7 @@ class TestSystemPrompt:
             "These boots can handle rain.",
             "These boots work well in wet conditions.",
         ):
-            assert runtime_mod._safe_shopper_guidance(
+            assert runtime_mod_support._safe_shopper_guidance(
                 unsafe_guidance,
                 "boots",
             ) == "Finding boots for the shopper's request."
@@ -952,11 +954,11 @@ class TestStorePolicyPath:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         monkeypatch.setenv("SHARED_CONFIG_ROOT", str(tmp_path))
 
-        assert runtime_mod._store_policies_path() == (
+        assert runtime_mod_support._store_policies_path() == (
             tmp_path / "chain_server" / "store_policies.yaml"
         )
 
@@ -964,11 +966,11 @@ class TestStorePolicyPath:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         monkeypatch.delenv("SHARED_CONFIG_ROOT", raising=False)
 
-        assert runtime_mod._store_policies_path() == (
+        assert runtime_mod_support._store_policies_path() == (
             Path(__file__).resolve().parents[3]
             / "shared"
             / "configs"
@@ -1022,9 +1024,10 @@ class TestDeepAgentsRuntimeScopes:
         base_config,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1106,9 +1109,10 @@ class TestDeepAgentsRuntimeScopes:
         base_config,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1131,9 +1135,10 @@ class TestDeepAgentsRuntimeScopes:
         base_config,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1191,7 +1196,7 @@ class TestDeepAgentsRuntimeScopes:
         turn = runtime._start_conversation_turn(state, identity)
         assert turn is not None
         state.response = "Done"
-        state.agent_diagnostics = runtime_mod._empty_agent_diagnostics("completed")
+        state.agent_diagnostics = runtime_mod_support._empty_agent_diagnostics("completed")
         state.selected_skill_names = ["product-discovery"]
         runtime._finalize_conversation_turn(state, identity, turn)
 
@@ -1217,9 +1222,10 @@ class TestDeepAgentsRuntimeScopes:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1274,10 +1280,11 @@ class TestDeepAgentsRuntimeScopes:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
         memory = _install_conversation_memory_stub(runtime)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1306,9 +1313,10 @@ class TestDeepAgentsRuntimeScopes:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1352,11 +1360,12 @@ class TestDeepAgentsRuntimeScopes:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
         memory = _ConversationMemoryStub()
         runtime._conversation_memory = memory
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1425,9 +1434,10 @@ class TestDeepAgentsRuntimeScopes:
         expected_response: str,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1474,10 +1484,11 @@ class TestDeepAgentsRuntimeScopes:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
         memory = _install_conversation_memory_stub(runtime)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1518,11 +1529,12 @@ class TestDeepAgentsRuntimeScopes:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage
 
         base_config.deepagents_execution_timeout_seconds = 0.01
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1642,13 +1654,13 @@ class TestDeepAgentsRuntimeScopes:
 
         async def complete_turn(state, identity):
             state.response = "The next turn completed."
-            state.agent_diagnostics = runtime_mod._empty_agent_diagnostics("completed")
+            state.agent_diagnostics = runtime_mod_support._empty_agent_diagnostics("completed")
             return state
 
         monkeypatch.setattr(runtime, "_execute_turn", complete_turn)
         second_output = await runtime._run_turn(
             State(user_id=111, query="next", guardrails=False),
-            runtime_mod.RequestIdentity(
+            runtime_mod_support.RequestIdentity(
                 session_id="session-a",
                 conversation_id="conversation-a",
                 cart_id="cart-a",
@@ -1668,7 +1680,7 @@ class TestDeepAgentsRuntimeScopes:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         cancelled = False
 
@@ -1682,12 +1694,12 @@ class TestDeepAgentsRuntimeScopes:
                     raise
 
         monkeypatch.setattr(
-            runtime_mod,
+            runtime_mod_support,
             "_PARTIAL_GRAPH_SNAPSHOT_TIMEOUT_SECONDS",
             0.01,
         )
 
-        messages, error = await runtime_mod._partial_graph_messages(
+        messages, error = await runtime_mod_support._partial_graph_messages(
             HangingSnapshotAgent(),
             {"configurable": {"thread_id": "request-a"}},
         )
@@ -1703,6 +1715,7 @@ class TestDeepAgentsRuntimeScopes:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
 
@@ -1728,7 +1741,7 @@ class TestDeepAgentsRuntimeScopes:
         runtime._checkpointer = SimpleNamespace(
             delete_thread=deleted_threads.append,
         )
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1739,7 +1752,7 @@ class TestDeepAgentsRuntimeScopes:
 
         async def complete_turn(state, _identity):
             state.response = "Grounded response."
-            state.agent_diagnostics = runtime_mod._empty_agent_diagnostics("completed")
+            state.agent_diagnostics = runtime_mod_support._empty_agent_diagnostics("completed")
             return state
 
         monkeypatch.setattr(runtime, "_execute_turn", complete_turn)
@@ -1760,6 +1773,7 @@ class TestDeepAgentsRuntimeScopes:
         base_config,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
 
@@ -1772,7 +1786,7 @@ class TestDeepAgentsRuntimeScopes:
                 )
 
         runtime._conversation_memory = SupersededMemory()
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -1791,7 +1805,7 @@ class TestDeepAgentsRuntimeScopes:
                 }
             ],
             retrieved={"Stale product": "/images/stale.png"},
-            agent_diagnostics=runtime_mod._empty_agent_diagnostics("completed"),
+            agent_diagnostics=runtime_mod_support._empty_agent_diagnostics("completed"),
         )
 
         runtime._finalize_conversation_turn(
@@ -1813,7 +1827,7 @@ class TestDeepAgentsRuntimeScopes:
 
 class TestDeepAgentsRuntimeTokenUsage:
     def test_collects_normalized_usage_metadata_without_double_counting(self) -> None:
-        from chain_server.src.deepagents_runtime import _collect_token_usage
+        from chain_server.src.turn_support import _collect_token_usage
 
         result = {
             "messages": [
@@ -1853,7 +1867,7 @@ class TestDeepAgentsRuntimeTokenUsage:
         }
 
     def test_collect_token_usage_defaults_when_metadata_is_absent(self) -> None:
-        from chain_server.src.deepagents_runtime import _collect_token_usage
+        from chain_server.src.turn_support import _collect_token_usage
 
         assert _collect_token_usage({"messages": [{"content": "hello"}]}) == {
             "input_tokens": 0,
@@ -1865,7 +1879,7 @@ class TestDeepAgentsRuntimeTokenUsage:
 
 class TestDeepAgentsRuntimeModelUsage:
     def test_safety_model_usage_matches_guardrails_flows(self) -> None:
-        from chain_server.src.deepagents_runtime import _record_safety_model_usage
+        from chain_server.src.turn_support import _record_safety_model_usage
 
         state = State(user_id=1, query="hello")
 
@@ -1878,7 +1892,7 @@ class TestDeepAgentsRuntimeModelUsage:
         assert state.model_usage["topic_control"]["calls"] == 1
 
     def test_safety_model_usage_marks_transport_failures(self) -> None:
-        from chain_server.src.deepagents_runtime import _record_safety_model_usage
+        from chain_server.src.turn_support import _record_safety_model_usage
 
         state = State(user_id=1, query="hello")
 
@@ -1909,7 +1923,7 @@ class TestDeepAgentsRuntimeModelUsage:
         assert check_ok is False
 
     def test_language_model_failure_usage_is_explicit(self) -> None:
-        from chain_server.src.deepagents_runtime import _record_language_model_failure
+        from chain_server.src.turn_support import _record_language_model_failure
 
         state = State(user_id=1, query="hello")
 
@@ -1949,7 +1963,7 @@ class TestDeepAgentsRuntimeMediaFailures:
         assert "turn.. Please" not in response
 
     def test_explicit_text_query_can_continue_when_media_is_unavailable(self) -> None:
-        from chain_server.src.deepagents_runtime import _should_short_circuit_media_failure
+        from chain_server.src.turn_support import _should_short_circuit_media_failure
 
         state = State(
             user_id=1,
@@ -1970,7 +1984,7 @@ class TestDeepAgentsRuntimeMediaFailures:
         assert _should_short_circuit_media_failure(state) is False
 
     def test_image_similarity_query_continues_when_vlm_is_unavailable(self) -> None:
-        from chain_server.src.deepagents_runtime import _should_short_circuit_media_failure
+        from chain_server.src.turn_support import _should_short_circuit_media_failure
 
         image_data = "data:image/jpeg;base64,QUFB"
         state = State(
@@ -1996,32 +2010,32 @@ class TestDeepAgentsRuntimeMediaFailures:
 
 class TestDeepAgentsRuntimeRefs:
     def test_product_type_text_normalization_is_conservative(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        assert runtime_mod._normalize_product_text("Accessories") == "accessory"
-        assert runtime_mod._normalize_product_text("dresses") == "dress"
-        assert runtime_mod._normalize_product_text("crossbody_bags") == (
+        assert runtime_mod_support._normalize_product_text("Accessories") == "accessory"
+        assert runtime_mod_support._normalize_product_text("dresses") == "dress"
+        assert runtime_mod_support._normalize_product_text("crossbody_bags") == (
             "crossbody bag"
         )
-        assert runtime_mod._normalize_product_text("Crossbody-Bags") == (
+        assert runtime_mod_support._normalize_product_text("Crossbody-Bags") == (
             "crossbody bag"
         )
-        assert runtime_mod._normalize_product_text("boots & flats") == (
+        assert runtime_mod_support._normalize_product_text("boots & flats") == (
             "boot and flat"
         )
 
     def test_unadvertised_requirement_must_be_grounded_in_current_turn(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        assert runtime_mod._shopper_stated_requirement(
+        assert runtime_mod_support._shopper_stated_requirement(
             "Do you have water-resistant bags?",
             "water resistance",
         )
-        assert runtime_mod._shopper_stated_requirement(
+        assert runtime_mod_support._shopper_stated_requirement(
             "Show me denim skirts",
             "denim",
         )
-        assert not runtime_mod._shopper_stated_requirement(
+        assert not runtime_mod_support._shopper_stated_requirement(
             "Build a rainy day outfit",
             "water resistance",
         )
@@ -2029,7 +2043,7 @@ class TestDeepAgentsRuntimeRefs:
     def test_full_product_scope_does_not_conflate_advertised_bag_types(
         self,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         capabilities = CatalogCapabilities(
             catalog_id="scope-test",
@@ -2051,55 +2065,55 @@ class TestDeepAgentsRuntimeRefs:
             ),
         )
 
-        assert runtime_mod._product_scope_key("crossbody_bags") == "crossbody bag"
-        assert not runtime_mod._same_product_scope(
+        assert runtime_mod_support._product_scope_key("crossbody_bags") == "crossbody bag"
+        assert not runtime_mod_support._same_product_scope(
             "crossbody bag",
             "tote bag",
             capabilities,
         )
-        assert not runtime_mod._same_product_scope(
+        assert not runtime_mod_support._same_product_scope(
             "crossbody bag",
             "formal crossbody bag",
             capabilities,
         )
-        assert runtime_mod._same_product_scope(
+        assert runtime_mod_support._same_product_scope(
             "formal crossbody bag",
             "crossbody bag",
             capabilities,
         )
-        assert not runtime_mod._same_product_scope(
+        assert not runtime_mod_support._same_product_scope(
             "formal crossbody bag",
             "bag",
             capabilities,
         )
-        assert not runtime_mod._same_product_scope(
+        assert not runtime_mod_support._same_product_scope(
             "crossbody bag or tote bag",
             "tote bag",
             capabilities,
         )
-        assert runtime_mod._exact_taxonomy_issue(
+        assert runtime_mod_support._exact_taxonomy_issue(
             "crossbody bags",
             {"category": ["bags"], "subcategory": []},
         ) is not None
-        assert runtime_mod._advertised_taxonomy_scope_issue(
+        assert runtime_mod_support._advertised_taxonomy_scope_issue(
             "crossbody bags",
             "member_of_requested_umbrella",
             {"category": ["bags"], "subcategory": ["tote_bags"]},
             capabilities,
         ) is not None
-        assert runtime_mod._advertised_taxonomy_scope_issue(
+        assert runtime_mod_support._advertised_taxonomy_scope_issue(
             "formal crossbody bags",
             "member_of_requested_umbrella",
             {"category": ["bags"], "subcategory": ["tote_bags"]},
             capabilities,
         ) is not None
-        assert runtime_mod._advertised_taxonomy_scope_issue(
+        assert runtime_mod_support._advertised_taxonomy_scope_issue(
             "formal crossbody bags",
             "exact_requested_type",
             {"category": ["bags"], "subcategory": ["crossbody_bags"]},
             capabilities,
         ) is None
-        assert runtime_mod._advertised_taxonomy_scope_issue(
+        assert runtime_mod_support._advertised_taxonomy_scope_issue(
             "bags",
             "member_of_requested_umbrella",
             {"category": ["apparel"], "subcategory": ["dresses"]},
@@ -2109,7 +2123,7 @@ class TestDeepAgentsRuntimeRefs:
     def test_typed_multi_subcategory_selection_preserves_coverage(
         self,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         capabilities = CatalogCapabilities(
             catalog_id="alternatives-test",
@@ -2130,7 +2144,7 @@ class TestDeepAgentsRuntimeRefs:
             ),
         )
 
-        alternatives = runtime_mod._selected_advertised_subcategories(
+        alternatives = runtime_mod_support._selected_advertised_subcategories(
             {
                 "category": ["footwear"],
                 "subcategory": ["heels", "flats", "sandals"],
@@ -2138,14 +2152,14 @@ class TestDeepAgentsRuntimeRefs:
             capabilities,
         )
         assert alternatives == ("footwear", ["heels", "flats", "sandals"])
-        assert runtime_mod._selected_advertised_subcategories(
+        assert runtime_mod_support._selected_advertised_subcategories(
             {
                 "category": ["footwear"],
                 "subcategory": ["heels"],
             },
             capabilities,
         ) is None
-        assert runtime_mod._selected_advertised_subcategories(
+        assert runtime_mod_support._selected_advertised_subcategories(
             {
                 "category": ["bags"],
                 "subcategory": ["heels", "flats"],
@@ -2175,13 +2189,13 @@ class TestDeepAgentsRuntimeRefs:
             )
             for index in range(2)
         ]
-        covered = runtime_mod._products_with_subcategory_coverage(
+        covered = runtime_mod_support._products_with_subcategory_coverage(
             products,
             alternatives,
             4,
         )
 
-        assert runtime_mod._multi_subcategory_candidate_limit(
+        assert runtime_mod_support._multi_subcategory_candidate_limit(
             alternatives,
             capabilities,
             4,
@@ -2196,7 +2210,7 @@ class TestDeepAgentsRuntimeRefs:
     def test_search_catalog_tool_schema_is_generated_from_catalog_taxonomy(
         self,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         capabilities = CatalogCapabilities(
             catalog_id="custom",
@@ -2235,33 +2249,33 @@ class TestDeepAgentsRuntimeRefs:
             ),
         )
 
-        assert runtime_mod._duplicates_unavailable_product_type(
+        assert runtime_mod_support._duplicates_unavailable_product_type(
             ["sneakers"],
             "sneakers",
             capabilities,
         )
-        assert not runtime_mod._duplicates_unavailable_product_type(
+        assert not runtime_mod_support._duplicates_unavailable_product_type(
             ["sneakers", "water resistance"],
             "sneakers",
             capabilities,
         )
-        assert not runtime_mod._duplicates_unavailable_product_type(
+        assert not runtime_mod_support._duplicates_unavailable_product_type(
             ["sneakers", "sneakers"],
             "sneakers",
             capabilities,
         )
-        assert not runtime_mod._duplicates_unavailable_product_type(
+        assert not runtime_mod_support._duplicates_unavailable_product_type(
             ["bags"],
             "bags",
             capabilities,
         )
-        assert not runtime_mod._duplicates_unavailable_product_type(
+        assert not runtime_mod_support._duplicates_unavailable_product_type(
             ["sneakers or boots"],
             "sneakers or boots",
             capabilities,
         )
 
-        schema_model = runtime_mod._search_catalog_tool_input_model(capabilities)
+        schema_model = runtime_mod_support._search_catalog_tool_input_model(capabilities)
         schema = schema_model.model_json_schema()
 
         assert set(schema_model.model_fields) == {
@@ -2503,7 +2517,7 @@ class TestDeepAgentsRuntimeRefs:
             }
         )
         assert "single taxonomy value must match requested_product_type" in (
-            runtime_mod._exact_taxonomy_issue(
+            runtime_mod_support._exact_taxonomy_issue(
                 mismatched_exact.requested_product_type,
                 mismatched_exact.taxonomy,
             )
@@ -2527,7 +2541,7 @@ class TestDeepAgentsRuntimeRefs:
             }
         )
         assert modified_exact_type.taxonomy.subcategory == ["clutches"]
-        assert runtime_mod._exact_taxonomy_issue(
+        assert runtime_mod_support._exact_taxonomy_issue(
             modified_exact_type.requested_product_type,
             modified_exact_type.taxonomy,
         ) is not None
@@ -2539,7 +2553,7 @@ class TestDeepAgentsRuntimeRefs:
                 "taxonomy_status": "exact_requested_type",
             }
         )
-        assert runtime_mod._exact_taxonomy_issue(
+        assert runtime_mod_support._exact_taxonomy_issue(
             semantic_direction_exact.requested_product_type,
             semantic_direction_exact.taxonomy,
         ) is None
@@ -2572,7 +2586,7 @@ class TestDeepAgentsRuntimeRefs:
             }
         )
         assert "selected taxonomy must faithfully represent one requested type" in (
-            runtime_mod._exact_taxonomy_issue(
+            runtime_mod_support._exact_taxonomy_issue(
                 multi_value_exact.requested_product_type,
                 multi_value_exact.taxonomy,
             )
@@ -2686,7 +2700,7 @@ class TestDeepAgentsRuntimeRefs:
     def test_search_catalog_tool_input_rejects_legacy_constraint_fields(
         self, legacy_field: str
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         capabilities = CatalogCapabilities(
             catalog_id="custom",
@@ -2697,7 +2711,7 @@ class TestDeepAgentsRuntimeRefs:
                 },
             ),
         )
-        schema_model = runtime_mod._search_catalog_tool_input_model(capabilities)
+        schema_model = runtime_mod_support._search_catalog_tool_input_model(capabilities)
 
         with pytest.raises(ValueError, match="Extra inputs are not permitted"):
             schema_model.model_validate(
@@ -2717,7 +2731,7 @@ class TestDeepAgentsRuntimeRefs:
             )
 
     def test_taxonomy_mapping_uses_catalog_fields_and_validates_scope(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         capabilities = CatalogCapabilities(
             catalog_id="custom",
@@ -2748,20 +2762,20 @@ class TestDeepAgentsRuntimeRefs:
             ),
         )
 
-        mapped, issues = runtime_mod._taxonomy_hard_constraints(
+        mapped, issues = runtime_mod_support._taxonomy_hard_constraints(
             {"category": ["bags"], "subcategory": ["clutches"]},
             capabilities,
         )
-        inferred, inferred_issues = runtime_mod._taxonomy_hard_constraints(
+        inferred, inferred_issues = runtime_mod_support._taxonomy_hard_constraints(
             {"category": [], "subcategory": ["clutches"]},
             capabilities,
         )
-        mismatched, mismatch_issues = runtime_mod._taxonomy_hard_constraints(
+        mismatched, mismatch_issues = runtime_mod_support._taxonomy_hard_constraints(
             {"category": ["apparel"], "subcategory": ["clutches"]},
             capabilities,
         )
         partially_mismatched, partial_mismatch_issues = (
-            runtime_mod._taxonomy_hard_constraints(
+            runtime_mod_support._taxonomy_hard_constraints(
                 {
                     "category": ["bags", "apparel"],
                     "subcategory": ["clutches"],
@@ -2769,7 +2783,7 @@ class TestDeepAgentsRuntimeRefs:
                 capabilities,
             )
         )
-        normalized, normalized_issues = runtime_mod._taxonomy_hard_constraints(
+        normalized, normalized_issues = runtime_mod_support._taxonomy_hard_constraints(
             {
                 "category": ["bags", "bags"],
                 "subcategory": ["clutches", "clutches"],
@@ -2818,26 +2832,26 @@ class TestDeepAgentsRuntimeRefs:
                 },
             ),
         )
-        assert runtime_mod._advertised_scope_match(
+        assert runtime_mod_support._advertised_scope_match(
             "waterproof boots",
             footwear_capabilities,
         ) == ("subcategory", "boots", "footwear", "boot")
-        assert runtime_mod._advertised_scope_match(
+        assert runtime_mod_support._advertised_scope_match(
             "closed shoes or boots",
             footwear_capabilities,
         ) is None
-        assert runtime_mod._advertised_scope_match(
+        assert runtime_mod_support._advertised_scope_match(
             "boots & flats",
             footwear_capabilities,
         ) is None
-        assert not runtime_mod._same_product_scope(
-            runtime_mod._product_scope_key("boots / flats"),
-            runtime_mod._product_scope_key("flats"),
+        assert not runtime_mod_support._same_product_scope(
+            runtime_mod_support._product_scope_key("boots / flats"),
+            runtime_mod_support._product_scope_key("flats"),
             footwear_capabilities,
         )
 
     def test_catalog_model_usage_counts_attempted_hybrid_fallback(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from chain_server.src.catalog_request import CatalogSearchPlan
 
         state = State(
@@ -2851,7 +2865,7 @@ class TestDeepAgentsRuntimeRefs:
             search_mode="hybrid",
         )
 
-        runtime_mod._record_catalog_model_usage(
+        runtime_mod_support._record_catalog_model_usage(
             state,
             plan,
             True,
@@ -2867,6 +2881,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         captured: Dict[str, Any] = {}
         deepagents_mod = ModuleType("deepagents")
@@ -2937,7 +2952,7 @@ class TestDeepAgentsRuntimeRefs:
                 ),
             )
         )
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -3010,7 +3025,7 @@ class TestDeepAgentsRuntimeRefs:
             "store-policy-answers",
         ]
         search_schema = tools_by_name["search_catalog_tool"].args_schema
-        assert search_schema is not runtime_mod.SearchCatalogToolArguments
+        assert search_schema is not runtime_mod_support.SearchCatalogToolArguments
         assert set(search_schema.model_fields) == {
             "semantic_query",
             "shopper_guidance",
@@ -3348,6 +3363,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         base_config.max_catalog_searches_per_turn = 4
         captured: Dict[str, Any] = {}
@@ -3494,7 +3510,7 @@ class TestDeepAgentsRuntimeRefs:
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
         runtime._catalog_capabilities = SimpleNamespace(get=lambda **_: capabilities)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -4464,6 +4480,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         captured: Dict[str, Any] = {}
         deepagents_mod = ModuleType("deepagents")
@@ -4577,7 +4594,7 @@ class TestDeepAgentsRuntimeRefs:
         runtime._catalog_capabilities = SimpleNamespace(
             get=capabilities_for_turn
         )
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -4726,9 +4743,10 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -4792,7 +4810,7 @@ class TestDeepAgentsRuntimeRefs:
         )
 
     def test_partial_product_results_response_is_grounded(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         state = State(
             user_id=111,
@@ -4807,7 +4825,7 @@ class TestDeepAgentsRuntimeRefs:
             ],
         )
 
-        response = runtime_mod._partial_product_results_response(state)
+        response = runtime_mod_support._partial_product_results_response(state)
 
         assert "**Yonder Floral Maxi Dress** — dress — $119.99 USD" in response
         assert "overstate outdoor performance" in response
@@ -4821,11 +4839,12 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
         from langgraph.errors import GraphRecursionError
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -4957,10 +4976,11 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -5257,11 +5277,12 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, ToolMessage
 
         base_config.deepagents_execution_timeout_seconds = 0.05
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -5579,6 +5600,8 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import tool_loop_control
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
@@ -5620,7 +5643,7 @@ class TestDeepAgentsRuntimeRefs:
                 AIMessage(
                     content=unsafe_model_text,
                     additional_kwargs={
-                        runtime_mod.SERVER_CATALOG_CLARIFICATION: True
+                        tool_loop_control.SERVER_CATALOG_CLARIFICATION: True
                     },
                 ),
             ]
@@ -5633,9 +5656,9 @@ class TestDeepAgentsRuntimeRefs:
             request_id="current-request",
         )
 
-        assert response == runtime_mod._CATALOG_REPAIR_CLARIFICATION_RESPONSE
+        assert response == runtime_mod_support._CATALOG_REPAIR_CLARIFICATION_RESPONSE
         assert unsafe_model_text not in response
-        assert runtime_mod._rejected_catalog_search_response(
+        assert runtime_mod_support._rejected_catalog_search_response(
             result,
             request_id="current-request",
         ) is None
@@ -5647,6 +5670,8 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import tool_loop_control
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
@@ -5696,7 +5721,7 @@ class TestDeepAgentsRuntimeRefs:
                 AIMessage(
                     content=unsafe_model_text,
                     additional_kwargs={
-                        runtime_mod.SERVER_CATALOG_CLARIFICATION: True
+                        tool_loop_control.SERVER_CATALOG_CLARIFICATION: True
                     },
                 ),
             ]
@@ -5710,7 +5735,7 @@ class TestDeepAgentsRuntimeRefs:
         )
 
         assert "**Everyday Boot**" in response
-        assert runtime_mod._CATALOG_REPAIR_CLARIFICATION_RESPONSE in response
+        assert runtime_mod_support._CATALOG_REPAIR_CLARIFICATION_RESPONSE in response
         assert unsafe_model_text not in response
 
     @pytest.mark.asyncio
@@ -5720,6 +5745,8 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import tool_loop_control
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
         captured: dict[str, str] = {}
@@ -5730,7 +5757,7 @@ class TestDeepAgentsRuntimeRefs:
                 return AIMessage(
                     content=(
                         "I added Everyday Boot to your cart.\n\n"
-                        + runtime_mod._CATALOG_REPAIR_CLARIFICATION_RESPONSE
+                        + runtime_mod_support._CATALOG_REPAIR_CLARIFICATION_RESPONSE
                     )
                 )
 
@@ -5780,7 +5807,7 @@ class TestDeepAgentsRuntimeRefs:
                 AIMessage(
                     content=unsafe_model_text,
                     additional_kwargs={
-                        runtime_mod.SERVER_CATALOG_CLARIFICATION: True
+                        tool_loop_control.SERVER_CATALOG_CLARIFICATION: True
                     },
                 ),
             ]
@@ -5794,9 +5821,9 @@ class TestDeepAgentsRuntimeRefs:
         )
 
         assert "I added Everyday Boot to your cart." in response
-        assert runtime_mod._CATALOG_REPAIR_CLARIFICATION_RESPONSE in response
+        assert runtime_mod_support._CATALOG_REPAIR_CLARIFICATION_RESPONSE in response
         assert unsafe_model_text not in captured["prompt"]
-        assert runtime_mod._CATALOG_REPAIR_CLARIFICATION_RESPONSE in (
+        assert runtime_mod_support._CATALOG_REPAIR_CLARIFICATION_RESPONSE in (
             captured["prompt"]
         )
         assert "Everyday Boot" in captured["prompt"]
@@ -5808,6 +5835,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
@@ -5883,7 +5911,7 @@ class TestDeepAgentsRuntimeRefs:
             request_id="current-request",
         )
 
-        assert response == runtime_mod._REJECTED_CATALOG_SEARCH_RESPONSE
+        assert response == runtime_mod_support._REJECTED_CATALOG_SEARCH_RESPONSE
         assert "Navy Wool Blend Blazer" not in response
         assert "$189" not in response
         assert "app_llm_grounding_editor" not in state.model_usage
@@ -5892,9 +5920,10 @@ class TestDeepAgentsRuntimeRefs:
         self,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-        assert runtime_mod._rejected_catalog_search_response(
+        assert runtime_mod_support._rejected_catalog_search_response(
             {
                 "messages": [
                     HumanMessage(content="REQUEST ID: current-request"),
@@ -5933,7 +5962,7 @@ class TestDeepAgentsRuntimeRefs:
             },
             request_id="current-request",
         ) is None
-        assert runtime_mod._rejected_catalog_search_response(
+        assert runtime_mod_support._rejected_catalog_search_response(
             {
                 "messages": [
                     HumanMessage(content="REQUEST ID: current-request"),
@@ -5977,10 +6006,11 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -6039,7 +6069,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch.setattr(
             runtime_mod,
             "_safe_collect_agent_diagnostics",
-            lambda *args, **kwargs: runtime_mod._empty_agent_diagnostics(
+            lambda *args, **kwargs: runtime_mod_support._empty_agent_diagnostics(
                 "completed"
             ),
         )
@@ -6054,12 +6084,12 @@ class TestDeepAgentsRuntimeRefs:
             identity,
         )
 
-        assert output.response == runtime_mod._REJECTED_CATALOG_SEARCH_RESPONSE
+        assert output.response == runtime_mod_support._REJECTED_CATALOG_SEARCH_RESPONSE
         assert output.agent_diagnostics["tool_calls"] == []
         assert "Navy Wool Blend Blazer" not in output.response
 
     def test_recent_shopper_statements_exclude_assistant_responses(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
         from chain_server.src.agenttypes import DialogueTurn
 
         dialogue = [
@@ -6075,32 +6105,32 @@ class TestDeepAgentsRuntimeRefs:
             ),
         ]
 
-        assert runtime_mod._recent_shopper_statements(dialogue) == (
+        assert runtime_mod_support._recent_shopper_statements(dialogue) == (
             "Start with a beige top.\nGo back to the beige look."
         )
-        assert "Flat Strappy" not in runtime_mod._recent_shopper_statements(
+        assert "Flat Strappy" not in runtime_mod_support._recent_shopper_statements(
             dialogue
         )
 
     def test_private_taxonomy_helpers_validate_legacy_execution_modes(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        assert runtime_mod._exact_taxonomy_issue(
+        assert runtime_mod_support._exact_taxonomy_issue(
             "bottoms",
             {"category": ["apparel"], "subcategory": ["skirts"]},
         ) is not None
-        assert runtime_mod._exact_taxonomy_issue(
+        assert runtime_mod_support._exact_taxonomy_issue(
             "sneakers",
             {"category": ["footwear"], "subcategory": ["flats"]},
         ) is not None
-        assert not runtime_mod._agent_selected_scope_is_advertised(
+        assert not runtime_mod_support._agent_selected_scope_is_advertised(
             "bag",
             {
                 "category": ["bags"],
                 "subcategory": ["clutches", "satchels"],
             },
         )
-        assert runtime_mod._agent_selected_scope_is_advertised(
+        assert runtime_mod_support._agent_selected_scope_is_advertised(
             "clutch",
             {
                 "category": ["bags"],
@@ -6109,7 +6139,7 @@ class TestDeepAgentsRuntimeRefs:
         )
 
     def test_advertised_taxonomy_value_matches_singular_requested_type(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         capabilities = CatalogCapabilities(
             catalog_id="fashion",
@@ -6129,20 +6159,20 @@ class TestDeepAgentsRuntimeRefs:
             ),
         )
 
-        assert runtime_mod._advertised_taxonomy_value("bag", capabilities) == "bags"
+        assert runtime_mod_support._advertised_taxonomy_value("bag", capabilities) == "bags"
         assert (
-            runtime_mod._advertised_taxonomy_value("clutch", capabilities)
+            runtime_mod_support._advertised_taxonomy_value("clutch", capabilities)
             == "clutches"
         )
-        assert runtime_mod._advertised_taxonomy_value("backpack", capabilities) is None
-        assert not runtime_mod._agent_selected_scope_is_advertised(
+        assert runtime_mod_support._advertised_taxonomy_value("backpack", capabilities) is None
+        assert not runtime_mod_support._agent_selected_scope_is_advertised(
             "outerwear",
             {
                 "category": ["apparel"],
                 "subcategory": ["dresses", "skirts"],
             },
         )
-        assert not runtime_mod._agent_selected_scope_is_advertised(
+        assert not runtime_mod_support._agent_selected_scope_is_advertised(
             "shoes",
             {
                 "category": ["footwear"],
@@ -6156,9 +6186,10 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -6543,7 +6574,7 @@ class TestDeepAgentsRuntimeRefs:
         assert "waterproof" not in response
 
     def test_scoped_no_match_is_customer_safe_and_not_search_only(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -6567,7 +6598,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        evidence = runtime_mod._collect_tool_grounding_evidence(
+        evidence = runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
             request_id="current-request",
@@ -6578,7 +6609,7 @@ class TestDeepAgentsRuntimeRefs:
         assert '"primary_color": ["black"]' in evidence
         assert "does not establish" in evidence
         assert "black tailored trousers" not in evidence
-        assert runtime_mod._has_search_only_tool_evidence(
+        assert runtime_mod_support._has_search_only_tool_evidence(
             result,
             request_id="current-request",
         ) is False
@@ -6601,7 +6632,7 @@ class TestDeepAgentsRuntimeRefs:
                 },
             ]
         }
-        assert runtime_mod._no_direct_taxonomy_response(
+        assert runtime_mod_support._no_direct_taxonomy_response(
             cart_then_no_direct,
             request_id="current-request",
         ) is None
@@ -6610,6 +6641,7 @@ class TestDeepAgentsRuntimeRefs:
         self,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         message = search_tool_message(
             search_evidence(
@@ -6626,7 +6658,7 @@ class TestDeepAgentsRuntimeRefs:
                 "adjacent product types."
             ),
         )
-        evidence = runtime_mod._customer_safe_tool_evidence(
+        evidence = runtime_mod_support._customer_safe_tool_evidence(
             message["content"],
             message,
         )
@@ -6644,6 +6676,7 @@ class TestDeepAgentsRuntimeRefs:
         self,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -6660,7 +6693,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        assert runtime_mod._no_direct_taxonomy_response(
+        assert runtime_mod_support._no_direct_taxonomy_response(
             result,
             request_id="current-request",
         ) is None
@@ -6674,10 +6707,10 @@ class TestDeepAgentsRuntimeRefs:
                 ),
             }
         )
-        assert runtime_mod._no_direct_taxonomy_response(
+        assert runtime_mod_support._no_direct_taxonomy_response(
             result,
             request_id="current-request",
-        ) == runtime_mod._NO_DIRECT_TAXONOMY_RESPONSE
+        ) == runtime_mod_support._NO_DIRECT_TAXONOMY_RESPONSE
 
         repair_then_no_direct = {
             "messages": [
@@ -6693,10 +6726,10 @@ class TestDeepAgentsRuntimeRefs:
                 result["messages"][-1],
             ]
         }
-        assert runtime_mod._no_direct_taxonomy_response(
+        assert runtime_mod_support._no_direct_taxonomy_response(
             repair_then_no_direct,
             request_id="current-request",
-        ) == runtime_mod._NO_DIRECT_TAXONOMY_RESPONSE
+        ) == runtime_mod_support._NO_DIRECT_TAXONOMY_RESPONSE
 
         result["messages"].insert(
             -1,
@@ -6709,11 +6742,11 @@ class TestDeepAgentsRuntimeRefs:
                 ),
             },
         )
-        assert runtime_mod._no_direct_taxonomy_response(
+        assert runtime_mod_support._no_direct_taxonomy_response(
             result,
             request_id="current-request",
         ) is None
-        assert runtime_mod._has_search_only_tool_evidence(
+        assert runtime_mod_support._has_search_only_tool_evidence(
             result,
             request_id="current-request",
         ) is False
@@ -6723,6 +6756,7 @@ class TestDeepAgentsRuntimeRefs:
         base_config,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
         state = State(
@@ -6766,14 +6800,14 @@ class TestDeepAgentsRuntimeRefs:
             request_id="current-request",
         )
         assert "**Day Dress**" in response
-        assert runtime_mod._UNSUPPORTED_REQUIREMENT_RESPONSE in response
+        assert runtime_mod_support._UNSUPPORTED_REQUIREMENT_RESPONSE in response
 
     def test_grouped_search_deduplicates_by_product_ref_not_display_name(
         self,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        lines, displayed_names = runtime_mod._grouped_search_response_lines(
+        lines, displayed_names = runtime_mod_support._grouped_search_response_lines(
             [
                 {
                     "guidance": "Use the first role as the base.",
@@ -6810,10 +6844,11 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         base_config.grounding_rewrite_enabled = False
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -6857,7 +6892,7 @@ class TestDeepAgentsRuntimeRefs:
         assert "app_llm_grounding_editor" not in output.model_usage
 
     def test_collect_tool_grounding_evidence_uses_customer_safe_summary(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -6881,7 +6916,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        evidence = runtime_mod._collect_tool_grounding_evidence(
+        evidence = runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
         )
@@ -6896,6 +6931,7 @@ class TestDeepAgentsRuntimeRefs:
 
     def test_collect_search_evidence_forbids_name_based_attribute_inference(self) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -6930,7 +6966,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        evidence = runtime_mod._collect_tool_grounding_evidence(
+        evidence = runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
         )
@@ -6973,7 +7009,7 @@ class TestDeepAgentsRuntimeRefs:
     def test_collect_search_evidence_preserves_parent_category_caveat(
         self,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -7002,7 +7038,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        evidence = runtime_mod._collect_tool_grounding_evidence(
+        evidence = runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
         )
@@ -7016,7 +7052,7 @@ class TestDeepAgentsRuntimeRefs:
     def test_skill_activation_content_is_not_commerce_grounding_evidence(
         self,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -7036,7 +7072,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        evidence = runtime_mod._collect_tool_grounding_evidence(
+        evidence = runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
         )
@@ -7044,7 +7080,7 @@ class TestDeepAgentsRuntimeRefs:
         assert evidence == ""
 
     def test_assistant_claims_are_not_treated_as_tool_evidence(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -7058,13 +7094,13 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        assert runtime_mod._collect_tool_grounding_evidence(
+        assert runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
         ) == ""
 
     def test_grounding_evidence_is_scoped_to_the_current_turn(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -7089,7 +7125,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        evidence = runtime_mod._collect_tool_grounding_evidence(
+        evidence = runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
             request_id="current-request",
@@ -7101,7 +7137,7 @@ class TestDeepAgentsRuntimeRefs:
     def test_grounding_evidence_without_current_request_marker_fails_closed(
         self,
     ) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -7116,14 +7152,14 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        assert runtime_mod._collect_tool_grounding_evidence(
+        assert runtime_mod_support._collect_tool_grounding_evidence(
             result,
             max_chars=12000,
             request_id="missing-request",
         ) == ""
 
     def test_search_only_filter_groups_preserve_product_scope(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         result = {
             "messages": [
@@ -7146,7 +7182,7 @@ class TestDeepAgentsRuntimeRefs:
             ]
         }
 
-        assert runtime_mod._confirmed_search_filter_groups(
+        assert runtime_mod_support._confirmed_search_filter_groups(
             result,
             request_id="current-request",
         ) == [
@@ -7162,7 +7198,7 @@ class TestDeepAgentsRuntimeRefs:
                 "statements": ["primary color is red"],
             },
         ]
-        response = runtime_mod._format_search_only_response(
+        response = runtime_mod_support._format_search_only_response(
             State(
                 user_id=111,
                 query="Show me black flats and red tops.",
@@ -7189,7 +7225,7 @@ class TestDeepAgentsRuntimeRefs:
         assert "primary color is black; primary color is red" not in response
 
     def test_explicit_product_matching_allows_specific_abbreviated_names(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         sandals = ProductSummary(
             product_id="prod_sandals",
@@ -7204,7 +7240,7 @@ class TestDeepAgentsRuntimeRefs:
             display_name="Green Meadow Sweater Top",
         )
 
-        matches = runtime_mod._explicitly_named_products(
+        matches = runtime_mod_support._explicitly_named_products(
             (
                 "Please add the Flat Strappy Sandals and Gentle Meadow Blouse "
                 "Sweater to my cart."
@@ -7218,9 +7254,9 @@ class TestDeepAgentsRuntimeRefs:
         ]
 
     def test_scrub_internal_shopper_language_removes_tool_mechanics(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        scrubbed = runtime_mod._scrub_internal_shopper_language(
+        scrubbed = runtime_mod_support._scrub_internal_shopper_language(
             (
                 "The product detail tool doesn't return fabric composition, "
                 "and the sandals weren't added because the tool requires an "
@@ -7238,6 +7274,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         captured: Dict[str, Any] = {}
         deepagents_mod = ModuleType("deepagents")
@@ -7290,7 +7327,7 @@ class TestDeepAgentsRuntimeRefs:
                 filters={},
             )
         )
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -7552,6 +7589,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         base_config.max_product_detail_reads_per_turn = 4
         captured: Dict[str, Any] = {}
@@ -7598,7 +7636,7 @@ class TestDeepAgentsRuntimeRefs:
                 filters={},
             )
         )
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -7678,6 +7716,7 @@ class TestDeepAgentsRuntimeRefs:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         base_config.max_product_detail_reads_per_turn = 1
         captured: Dict[str, Any] = {}
@@ -7740,7 +7779,7 @@ class TestDeepAgentsRuntimeRefs:
                 filters={},
             )
         )
-        identity = runtime_mod.RequestIdentity(
+        identity = runtime_mod_support.RequestIdentity(
             session_id="session-a",
             conversation_id="conversation-a",
             cart_id="cart-a",
@@ -7773,7 +7812,7 @@ class TestDeepAgentsRuntimeRefs:
         assert "STOP_TOOL_USE: Product-detail read limit reached" in second
 
     def test_format_product_exposes_product_ref(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         product = ProductSummary(
             product_id="prod_456",
@@ -7782,7 +7821,7 @@ class TestDeepAgentsRuntimeRefs:
             price=Money(amount=129.0),
         )
 
-        formatted = runtime_mod._format_product(product)
+        formatted = runtime_mod_support._format_product(product)
 
         assert "PRODUCT_REF: prod_456" in formatted
         assert "Leather Bag" in formatted
@@ -7792,7 +7831,7 @@ class TestDeepAgentsRuntimeRefs:
         assert "absence here is not evidence" in formatted
 
     def test_format_product_details_warns_against_performance_overclaims(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         product = ProductDetail(
             product_id="prod_789",
@@ -7802,7 +7841,7 @@ class TestDeepAgentsRuntimeRefs:
             attributes={"sole": "rubber", "fastening": "ankle strap"},
         )
 
-        formatted = runtime_mod._format_product_details(product)
+        formatted = runtime_mod_support._format_product_details(product)
 
         assert "PRODUCT_DETAIL_GROUNDING_NOTE" in formatted
         assert "- sole: rubber" in formatted
@@ -7869,7 +7908,7 @@ class TestDeepAgentsRuntimeRefs:
         ]
 
     def test_cart_line_lookup_uses_exact_cart_line_id(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         cart = Cart(
             contents=[
@@ -7878,8 +7917,8 @@ class TestDeepAgentsRuntimeRefs:
             ]
         )
 
-        assert runtime_mod._cart_line_by_id("line_2", cart) == cart.contents[1]
-        assert runtime_mod._cart_line_by_id("Silk Dress", cart) is None
+        assert runtime_mod_support._cart_line_by_id("line_2", cart) == cart.contents[1]
+        assert runtime_mod_support._cart_line_by_id("Silk Dress", cart) is None
 
 
 class TestValidation:
@@ -7903,9 +7942,10 @@ class TestCommittedMutationReceipt:
 
     def test_receipt_replaces_product_fallback_when_a_mutation_committed(self) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support
 
         cart = runtime_mod.Cart(contents=[{"item": "Work Bag", "amount": 1}])
-        receipt = runtime_mod._committed_effect_receipt(
+        receipt = turn_support._committed_effect_receipt(
             [
                 {
                     "operation": "added to cart",
@@ -7923,9 +7963,9 @@ class TestCommittedMutationReceipt:
         assert "not applied twice" in receipt
 
     def test_receipt_survives_an_unreadable_cart(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support
 
-        receipt = runtime_mod._committed_effect_receipt(
+        receipt = turn_support._committed_effect_receipt(
             [{"operation": "removed from cart", "idempotency_key": "k", "cart_line_id": "line-9"}],
             None,
         )
@@ -8007,10 +8047,12 @@ class TestCommittedMutationSurvivesTurnFailure:
         assert [e["operation"] for e in recovered] == [k for k, _ in kinds]
 
     def test_failed_turn_reports_the_effect_instead_of_a_product_list(self) -> None:
+        from chain_server.src import turn_support
+
         runtime_mod = self._runtime()
         cart = runtime_mod.Cart(contents=[{"item": "Work Bag", "amount": 1}])
 
-        receipt = runtime_mod._committed_effect_receipt(
+        receipt = turn_support._committed_effect_receipt(
             [
                 {
                     "operation": "removed from cart",
@@ -8045,6 +8087,7 @@ class TestEvidenceFreeTurnsStillGetEdited:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
         seen: dict[str, object] = {}
@@ -8056,7 +8099,7 @@ class TestEvidenceFreeTurnsStillGetEdited:
 
         monkeypatch.setattr(runtime, "_create_chat_model", lambda: RecordingEditor())
         state = State(user_id=111, query="what can you do?")
-        assert runtime_mod._has_grounding_authority(state, "") is False
+        assert runtime_mod_support._has_grounding_authority(state, "") is False
 
         response = await runtime._rewrite_response_for_grounding(
             state,
@@ -8081,6 +8124,7 @@ class TestEvidenceFreeTurnsStillGetEdited:
         """
 
         from chain_server.src import deepagents_runtime as runtime_mod
+
 
         runtime = runtime_mod.DeepAgentsRuntime(base_config)
 
@@ -8110,8 +8154,8 @@ class TestGroundingGateCountsHydratedLanes:
     """Every turn hydrates memory lanes; the gate must not discard them."""
 
     def _gate(self):
-        from chain_server.src import deepagents_runtime as runtime_mod
-        return runtime_mod._has_grounding_authority
+        from chain_server.src import turn_support as runtime_mod_support
+        return runtime_mod_support._has_grounding_authority
 
     def _state(self, **kw):
         from chain_server.src.agenttypes import State
@@ -8176,12 +8220,13 @@ class TestUnenforceableRequirementIsModelOwned:
 
         from chain_server.src import deepagents_runtime as runtime_mod
 
+
         assert not hasattr(runtime_mod, "_unsupported_requirement_response")
 
     def test_tool_outcome_states_the_fact_and_forbids_refusing(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        message = runtime_mod._unsupported_requirement_message(["matte"])
+        message = runtime_mod_support._unsupported_requirement_message(["matte"])
 
         assert "not an advertised hard filter" in message
         assert "Do not refuse the request." in message
@@ -8189,9 +8234,9 @@ class TestUnenforceableRequirementIsModelOwned:
         assert "Ask the shopper whether to treat it as a preference." not in message
 
     def test_outcome_defers_to_what_the_shopper_already_said(self) -> None:
-        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
 
-        message = runtime_mod._unsupported_requirement_message(["matte"])
+        message = runtime_mod_support._unsupported_requirement_message(["matte"])
 
         assert "already told you" in message
 
@@ -8207,6 +8252,7 @@ class TestComposerAuthorityLanes:
         """
 
         from chain_server.src import deepagents_runtime as runtime_mod
+
 
         src = runtime_mod._GROUNDING_EDITOR_SYSTEM_PROMPT
         assert "CONVERSATION" in src
@@ -8231,6 +8277,7 @@ class TestComposerAuthorityLanes:
         """_prior_turn_messages always returns [] — one human message per turn."""
 
         from chain_server.src import deepagents_runtime as runtime_mod
+
 
         assert "PRIOR-TURN TOOL EVIDENCE" not in runtime_mod._GROUNDING_EDITOR_SYSTEM_PROMPT
 

--- a/tests/unit/chain_server/test_skill_activation.py
+++ b/tests/unit/chain_server/test_skill_activation.py
@@ -27,6 +27,8 @@ from chain_server.src.agenttypes import Cart, State
 from chain_server.src.catalog_execution import CatalogSearchExecution
 from chain_server.src.deepagents_runtime import (
     DeepAgentsRuntime,
+)
+from chain_server.src.turn_support import (
     RequestIdentity,
     _skill_activation_input_model,
 )

--- a/tests/unit/chain_server/test_tool_evidence_artifact.py
+++ b/tests/unit/chain_server/test_tool_evidence_artifact.py
@@ -23,6 +23,7 @@ from typing import Any
 import pytest
 
 from chain_server.src import deepagents_runtime as runtime_mod
+from chain_server.src import turn_support as runtime_mod_support
 from chain_server.src import response_format
 from chain_server.src.tool_evidence import (
     DETAIL_EVIDENCE_KEY,
@@ -117,7 +118,7 @@ class _StubToolMessage:
 def test_search_result_text_the_model_reads(
     product: ProductSummary, expected: str
 ) -> None:
-    assert runtime_mod._format_product(product) == expected
+    assert runtime_mod_support._format_product(product) == expected
 
 
 @pytest.mark.parametrize(
@@ -187,7 +188,7 @@ def test_product_detail_text_the_model_reads(
 ) -> None:
     expected = f"{response_format._PRODUCT_DETAIL_GROUNDING_NOTE}\n{expected_body}"
 
-    assert runtime_mod._format_product_details(detail) == expected
+    assert runtime_mod_support._format_product_details(detail) == expected
 
 
 # --------------------------------------------------------------------------
@@ -226,7 +227,7 @@ def _results_evidence() -> SearchEvidence:
 def test_composer_summary_for_search_results() -> None:
     """Every fact the composer may repeat, and the limits placed on it."""
 
-    summary = runtime_mod._customer_safe_tool_evidence(
+    summary = runtime_mod_support._customer_safe_tool_evidence(
         "", _StubToolMessage(_results_evidence())
     )
 
@@ -288,7 +289,7 @@ def test_search_results_carry_the_attributes_the_catalog_confirmed() -> None:
         },
     )
 
-    record = runtime_mod._search_product_record(product)
+    record = runtime_mod_support._search_product_record(product)
 
     assert record["attributes"] == {
         "composition": "100% satin",
@@ -311,7 +312,7 @@ def test_composer_may_state_a_confirmed_attribute() -> None:
     evidence = _results_evidence()
     evidence.products[0]["attributes"] = {"composition": "100% satin"}
 
-    summary = runtime_mod._customer_safe_tool_evidence("", _StubToolMessage(evidence))
+    summary = runtime_mod_support._customer_safe_tool_evidence("", _StubToolMessage(evidence))
 
     assert "confirmed: composition: 100% satin" in summary
     assert "any attribute listed as confirmed for that specific product" in summary
@@ -330,7 +331,7 @@ def test_composer_summary_for_zero_results() -> None:
         advertised_category="Bags",
     )
 
-    summary = runtime_mod._customer_safe_tool_evidence("", _StubToolMessage(evidence))
+    summary = runtime_mod_support._customer_safe_tool_evidence("", _StubToolMessage(evidence))
 
     assert summary == (
         "CUSTOMER_SAFE_SCOPED_NO_MATCH_EVIDENCE: Zero products matched only "
@@ -359,7 +360,7 @@ def test_composer_summary_for_product_detail() -> None:
         "details": ["care: Machine wash cold.", "composition: 100% linen"],
     }
 
-    summary = runtime_mod._customer_safe_tool_evidence(
+    summary = runtime_mod_support._customer_safe_tool_evidence(
         "",
         _StubToolMessage(
             artifact=ProductDetailEvidence(products=[record]).as_artifact()
@@ -390,7 +391,7 @@ def test_no_direct_catalog_match_is_a_refusal_not_an_empty_search() -> None:
         requested_product_type="casual sneakers",
     )
 
-    summary = runtime_mod._customer_safe_tool_evidence("", _StubToolMessage(evidence))
+    summary = runtime_mod_support._customer_safe_tool_evidence("", _StubToolMessage(evidence))
 
     assert summary.startswith("CUSTOMER_SAFE_NO_MATCH_EVIDENCE:")
     assert "No retrieval ran" in summary
@@ -406,7 +407,7 @@ def test_scope_relation_is_absent_when_no_parent_was_substituted() -> None:
     evidence = _results_evidence()
     evidence.advertised_category = None
 
-    summary = runtime_mod._customer_safe_tool_evidence("", _StubToolMessage(evidence))
+    summary = runtime_mod_support._customer_safe_tool_evidence("", _StubToolMessage(evidence))
 
     assert "REQUESTED_SCOPE_RELATION" not in summary
 
@@ -417,7 +418,7 @@ def test_empty_results_do_not_append_a_blank_line() -> None:
     evidence = _results_evidence()
     evidence.products = []
 
-    summary = runtime_mod._customer_safe_tool_evidence("", _StubToolMessage(evidence))
+    summary = runtime_mod_support._customer_safe_tool_evidence("", _StubToolMessage(evidence))
 
     assert not summary.endswith("\n")
 


### PR DESCRIPTION
`deepagents_runtime.py` held the class that sequences a turn *and* every helper
that class calls, in one 6,611-line file. This separates the two.

## What this does

- Moves 141 definitions into a new `chain_server/src/turn_support.py`: catalog
  scope reasoning, evidence shaping, response assembly, diagnostics, and the
  pydantic schemas for tool arguments. None of them touches `self`, the graph, or
  a live service — each takes data and returns data, so they can now be read and
  tested without standing up a runtime.
- Leaves `deepagents_runtime.py` as the orchestration it was named for:
  **6,611 → 3,638 lines**.
- Fixes a defect the move itself introduced: `logger = logging.getLogger(__name__)`
  moved out with the helpers, so the ten logging call sites left behind in
  `DeepAgentsRuntime` silently started emitting under the other module's name.
  Each module now builds its own logger.
- Repoints the tests and two docs that named the old location.

## Why one module and not several

The call graph between the natural themes is cyclic — evidence calls scope, scope
calls shared helpers, and those call back into diagnostics and response assembly.
Splitting further means breaking those cycles, which is a design change rather
than a move, so it is left to its own change instead of being smuggled into this
one. `turn_support.py` is a holding pen at 3,426 lines, not a finished design.

## Behaviour

Unchanged, and checked rather than asserted: every moved definition is
byte-identical to its original, and every global name each function reads
resolves to the same object as before the move. That second check is what caught
the logger defect above — byte identity alone did not.
