### PR TITLE
Say who the catalog serves before dressing someone

### DIFF
--- a/chain_server/skills/shopper/outfit-styling/SKILL.md
+++ b/chain_server/skills/shopper/outfit-styling/SKILL.md
@@ -174,5 +174,11 @@ facts.
 - For search-only candidates, use grounded names, prices, categories, and one
   modest styling reason. Label unverified qualities as worth checking.
 - If only part of the requested look is covered, state what is missing plainly.
+- When you choose the product roles yourself, say in one clause who the catalog
+  serves, using the audience values in Catalog capabilities. Choosing a dress is
+  a styling call the shopper can take or leave; assuming they wear the range at
+  all decides whether any of it applies to them, and going unsaid is the worse
+  of the two. Say it once in a conversation, never as a question, and not for a
+  product the shopper named.
 - End with one useful next action, such as a focused swap, one missing role, or
   one concise clarification.

--- a/chain_server/skills/shopper/product-discovery/SKILL.md
+++ b/chain_server/skills/shopper/product-discovery/SKILL.md
@@ -64,6 +64,10 @@ Use for search, browse, and filter requests. Do not expose skill names or tool n
 
 ## Fact Boundary
 
+- When you choose the product roles yourself rather than searching a type the
+  shopper named, say in one clause who the catalog serves, using the audience
+  values in Catalog capabilities. Say it once in a conversation and never as a
+  question: what the shop stocks is a fact about the shop.
 - Product names are display names, not attribute evidence. Do not infer material, fit, length, or construction from a name such as "Canvas Tote", "Linen Dress", or "Sport Sneaker" unless product details confirm the attribute.
 - Search results support: name, price, category, and image availability. Nothing else.
 - Label unverified attributes as "worth checking" or "likely" — not as facts.

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3135,7 +3135,11 @@ def _composed_role_line(payload: dict[str, Any], *, has_products: bool) -> str:
         f"REQUESTED_SCOPE_RELATION: the shopper did not ask for {requested}; "
         "this role was proposed by the assistant. Offer it as a suggestion "
         "rather than as something they asked for, and keep every returned "
-        "product's actual catalog category."
+        "product's actual catalog category. Say once in this reply who the "
+        "catalog serves, using the audience values in Catalog capabilities: "
+        "choosing this role is a suggestion the shopper can decline, but "
+        "assuming the range suits them at all decides whether any of it "
+        "applies, and that one goes unsaid."
     )
 
 

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3136,10 +3136,12 @@ def _composed_role_line(payload: dict[str, Any], *, has_products: bool) -> str:
         "this role was proposed by the assistant. Offer it as a suggestion "
         "rather than as something they asked for, and keep every returned "
         "product's actual catalog category. Say once in this reply who the "
-        "catalog serves, using the audience values in Catalog capabilities: "
-        "choosing this role is a suggestion the shopper can decline, but "
-        "assuming the range suits them at all decides whether any of it "
-        "applies, and that one goes unsaid."
+        "catalog serves, using the audience values in Catalog capabilities, "
+        "and that you have assumed the pieces are for the shopper -- invite "
+        "them to say so if they are shopping for someone else. Naming the "
+        "range alone is an inventory note: it lists what is on the shelves "
+        "and still hands them an outfit built on an assumption nobody "
+        "stated. Never ask who they are."
     )
 
 

--- a/tests/unit/chain_server/test_composed_roles.py
+++ b/tests/unit/chain_server/test_composed_roles.py
@@ -246,6 +246,12 @@ def test_the_composer_is_told_the_role_was_proposed(
     assert relation["requested_product_type"] == "top"
     assert "did not ask for top" in line
     assert "proposed by the assistant" in line
+    # Naming the range alone is an inventory note. It lists what is on the
+    # shelves and still hands the shopper an outfit built on an assumption
+    # nobody stated, which is what a live guest turn actually did.
+    assert "who the catalog serves" in line
+    assert "assumed the pieces are for the shopper" in line
+    assert "Never ask who they are" in line
 
 
 def test_a_composed_role_with_no_matches_names_what_was_searched(

--- a/tests/unit/chain_server/test_shopper_skills.py
+++ b/tests/unit/chain_server/test_shopper_skills.py
@@ -234,3 +234,27 @@ def test_chain_server_docker_image_includes_skill_files() -> None:
     dockerfile = (REPO_ROOT / "chain_server" / "Dockerfile").read_text()
 
     assert "COPY ./skills ./skills" in dockerfile
+
+
+def test_role_proposing_skills_name_the_audience_without_asking() -> None:
+    """Choosing a dress is a styling call; assuming the range applies is not.
+
+    A live turn returned three dress-led outfits and disclosed only the role it
+    had picked -- "you didn't specifically ask for dresses" -- while saying
+    nothing about who the shop serves. The disclosure that went unsaid is the
+    one deciding whether any of it applies to the shopper.
+    """
+
+    root = Path(__file__).resolve().parents[3] / "chain_server/skills/shopper"
+
+    for skill in ("outfit-styling", "product-discovery"):
+        raw = (root / skill / "SKILL.md").read_text()
+        # Normalised: the guidance is wrapped, so a phrase can span a newline.
+        body = " ".join(raw.split())
+        assert "who the catalog serves" in body, skill
+        assert "audience values in Catalog capabilities" in body, skill
+        assert "never as a question" in body, skill
+        # The values live in the catalog. Naming one here would survive a
+        # catalog swap and keep being stated after it stopped being true.
+        for value in ("womens", "adult_all_genders", "womenswear", "menswear"):
+            assert value not in body, f"{skill} hardcodes {value}"


### PR DESCRIPTION
A guest asked for a work-conference outfit under $300 and was handed three dress-led looks. The reply disclosed the role it had chosen — *"you didn't specifically ask for dresses"* — and said nothing about who the shop is for.

That is the wrong half of the disclosure. Picking a dress is a styling call the shopper can decline; assuming they wear the range at all decides whether any of it applies.

- **The assistant states who the catalog serves, and that it has assumed the pieces are for the shopper** — inviting them to say otherwise. Once, in one clause, and never as a question about who they are.
- **Naming the range alone was not enough.** The first version produced an inventory note — "our catalog (women's apparel/footwear/jewelry; bags are adult all-genders)" — which lists what is on the shelves and still hands the shopper an outfit built on an unstated assumption. The leap from *what the shop stocks* to *so this is for you* is now spoken and reversible in a word.
- **The instruction rides the search evidence**, because that is the only channel here with a record of being acted on. The same rule as a system-prompt bullet, as a tool-schema field description, and in both skill bodies was ignored every time.
- **The values stay in the catalog.** The instruction names no audience and a test asserts no skill or prompt does either, so a catalog carrying menswear tomorrow changes the sentence with no edit here.

### Before and after, same prompt

```
before   "Here are a few conference outfit combinations under $300 total
          (dress + shoes + bag). You didn't specifically ask for dresses..."

after    "I'm building these assuming you're shopping for yourself; this
          catalog includes items for womens and adult_all_genders — tell me
          if you're shopping for someone else."
```

### Not addressed

The wearer does not survive the turn it was stated in. In a live run, turn 3 bought sunglasses for a husband and returned four `adult_all_genders` items; turn 4 asked for a suit and returned four `womens` items — same person, one turn later.

The dialogue is carried (8 turns, 16k characters, nothing truncated) but by the tenets it establishes intent rather than fact, so the wearer has no standing. That needs a hydrated slot rather than more context, and is written up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
