### PR TITLE
fix: hand back product facts the system already holds, and record what it cannot serve

### DIFF
--- a/chain_server/src/catalog_scope.py
+++ b/chain_server/src/catalog_scope.py
@@ -20,6 +20,16 @@ CATALOG_SEARCH_RULES = """- Call search_catalog_tool when exact advertised
 - Different wording is not a reason to ask. When the shopper names a true
   umbrella, search every advertised value that is genuinely a kind of that
   umbrella. For example, skirts can satisfy bottoms; dresses cannot.
+- The advertised categories in Catalog capabilities are the whole store. If what
+  the shopper asks for is not a kind of any advertised category, do not search
+  for it and do not substitute a neighbour. When the same turn also asks for
+  things the catalog does carry, send scopes for those and name the uncovered
+  ones in `not_covered`: "a pan, a shoe and a bag" is scopes for the shoe and
+  the bag, plus `not_covered: ["pan"]`. When nothing in the turn is covered, do
+  not call the tool at all -- say so plainly and name what this catalog does
+  cover. Either way that is a fact stated by the capability contract above, not
+  a guess about stock. Absence *within* an advertised category is different: it
+  is unknown until searched.
 - A catalog search carries a list of scopes. **One scope carries exactly one
   advertised category.** A product role the shopper names may need more than one
   scope: when a role spans categories, send one scope per category in the same

--- a/chain_server/src/catalog_search.py
+++ b/chain_server/src/catalog_search.py
@@ -1377,6 +1377,7 @@ def search_catalog(
     scopes: list[dict[str, Any]],
     scope_complete: bool = True,
     search_mode: str | None = None,
+    not_covered: list[str] | None = None,
 ):
     """Execute one catalog search per product role, concurrently.
 
@@ -1470,6 +1471,16 @@ def search_catalog(
                 outcomes[index] = outcome
 
     rendered: list[str] = []
+    if not_covered:
+        # The shopper asked for something no advertised category covers. It
+        # costs no retrieval, but recording it is what stops the request being
+        # silently dropped: without this the tool sees two scopes and cannot
+        # know a third thing was asked for.
+        rendered.append(
+            "NOT_COVERED: this catalog carries nothing of these kinds, so they "
+            "were not searched. Tell the shopper plainly rather than omitting "
+            "them: " + ", ".join(str(item) for item in not_covered)
+        )
     artifacts: list[dict[str, Any]] = []
     for index, attempt in enumerate(attempts):
         outcome = outcomes[index]

--- a/chain_server/src/conversation_products.py
+++ b/chain_server/src/conversation_products.py
@@ -235,6 +235,29 @@ class ProductEvidence:
         return tuple(self._products.values())
 
 
+#: Fields the catalog returns alongside attributes that are not product facts:
+#: marketing copy and retrieval scores must never reach the model as evidence.
+_NON_ATTRIBUTE_KEYS = frozenset({"catalog_text", "similarity", "taxonomy"})
+
+
+def _presented_attribute_facts(product: Any) -> dict[str, str]:
+    """Attributes the catalog confirmed when this product was shown."""
+
+    attributes = getattr(product, "attributes", None)
+    if not isinstance(attributes, dict):
+        return {}
+    facts: dict[str, str] = {}
+    for name, value in sorted(attributes.items()):
+        if name in _NON_ATTRIBUTE_KEYS:
+            continue
+        text = str(value).strip() if not isinstance(value, (list, dict)) else ", ".join(
+            str(v) for v in (value if isinstance(value, list) else value.values())
+        ).strip()
+        if text:
+            facts[str(name)] = text
+    return facts
+
+
 def format_product_resolution(result: ResolveConversationProductsResult) -> str:
     """Render resolution outcomes without authorizing a guessed product."""
 
@@ -268,11 +291,21 @@ def format_product_resolution(result: ResolveConversationProductsResult) -> str:
                 )
             if product.image_url:
                 lines.append("IMAGE_AVAILABLE: yes")
