### PR TITLE
fix: resolve product references the model quoted, and raise the detail-read cap

### DIFF
--- a/chain_server/src/config.py
+++ b/chain_server/src/config.py
@@ -109,7 +109,7 @@ class ChainServerConfig(BaseModel):
         description="Maximum distinct catalog taxonomy scopes allowed per turn",
     )
     max_product_detail_reads_per_turn: int = Field(
-        default=2,
+        default=10,
         description="Maximum product-detail tool calls allowed for one assistant turn",
     )
     grounding_rewrite_enabled: bool = Field(

--- a/chain_server/src/conversation_products.py
+++ b/chain_server/src/conversation_products.py
@@ -112,6 +112,8 @@ class ProductReferenceResolution(_ConversationProductModel):
     status: Literal["resolved", "ambiguous", "not_found"]
     matches: list[ConversationProductMatch] = Field(default_factory=list)
     match_count: int = Field(..., ge=0)
+    #: Which supplied field stopped the match, when exactly one is responsible.
+    blocking_field: str | None = Field(default=None, max_length=64)
 
     @model_validator(mode="after")
     def _status_matches_result(self):
@@ -280,6 +282,19 @@ def format_product_resolution(result: ResolveConversationProductsResult) -> str:
             lines.append(
                 f"REFERENCE {resolution.reference_id}: CLARIFICATION REQUIRED "
                 f"({names}). Do not guess."
+            )
+            continue
+        if resolution.blocking_field:
+            # Naming the field is what lets the model correct the call. Reporting
+            # only NOT FOUND told it the product was gone when it had in fact
+            # identified it correctly by every other field, so it repeated the
+            # same call and kept telling the shopper the listing was unavailable.
+            lines.append(
+                f"REFERENCE {resolution.reference_id}: NOT FOUND. Every other "
+                f"field you supplied matched one earlier product; "
+                f"'{resolution.blocking_field}' did not. Correct that field and "
+                "retry, or ask which earlier product the shopper means. Do not "
+                "guess."
             )
             continue
         lines.append(

--- a/memory_retriever/src/product_references.py
+++ b/memory_retriever/src/product_references.py
@@ -77,6 +77,9 @@ class ProductResolutionResult(_ReferenceModel):
     status: Literal["resolved", "ambiguous", "not_found"]
     matches: list[ProductReferenceMatch]
     match_count: int
+    #: The one supplied field that stopped an otherwise clear match, when
+    #: exactly one is responsible. Diagnosis only; it names no product.
+    blocking_field: str | None = None
 
 
 class ProductResolutionResponse(_ReferenceModel):
@@ -163,10 +166,56 @@ def resolve_product_references(
     )
 
 
+#: Descriptor fields that narrow a match, in the order a reader would check them.
+_DESCRIPTOR_FIELDS = (
+    "product_ref",
+    "display_name",
+    "category",
+    "turn_sequence",
+    "candidate_set_id",
+    "ordinal",
+)
+
+
+def _blocking_field(
+    descriptor: ProductReferenceDescriptor,
+    occurrences: list[ProductReferenceMatch],
+) -> str | None:
+    """Return the one supplied field that stopped an otherwise clear match.
+
+    Matching is conjunctive, so a descriptor carrying five correct identifiers
+    and one wrong one resolves nothing and reports not_found -- which tells the
+    model only that the product is missing, when in fact it named it correctly
+    five ways. Naming the field lets the model correct the call instead of
+    repeating it, which is what it did for four turns.
+
+    This only diagnoses. It never resolves to the product it found, because a
+    descriptor the shopper's assistant got wrong is not authority to pick one.
+    """
+
+    supplied = [
+        name
+        for name in _DESCRIPTOR_FIELDS
+        if getattr(descriptor, name, None) is not None
+    ]
+    if len(supplied) < 2:
+        return None
+    blocking: str | None = None
+    for name in supplied:
+        relaxed = descriptor.model_copy(update={name: None})
+        if any(_matches_descriptor(o, relaxed) for o in occurrences):
+            if blocking is not None:
+                # More than one field is wrong; naming one would mislead.
+                return None
+            blocking = name
+    return blocking
+
+
 def _resolve_descriptor(
     descriptor: ProductReferenceDescriptor,
     occurrences: list[ProductReferenceMatch],
 ) -> ProductResolutionResult:
+    blocking_field: str | None = None
     matches_by_ref: dict[str, ProductReferenceMatch] = {}
     for occurrence in occurrences:
         if not _matches_descriptor(occurrence, descriptor):
@@ -178,6 +227,7 @@ def _resolve_descriptor(
     matches = list(matches_by_ref.values())
     if not matches:
         status = "not_found"
+        blocking_field = _blocking_field(descriptor, occurrences)
     elif len(matches) == 1:
         status = "resolved"
     else:
@@ -187,6 +237,7 @@ def _resolve_descriptor(
         status=status,
         matches=matches[-_MAX_CLARIFICATION_MATCHES:],
         match_count=len(matches),
+        blocking_field=blocking_field,
     )
 
 
@@ -338,5 +389,20 @@ def _normalized(value: str) -> str:
     return " ".join(value.casefold().split())
 
 
+#: Characters a model may wrap an opaque identifier in. Nothing in the tool
+#: schema or the rendered index shows a quoted ref, so a model that quotes one
+#: is following a convention, not disobeying an instruction.
+_REFERENCE_WRAPPERS = "<>[]{}\"'`"
+
+
 def _identifier(value: str) -> str:
-    return value.strip()
+    """Compare the identifier, not the punctuation around it.
+
+    A model sent `<generated:add69d96c548b4a3>` for a product it had displayed
+    one turn earlier. The exact comparison missed, resolution returned
+    not_found, and four turns in a row told the shopper the listing was
+    unavailable. Stripping the wrapper compares what the index stored; it does
+    not change which product is named, so nothing is guessed by doing it.
+    """
+
+    return value.strip().strip(_REFERENCE_WRAPPERS).strip()

--- a/shared/configs/chain_server/config.yaml
+++ b/shared/configs/chain_server/config.yaml
@@ -17,7 +17,7 @@ deepagents_execution_timeout_seconds: 90.0
 # six turns consuming the entire budget.
 grounding_editor_reserve_seconds: 15.0
 max_catalog_searches_per_turn: 3
-max_product_detail_reads_per_turn: 2
+max_product_detail_reads_per_turn: 10
 expose_agent_diagnostics: false
 catalog_search_timeout_seconds: null
 weather:

--- a/tests/unit/memory_retriever/test_conversations.py
+++ b/tests/unit/memory_retriever/test_conversations.py
@@ -814,6 +814,7 @@ def test_product_resolution_batches_unique_ambiguous_and_missing_results(
             }
         ],
         "match_count": 1,
+        "blocking_field": None,
     }
     assert results["ambiguous"]["status"] == "ambiguous"
     assert results["ambiguous"]["match_count"] == 2
@@ -826,6 +827,7 @@ def test_product_resolution_batches_unique_ambiguous_and_missing_results(
         "status": "not_found",
         "matches": [],
         "match_count": 0,
+        "blocking_field": None,
     }
 
 
@@ -938,6 +940,7 @@ def test_product_resolution_is_conversation_scoped(
             "status": "not_found",
             "matches": [],
             "match_count": 0,
+            "blocking_field": None,
         }
     ]
 
