### PR TITLE
Stop showing the model a ZIP it may not use

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -195,9 +195,8 @@ _SHOPPER_CONTEXT_SYSTEM_RULES = """Representative-shopper precedence and safety:
   grants a shopper skill or tool. Never expose the internal type label to the
   shopper.
 - Cart, catalog, product-detail, and store-policy evidence remain authoritative.
-- A saved ZIP code is background location data only. It is not proof of current
-  location, event location, weather, or a product requirement. Perform no
-  weather lookup or weather inference from it."""
+- Never infer a shopper's location, the weather, or a seasonal need. Nothing in
+  this context establishes any of them, and naming one is an invented fact."""
 _GROUNDING_EDITOR_SYSTEM_PROMPT = """You are a final response editor for a retail shopping assistant.
 
 Rewrite the draft response only as needed so every factual claim is supported

--- a/chain_server/src/response_format.py
+++ b/chain_server/src/response_format.py
@@ -383,11 +383,16 @@ def _format_cart_total(cart: Cart) -> str:
 def _format_shopper_context(context: ShopperContext | None) -> str:
     if context is None:
         return ""
+    # The saved ZIP is deliberately absent. Every use of it is forbidden --
+    # it is not proof of location, weather, or a product requirement, and the
+    # weather slice that would give it a use is dormant. Showing the model a
+    # fact and then forbidding every use of it is an invitation, not a
+    # safeguard. It stays on the profile record and the picker; it returns
+    # here when weather tooling defines what may be concluded from it.
     return (
         "SHOPPER CONTEXT (server-resolved; soft guidance only):\n"
         f"shopper_type: {context.shopper_type}\n"
         f"behavior: {context.behavior}\n"
-        f"saved_zipcode: {context.zipcode}\n"
         "END SHOPPER CONTEXT"
     )
 

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -850,8 +850,14 @@ class TestSystemPrompt:
             "Cart, catalog, product-detail, and store-policy evidence"
             in normalized
         )
-        assert "not proof of current location, event location, weather" in normalized
-        assert "Perform no weather lookup or weather inference" in normalized
+        # The saved ZIP is no longer in the block, so the rule no longer names
+        # it. What must survive is the ban on concluding a location, the
+        # weather, or a season from anything in this context.
+        assert "saved_zipcode" not in normalized
+        assert (
+            "Never infer a shopper's location, the weather, or a seasonal need"
+            in normalized
+        )
         assert "strict_budget_style_mixer" not in normalized
 
     def test_budget_oriented_profile_remains_non_authoritative(
@@ -1078,7 +1084,6 @@ class TestDeepAgentsRuntimeScopes:
             "shopper_type: skeptical_researcher\n"
             "behavior: Probes for material, care burden, and repeated-wear "
             "practicality before choosing.\n"
-            "saved_zipcode: 60601\n"
             "END SHOPPER CONTEXT"
         )
 
@@ -1092,6 +1097,10 @@ class TestDeepAgentsRuntimeScopes:
         assert f"\n\n{expected_block}\n\nUSER QUERY:" in user_message
         assert "shopper_morgan" not in user_message
         assert "Morgan" not in user_message
+        # Held deliberately: the ZIP is on the profile record and the picker,
+        # and must not reach the model until weather tooling defines what may
+        # be concluded from it.
+        assert "60601" not in user_message
         assert expected_block not in state.context
         assert shopper_context.behavior not in state.context
         assert memory.start_calls == [


### PR DESCRIPTION
The shopper-context block handed the model a saved ZIP code and then forbade every use of it — not proof of location, not the weather, not a product requirement, and no lookup or inference from it. Nothing in the serving path reads it except the weather client, which is dormant.

- **The ZIP no longer reaches the model.** Showing a fact and then banning every conclusion from it is an invitation rather than a safeguard, and it is the shortest route to the one claim the assistant must never make: naming a shopper's weather without having fetched it.
- **It stays everywhere it was useful** — the profile record, the API, and the shopper picker. Only the prompt is changed.
- **The rule it was attached to is stated positively**, with nothing to be tempted by: never infer a location, the weather, or a seasonal need, because nothing in this context establishes one.
- **It returns when weather tooling lands**, which has to define what may be concluded from a saved location anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)