+            # The presented-product event stores the whole ProductSummary, so
+            # the attributes the catalog confirmed when this product was shown
+            # are already in hand. Withholding them told the model to spend a
+            # round trip fetching what the lane had recorded -- and the message
+            # below used to say details were required for material and care,
+            # which was never true of this data.
+            facts = _presented_attribute_facts(product)
+            if facts:
+                lines.append("CONFIRMED WHEN SHOWN:")
+                lines.extend(f"- {name}: {value}" for name, value in facts.items())
             lines.append(
-                "These are the facts presented earlier. Attributes such as "
-                "material, care, and dimensions require "
-                "get_product_details_tool. Confirm price with a fresh read "
-                "before a cart action or a budget claim."
+                "These are the facts presented earlier, including the "
+                "attributes the catalog confirmed at that time. Read details "
+                "only for a fact not listed above. Confirm price with a fresh "
+                "read before a cart action or a budget claim."
             )
             continue
         if resolution.status == "ambiguous":

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -856,10 +856,10 @@ class DeepAgentsRuntime:
             constraint_input_model=constraint_input_model,
         )
 
-        def _search_catalog_impl(scopes):
+        def _search_catalog_impl(scopes, not_covered=None):
             """Execute one catalog search per product role; may return signals."""
 
-            return search_catalog(search_context, scopes)
+            return search_catalog(search_context, scopes, not_covered=not_covered)
 
 
         @tool(
@@ -867,7 +867,7 @@ class DeepAgentsRuntime:
             return_direct=False,
             response_format="content_and_artifact",
         )
-        def search_catalog_tool(scopes):
+        def search_catalog_tool(scopes, not_covered=None):
             """Find products by description, advertised taxonomy, or constraints.
 
             Use for browse, search, and recommendation requests after product
@@ -877,7 +877,9 @@ class DeepAgentsRuntime:
             filter scope with different semantic wording.
             """
 
-            return normalize_tool_result(_search_catalog_impl(scopes))
+            return normalize_tool_result(
+                _search_catalog_impl(scopes, not_covered)
+            )
 
         @tool(return_direct=False)
         def get_cart_tool() -> str:

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -1151,9 +1151,23 @@ def _search_catalog_scopes_input_model(
                 min_length=1,
                 max_length=max_scopes,
                 description=(
-                    "One search scope per product role. Each scope owns its own "
-                    "taxonomy and constraints, so a filter for one role can never "
-                    "exclude another role's products."
+                    "One search scope per advertised category. Each scope owns "
+                    "its own taxonomy and constraints, so a filter for one role "
+                    "can never exclude another role's products."
+                ),
+            ),
+        ),
+        not_covered=(
+            list[str] | None,
+            Field(
+                default=None,
+                max_length=10,
+                description=(
+                    "Product types the shopper asked for that no advertised "
+                    "category covers, in the shopper's own words. Do not search "
+                    "for these -- naming them here is what records the request so "
+                    "it can be answered. A shopper asking for 'a pan, a shoe and "
+                    "a bag' gets scopes for the shoe and the bag, and 'pan' here."
                 ),
             ),
         ),

--- a/tests/unit/chain_server/test_catalog_scope.py
+++ b/tests/unit/chain_server/test_catalog_scope.py
@@ -92,3 +92,60 @@ class TestDetailReadRedundancy:
 
         product = self._product("cookware", {"bag_closure": "zip"})
         assert not _detail_fields_already_held(product, self._capabilities())
+
+
+class TestResolutionReturnsStoredAttributes:
+    """A product recovered from history carries the facts it was shown with.
+
+    The presented-product event stores the whole ProductSummary, attributes
+    included. Rendering only identity told the model to spend a round trip
+    fetching what the lane already held, and the old wording claimed material
+    and care *required* a detail read -- which was never true of this data.
+    """
+
+    def _product(self, attributes):
+        from shared.commerce_contracts import Money, ProductSummary
+
+        return ProductSummary(
+            product_id="generated:abc",
+            display_name="Ravenna Crossbody Bag",
+            category="crossbody_bags",
+            price=Money(amount=49.99, currency="USD"),
+            attributes=attributes,
+        )
+
+    def test_stored_attributes_are_rendered(self) -> None:
+        from chain_server.src.conversation_products import (
+            _presented_attribute_facts,
+        )
+
+        facts = _presented_attribute_facts(
+            self._product({"bag_closure": "zip", "composition": "leather"})
+        )
+        assert facts == {"bag_closure": "zip", "composition": "leather"}
+
+    def test_marketing_copy_and_scores_never_reach_the_model(self) -> None:
+        """catalog_text is marketing prose; similarity is a retrieval score."""
+
+        from chain_server.src.conversation_products import (
+            _presented_attribute_facts,
+        )
+
+        facts = _presented_attribute_facts(
+            self._product(
+                {
+                    "bag_closure": "zip",
+                    "catalog_text": "The only bag you will ever need!",
+                    "similarity": 0.83,
+                    "taxonomy": "bags > crossbody",
+                }
+            )
+        )
+        assert facts == {"bag_closure": "zip"}
+
+    def test_a_product_with_no_attributes_renders_nothing(self) -> None:
+        from chain_server.src.conversation_products import (
+            _presented_attribute_facts,
+        )
+
+        assert _presented_attribute_facts(self._product({})) == {}