@@ -1590,3 +1593,102 @@ def test_file_database_reopens_with_sqlite_safety_settings(
             == 6
         )
     reopened_engine.dispose()
+
+
+class TestProductReferenceResolutionIsForgivingButNeverGuesses:
+    """A reference the model quoted is still the reference it named.
+
+    Reproduces a live failure: the assistant showed three bags, then for four
+    consecutive turns told the shopper their listings were "not available to
+    me". It had sent `<generated:add69d96c548b4a3>` -- the correct id, wrapped
+    in angle brackets -- and the exact comparison missed.
+    """
+
+    def _occurrence(self):
+        from memory_retriever.src.product_references import ProductReferenceMatch
+
+        return ProductReferenceMatch(
+            product={
+                "product_id": "generated:add69d96c548b4a3",
+                "display_name": "Ravenna Crossbody Bag",
+                "category": "crossbody_bags",
+                "price": {"amount": 49.99, "currency": "USD"},
+            },
+            turn_sequence=1,
+            position=3,
+            candidate_set_id="f088dc105e0f4bd896ca9eaa018329f3",
+        )
+
+    def _descriptor(self, **overrides):
+        from memory_retriever.src.product_references import ProductReferenceDescriptor
+
+        fields = {
+            "reference_id": "bag1",
+            "product_ref": "generated:add69d96c548b4a3",
+            "display_name": "Ravenna Crossbody Bag",
+            "category": "crossbody_bags",
+            "turn_sequence": 1,
+            "candidate_set_id": "f088dc105e0f4bd896ca9eaa018329f3",
+            "ordinal": 3,
+        }
+        fields.update(overrides)
+        return ProductReferenceDescriptor(**fields)
+
+    def test_a_wrapped_reference_still_resolves(self) -> None:
+        from memory_retriever.src.product_references import _matches_descriptor
+
+        for wrapped in (
+            "<generated:add69d96c548b4a3>",
+            "`generated:add69d96c548b4a3`",
+            '"generated:add69d96c548b4a3"',
+            "  generated:add69d96c548b4a3  ",
+        ):
+            assert _matches_descriptor(
+                self._occurrence(), self._descriptor(product_ref=wrapped)
+            ), wrapped
+
+    def test_a_different_reference_still_does_not_resolve(self) -> None:
+        """Normalising punctuation must not make unrelated ids match."""
+
+        from memory_retriever.src.product_references import _matches_descriptor
+
+        assert not _matches_descriptor(
+            self._occurrence(), self._descriptor(product_ref="generated:0000000000")
+        )
+
+    def test_the_one_wrong_field_is_named(self) -> None:
+        from memory_retriever.src.product_references import _blocking_field
+
+        assert (
+            _blocking_field(
+                self._descriptor(product_ref="generated:0000000000"),
+                [self._occurrence()],
+            )
+            == "product_ref"
+        )
+
+    def test_two_wrong_fields_name_nothing(self) -> None:
+        """Naming one of several wrong fields would send the model the wrong way."""
+
+        from memory_retriever.src.product_references import _blocking_field
+
+        assert (
+            _blocking_field(
+                self._descriptor(
+                    product_ref="generated:0000000000", category="satchels"
+                ),
+                [self._occurrence()],
+            )
+            is None
+        )
+
+    def test_diagnosis_never_resolves_the_product_it_found(self) -> None:
+        from memory_retriever.src.product_references import _resolve_descriptor
+
+        result = _resolve_descriptor(
+            self._descriptor(product_ref="generated:0000000000"),
+            [self._occurrence()],
+        )
+        assert result.status == "not_found"
+        assert result.matches == []
+        assert result.blocking_field == "product_ref"


