### PR TITLE
Name the session you are in

### DIFF
--- a/ui/src/chatbox.css
+++ b/ui/src/chatbox.css
@@ -1329,3 +1329,42 @@ below the composer.
     gap: 8px 18px;
   }
 }
+
+/* The conversation id is the trace session's name, so it sits in the bar and
+   copies on click. Reading it out of sessionStorage in devtools was the
+   alternative. */
+.model-strip__session {
+  align-items: baseline;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 0.76rem;
+  gap: 6px;
+  padding: 3px 10px;
+  white-space: nowrap;
+}
+
+.model-strip__session:hover:not(:disabled) {
+  border-color: var(--primary);
+  color: var(--ink);
+}
+
+.model-strip__session:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.model-strip__session-label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.model-strip__session-id {
+  color: var(--ink);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+}

--- a/ui/src/components/chatbox/ModelStrip.tsx
+++ b/ui/src/components/chatbox/ModelStrip.tsx
@@ -9,7 +9,7 @@
  * unrelated bits of chrome.
  */
 
-import React from "react";
+import React, { useState } from "react";
 
 import { ModelCapabilities, ModelUsage, SessionUsage } from "../../types";
 
@@ -17,6 +17,8 @@ interface ModelStripProps {
   models: ModelCapabilities;
   modelUsage: ModelUsage;
   sessionUsage: SessionUsage;
+  /** The conversation id sent to the server, and the trace session's name. */
+  conversationId: string;
 }
 
 /**
@@ -43,7 +45,27 @@ const ModelStrip: React.FC<ModelStripProps> = ({
   models,
   modelUsage,
   sessionUsage,
+  conversationId,
 }) => {
+  const [copied, setCopied] = useState(false);
+
+  /**
+   * The conversation id is the trace session's name, so copying it is how a
+   * conversation on screen is found in the trace viewer. Reading it out of
+   * sessionStorage in devtools was the alternative.
+   */
+  const copyConversationId = () => {
+    const done = () => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    };
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(conversationId).then(done).catch(() => done());
+      return;
+    }
+    done();
+  };
+
   const shown = SHOWN_MODELS.filter((entry) =>
     entry.roles.some((role) => isConfigured(models[role]))
   );
@@ -90,6 +112,22 @@ const ModelStrip: React.FC<ModelStripProps> = ({
         })}
       </div>
 
+      <button
+        type="button"
+        className="model-strip__session"
+        onClick={copyConversationId}
+        disabled={!conversationId}
+        title={`Trace session: ${conversationId}\nClick to copy`}
+        aria-label={`Copy conversation id ${conversationId}`}
+      >
+        <span className="model-strip__session-label">session</span>
+        <span className="model-strip__session-id">
+          {/* Empty until the first turn: a reset clears the identity and the
+              next one is minted when the shopper speaks. */}
+          {!conversationId ? "—" : copied ? "copied" : shortId(conversationId)}
+        </span>
+      </button>
+
       <div className="model-strip__total">
         <span className="model-strip__total-label">This session</span>
         <span className="model-strip__total-value">
@@ -105,6 +143,12 @@ const sum = (
   roles: string[],
   pick: (role: string) => number | undefined
 ): number => roles.reduce((total, role) => total + (pick(role) ?? 0), 0);
+
+/** `conversation-3b0285ce-…` -> `3b0285ce`. Enough to recognise, short enough to sit in a bar. */
+const shortId = (value: string): string => {
+  const bare = value.replace(/^conversation-/, "");
+  return bare.slice(0, 8) || value;
+};
 
 const isConfigured = (model: ModelCapabilities[string]): boolean =>
   Boolean(model?.enabled && model?.model);

--- a/ui/src/components/chatbox/chatbox.tsx
+++ b/ui/src/components/chatbox/chatbox.tsx
@@ -242,6 +242,7 @@ const Chatbox: React.FC<ChatboxProps> = ({
     totalTokens: 0,
   });
   const mediaInputRef = useRef<HTMLInputElement | null>(null);
+  const [conversationId, setConversationId] = useState<string>("");
   const [modelCapabilities, setModelCapabilities] = useState<ModelCapabilities>({});
   const [modelUsage, setModelUsage] = useState<ModelUsage>({});
   const [sessionUsage, setSessionUsage] = useState<SessionUsage>({
@@ -527,6 +528,7 @@ const Chatbox: React.FC<ChatboxProps> = ({
     if (!outgoing && !image && !video) return;
 
     const userSession = getOrCreateUserSession();
+    setConversationId(userSession.conversationId);
     setIsLoading(true);
     currentTurnHasMedia.current = Boolean(image || video);
     currentTurnGuardrails.current = isGuardrailsOn;
@@ -782,6 +784,10 @@ const Chatbox: React.FC<ChatboxProps> = ({
     if (clearIdentity) {
       clearUserSession();
     }
+    // Cleared, not reissued. Reading it back here would mint an identity just
+    // to display one, and reset is meant to leave storage empty until the
+    // shopper says something. It fills in on the first turn.
+    setConversationId("");
 
     // Add welcome messages
     addMessage(
@@ -972,6 +978,7 @@ const Chatbox: React.FC<ChatboxProps> = ({
           models={modelCapabilities}
           modelUsage={modelUsage}
           sessionUsage={sessionUsage}
+          conversationId={conversationId}
         />
       </div>
 


### PR DESCRIPTION
The conversation id is the trace session's name, but the only way to read it
was `sessionStorage` in devtools — so a conversation on screen and its trace
could not be matched without opening the console.

- It now sits in the bottom bar and copies on click. Copy, paste into the trace
  viewer's session search, done.
- Shows a dash until the first turn rather than minting an identity just to
  display one. A reset is meant to leave storage empty until the shopper says
  something, and the existing App test asserts exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