--- a/tests/unit/chain_server/test_catalog_scope.py
+++ b/tests/unit/chain_server/test_catalog_scope.py
@@ -149,3 +149,41 @@ class TestResolutionReturnsStoredAttributes:
         )
 
         assert _presented_attribute_facts(self._product({})) == {}
+
+    def test_the_renderer_actually_emits_them(self) -> None:
+        """The unit above can pass while the renderer drops the result.
+
+        Caught by mutation: replacing the renderer's lookup with an empty dict
+        left every other test green, so nothing asserted the attributes reach
+        what the model reads.
+        """
+
+        from chain_server.src.conversation_products import (
+            ConversationProductMatch,
+            ProductReferenceResolution,
+            ResolveConversationProductsResult,
+            format_product_resolution,
+        )
+
+        product = self._product({"bag_closure": "zip", "composition": "leather"})
+        result = ResolveConversationProductsResult(
+            results=[
+                ProductReferenceResolution(
+                    reference_id="bag1",
+                    status="resolved",
+                    match_count=1,
+                    matches=[
+                        ConversationProductMatch(
+                            product=product,
+                            turn_sequence=1,
+                            position=1,
+                            candidate_set_id="set-1",
+                        )
+                    ],
+                )
+            ]
+        )
+        rendered = format_product_resolution(result)
+        assert "CONFIRMED WHEN SHOWN:" in rendered
+        assert "bag_closure: zip" in rendered
+        assert "composition: leather" in rendered

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -3031,7 +3031,7 @@ class TestDeepAgentsRuntimeRefs:
         assert search_schema is not runtime_mod_support.SearchCatalogToolArguments
         # The model-facing schema is now a list of scopes; the per-scope fields
         # are unchanged and live on the scope object.
-        assert set(search_schema.model_fields) == {"scopes"}
+        assert set(search_schema.model_fields) == {"scopes", "not_covered"}
         scope_schema = search_schema.model_fields["scopes"].annotation.__args__[0]
         assert {
             "semantic_query",


### PR DESCRIPTION
Two changes, both about the same thing: the system knowing something and not
telling the model.

## The memory lane stored attributes and then hid them

The presented-product event stores the whole `ProductSummary` — confirmed in the
live database, attributes included. Resolution rendered only identity and then
told the model:

> *"Attributes such as material, care, and dimensions require
> `get_product_details_tool`."*

That was never true of this data. So a product recovered from an earlier turn
cost a round trip — ~8.7s — to fetch facts already in hand.

- Resolution now renders those attributes, and the instruction says to read
  details only for a fact **not** listed.
- Marketing copy (`catalog_text`) and retrieval scores (`similarity`) stay out,
  as they do everywhere else the model reads evidence.

Measured across all five advertised categories and 20 products: a detail read
returns **no field a search has not already supplied** — and a search is what
writes this event. That leaves the tool for the genuinely open case: a fresh
read when a fact may have changed, and sized availability.

## A request the catalog cannot serve left no trace

"A pan, a shoe and a bag" produced scopes for the shoe and the bag, and nothing
recorded that a pan was asked for. The tool saw two scopes and could not know a
third thing was requested, so an agent that quietly dropped it was invisible.

- A search call now carries `not_covered`: product types the shopper named that
  no advertised category covers, in their own words. No retrieval; naming them
  is what creates the obligation to answer them.
- The paired prompt rule — the advertised categories are the whole store — was
  written for an earlier branch and never merged, so it is here. Absence *within*
  a category stays different: unknown until searched, and guessing there is how
  false refusals happen.

## Testing

996 unit tests. Mutation-checked rather than assumed: blanking the renderer's
attribute lookup originally left every test green, so a test was added that
asserts the facts reach what the model reads. Both mutations now fail.

No change to the cart paths — zero lines in `commerce_tools.py` or
`control_signals.py`.