### PR DESCRIPTION
Two measured defects in how a turn uses the catalog. Independent of each other;
one commit each.

## A product reference the model quoted never resolved

The assistant showed three bags, then for four consecutive turns told the shopper
their listings were "not available to me" — including a turn where the shopper
supplied the exact names and prices. It had sent
`<generated:add69d96c548b4a3>`: the correct identifier, in angle brackets.
Comparison was `value.strip()`, so it missed.

**This affected 42% of all product references ever sent** — 159 of 372 across the
run archive, in 16 of 18 scenarios.

- Identifiers now compare without surrounding brackets, quotes or backticks.
  Nothing in the tool schema or the rendered index shows a quoted ref, so a model
  that quotes one is following a convention rather than disobeying an
  instruction. An unrelated id still does not match.
- A failed match now names the single field that blocked it. Matching is
  conjunctive, so that call carried five correct identifiers — display name,
  category, turn, candidate set, ordinal — and returned a bare `not_found`. The
  model had no way to learn which field was wrong, so it repeated the same call
  three more times. It stays silent when more than one field is wrong, rather
  than pointing the model the wrong way.
- The diagnosis never resolves the product it found. A descriptor the assistant
  got wrong is not authority to pick one.

## The product-detail read cap was too low

Sixteen of 48 tool-call rejections in a full run were the model wanting a third
detail read. A turn that resolves two products and reads both had already spent
the budget.

- Raised from 2 to 10. The deadline, not the cap, is the real bound: at a
  measured 8.7s per tool call against 75s of usable turn budget the effective
  limit is around five, and exceeding it degrades to a partial answer rather
  than failing.
