### PR TITLE
A product named but never shown is a search, not a dead end

### DIFF
--- a/chain_server/skills/shopper/cart-management/SKILL.md
+++ b/chain_server/skills/shopper/cart-management/SKILL.md
@@ -19,8 +19,13 @@ Handle explicit cart operations. Do not expose tool names or internal identifier
 ## Add Intent Rules
 
 - Use `resolve_conversation_products_tool` only for an earlier product not
-  established this turn. Zero or multiple matches require one concise
-  clarification; never guess, search for a substitute, or mutate the cart.
+  established this turn. Multiple matches require one concise clarification;
+  never guess or mutate the cart.
+- Zero matches means the shopper referred to something never shown. If they
+  named a product, search the catalog and show the closest matches, then ask
+  which to add. If they pointed at an earlier item, ask which one. Never add a
+  product the shopper has not been shown, and never offer to accept a product
+  link or a price as identification.
 - Call `add_cart_items_tool` only when the shopper explicitly says to add, buy, or put an item in the cart.
 - Styling approval, product discussion, or "I like it" is NOT add intent.
 - If the add scope is ambiguous ("add those", "add them all"), ask one concise clarification naming the candidates before calling the tool.

--- a/chain_server/skills/shopper/outfit-styling/SKILL.md
+++ b/chain_server/skills/shopper/outfit-styling/SKILL.md
@@ -58,8 +58,11 @@ internal reasoning to the shopper.
 ## Anchors And Conversation Continuity
 
 - Use `resolve_conversation_products_tool` only for an earlier product not
-  established this turn. Zero or multiple matches require one concise
-  clarification; never guess, search for a substitute, or mutate the cart.
+  established this turn. Multiple matches require one concise
+  clarification; never guess or mutate the cart. Zero matches means the
+  shopper referred to something never shown: if they named a product, search
+  the catalog and show the closest matches, then ask which to add. Never add a
+  product the shopper has not been shown.
 - Use the direct antecedent unless the shopper clearly reaches further back.
   Keep the accepted dress in "I like that dress; find different shoes" and
   search only for replacement shoes.

--- a/chain_server/skills/shopper/product-discovery/SKILL.md
+++ b/chain_server/skills/shopper/product-discovery/SKILL.md
@@ -51,8 +51,11 @@ Use for search, browse, and filter requests. Do not expose skill names or tool n
 
 - Use this as the single primary procedure for non-styling discovery; do not combine it with outfit-styling. Budget-shopping may accompany it only as a modifier.
 - Use `resolve_conversation_products_tool` only for an earlier product not
-  established this turn. Zero or multiple matches require one concise
-  clarification; never guess, search for a substitute, or mutate the cart.
+  established this turn. Multiple matches require one concise
+  clarification; never guess or mutate the cart. Zero matches means the
+  shopper referred to something never shown: if they named a product, search
+  the catalog and show the closest matches, then ask which to add. Never add a
+  product the shopper has not been shown.
 - When one selected taxonomy value directly represents the requested role, `requested_product_type` must name that value. When a true shopper-named umbrella spans multiple advertised children, include every selected value that is genuinely a kind of that umbrella. The semantic query may focus on soft ranking direction.
 - An objective attribute that defines the requested products is a must-have even when the shopper does not say the words "must have." For example, "Do you have water-resistant bags?" makes water resistance required. Subjective recommendation adjectives always remain semantic ranking direction.
 - Start with one focused catalog search using exact advertised values that faithfully represent the shopper's product type. If the type is not separately advertised and one advertised category is its faithful broader parent, select only that category and keep the type as semantic ranking direction. If either choice would require guessing, ask one concise clarification directly without calling the tool. For a true umbrella or explicit alternatives, include every faithful advertised child in the same search. Never substitute a sibling or arbitrary adjacent type. Do not fan out with synonym queries for the same scope.

--- a/chain_server/src/conversation_products.py
+++ b/chain_server/src/conversation_products.py
@@ -330,9 +330,22 @@ def format_product_resolution(result: ResolveConversationProductsResult) -> str:
                 "guess."
             )
             continue
+        # Nothing shown in this conversation matches -- which is a different
+        # situation from an ambiguous or near-miss reference above, and used to
+        # get the same answer: stop and ask. A shopper who names a product that
+        # was never shown was making a search request, and the turn ended with a
+        # full search budget unspent, offering to accept a product link the
+        # assistant cannot read.
+        #
+        # Which recovery fits depends on whether the shopper named a product or
+        # pointed at one, and the model is the only reader that can tell.
         lines.append(
-            f"REFERENCE {resolution.reference_id}: NOT FOUND. "
-            "Ask which earlier product the shopper means; do not guess."
+            f"REFERENCE {resolution.reference_id}: NOT FOUND. Nothing shown in "
+            "this conversation matches it. If the shopper named a product, "
+            "search the catalog and show the closest matches, then ask which to "
+            "add. If they pointed at an earlier item, ask which one. Never add "
+            "a product the shopper has not been shown, and do not ask for a "
+            "product link or a price -- neither identifies a catalog product."
         )
     return "\n".join(lines)
 

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -57,6 +57,7 @@ from .turn_support import (
     AddCartItemsToolItemInput,
     RequestIdentity,
     _add_model_usage,
+    _cart_size_issue,
     _build_checkpointer,
     _cart_add_scope_failures,
     _cart_line_by_id,
@@ -1223,8 +1224,9 @@ class DeepAgentsRuntime:
             """Resolve products the shopper refers to from earlier in this
             conversation. Use only when a needed product was not established
             in the current turn. Submit exact descriptors from the historical
-            product index. If a reference is missing or ambiguous, ask one
-            concise clarification; do not guess or search for a substitute.
+            product index. If a reference is ambiguous, ask one concise
+            clarification and do not guess. If nothing matches at all, the
+            result says what to do next.
             """
 
             with scope.resolution_lock:
@@ -1267,8 +1269,9 @@ class DeepAgentsRuntime:
             """Resolve products the shopper refers to from earlier in this
             conversation. Use only when a needed product was not established
             in the current turn. Submit exact descriptors from the historical
-            product index. If a reference is missing or ambiguous, ask one
-            concise clarification; do not guess or search for a substitute.
+            product index. If a reference is ambiguous, ask one concise
+            clarification and do not guess. If nothing matches at all, the
+            result says what to do next.
             """
 
             return normalize_tool_result(
@@ -1295,9 +1298,18 @@ class DeepAgentsRuntime:
             for (product_ref, size), request in requested_items.items():
                 product = scope.product_evidence.get(product_ref)
                 if product is None:
+                    # Read as a hint rather than an instruction, this ended the
+                    # turn: asked to add a product that was never shown, the
+                    # model passed the name here as a ref, saw the refusal, and
+                    # asked the shopper to supply the exact catalogue name --
+                    # which is the assistant's job, with a search budget unspent.
                     failed.append(
-                        f"- PRODUCT_REF '{product_ref}': Search this turn or "
-                        "resolve the earlier product first."
+                        f"- PRODUCT_REF '{product_ref}': not a product shown to "
+                        "this shopper, and a name is never a PRODUCT_REF. If it "
+                        "names a product, search the catalog now and show the "
+                        "closest matches, then ask which to add. Never add a "
+                        "product the shopper has not been shown, and do not ask "
+                        "them for a catalogue name, a link, or a price."
                     )
                     continue
                 expected_name = request.get("expected_display_name") or ""
@@ -1335,6 +1347,10 @@ class DeepAgentsRuntime:
                         "resolves to a different product. Search again and use "
                         "the new PRODUCT_REF before adding it."
                     )
+                    continue
+                size_issue = _cart_size_issue(active_detail.product, size)
+                if size_issue:
+                    blocked.append(f"- PRODUCT_REF '{product_ref}': {size_issue}")
                     continue
                 resolved.append(
                     (
@@ -1757,8 +1773,12 @@ class DeepAgentsRuntime:
             single-piece selection, including a statement or balancing piece,
             also uses outfit-styling. Use product-discovery for search and browse
             without styling intent. These are alternative primary procedures,
-            never a pair. Add budget-shopping only as a modifier when the shopper
-            states a budget. Keep outfit-styling as the primary skill throughout
+            never a pair. Adding a product the shopper names that no search in
+            this conversation has shown is a discovery request as well as a cart
+            one: select product-discovery with cart-management, because the cart
+            skill cannot search and the product must be found and shown before
+            it can be added. Add budget-shopping only as a modifier when the
+            shopper states a budget. Keep outfit-styling as the primary skill throughout
             an active outfit-building thread, including its single-piece follow-up
             searches.
 

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3800,6 +3800,54 @@ def _same_product_display_name(expected: str, actual: str) -> bool:
     return _normalize_product_name(expected) == _normalize_product_name(actual)
 
 
+#: What the catalog carries for a product sold in exactly one size.
+_ONE_SIZE = "onesize"
+
+
+def _cart_size_issue(product: Any, size: str | None) -> str:
+    """Say why this size cannot be added, or "" if it can.
+
+    Every product in the catalog states its sizes -- 136 carry a real range and
+    79 carry `onesize`, with no gaps -- so the tool has what it needs to decide
+    rather than trusting the caller to have asked. Left to prose alone, "always
+    confirm the size" held three times in four: a dress with six sizes reached
+    the cart with no size at all.
+    """
+
+    sizes = _advertised_sizes(product)
+    chosen = (size or "").strip()
+    if not sizes:
+        # The catalog said nothing. Refusing here would block a cart on missing
+        # data rather than on a real disagreement.
+        return ""
+    if sizes == [_ONE_SIZE]:
+        return ""
+    if not chosen:
+        return (
+            f"SIZE REQUIRED. '{product.display_name}' is sold in "
+            f"{', '.join(sizes)}. Ask the shopper which size and add it then. "
+            "Nothing was added."
+        )
+    if not any(chosen.casefold() == value.casefold() for value in sizes):
+        return (
+            f"SIZE '{chosen}' is not sold for '{product.display_name}'. "
+            f"Available: {', '.join(sizes)}. Ask the shopper which of those "
+            "they want. Nothing was added."
+        )
+    return ""
+
+
+def _advertised_sizes(product: Any) -> list[str]:
+    """Read the sizes the catalog states for a product."""
+
+    raw = (getattr(product, "attributes", None) or {}).get("sizes")
+    if isinstance(raw, str):
+        raw = [part.strip() for part in raw.split(",")]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(value).strip() for value in raw if str(value).strip()]
+
+
 def _product_detail_failure_message(
     error: CommerceError | None,
     *,

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import pathlib
 
 from chain_server.src.turn_support import _normalize_cart_add_tool_items
+from types import SimpleNamespace
+from chain_server.src.turn_support import _cart_size_issue
 
 
 def test_two_sizes_of_one_product_are_two_lines() -> None:
@@ -165,3 +167,55 @@ def test_a_relaxable_zero_result_is_not_told_to_stop_looking() -> None:
 
     assert "relaxable = bool(evidence.confirmed_filters)" in source
     assert "if evidence.scope_complete and not relaxable:" in source
+
+
+class TestCartSizeGate:
+    """The cart tool decides on the size, rather than trusting the caller.
+
+    Every catalog product states its sizes -- 136 a real range, 79 `onesize`,
+    no gaps -- so this is a question the tool can answer from data. Left to
+    prose, it held three times in four: asked to add a dress with six sizes,
+    one run in four put it in the cart with no size at all.
+    """
+
+    def _product(self, sizes):
+        return SimpleNamespace(
+            display_name="The Office A-line Dress",
+            attributes={"sizes": sizes} if sizes is not None else {},
+        )
+
+    def test_a_sized_product_cannot_enter_the_cart_without_one(self) -> None:
+        issue = _cart_size_issue(self._product(["2", "4", "6"]), None)
+
+        assert "SIZE REQUIRED" in issue
+        assert "2, 4, 6" in issue
+        assert "Nothing was added" in issue
+
+    def test_a_size_the_product_is_not_sold_in_is_refused(self) -> None:
+        issue = _cart_size_issue(self._product(["2", "4", "6"]), "14")
+
+        assert "not sold" in issue
+        assert "2, 4, 6" in issue
+
+    def test_a_size_the_product_is_sold_in_passes(self) -> None:
+        assert _cart_size_issue(self._product(["2", "4", "6"]), "4") == ""
+
+    def test_size_matching_ignores_case(self) -> None:
+        assert _cart_size_issue(self._product(["S", "M", "L"]), "m") == ""
+
+    def test_a_onesize_product_needs_no_size(self) -> None:
+        """79 accessories are `onesize`; asking which size would be nonsense."""
+
+        assert _cart_size_issue(self._product(["onesize"]), None) == ""
+
+    def test_a_catalog_that_states_no_sizes_does_not_block_the_cart(self) -> None:
+        """Refusing here would block on missing data, not on a disagreement."""
+
+        assert _cart_size_issue(self._product(None), None) == ""
+        assert _cart_size_issue(self._product([]), None) == ""
+
+    def test_sizes_arriving_as_a_string_are_still_read(self) -> None:
+        """Search evidence renders them as "sizes: 2, 4, 6"."""
+
+        assert _cart_size_issue(self._product("2, 4, 6"), "4") == ""
+        assert "SIZE REQUIRED" in _cart_size_issue(self._product("2, 4, 6"), None)

--- a/tests/unit/chain_server/test_conversation_products.py
+++ b/tests/unit/chain_server/test_conversation_products.py
@@ -324,4 +324,10 @@ def test_result_formatter_resolves_one_and_requires_clarification_otherwise() ->
     assert "REFERENCE ambiguous: CLARIFICATION REQUIRED" in rendered
     assert "Cobalt Crossbody, Tan Shoulder Bag" in rendered
     assert "REFERENCE missing: NOT FOUND" in rendered
-    assert rendered.casefold().count("do not guess") == 2
+    # An ambiguous reference is a question; nothing found is a search. Both
+    # used to say "do not guess" and stop, which left a shopper who named a
+    # product that was never shown with no path forward at all.
+    assert "Do not guess" in rendered.split("REFERENCE missing")[0]
+    assert "search the catalog" in rendered.split("REFERENCE missing")[1]
+    # Neither may authorise adding something the shopper has not seen.
+    assert "Never add a product the shopper has not been shown" in rendered

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -3379,7 +3379,10 @@ class TestDeepAgentsRuntimeRefs:
                 items=[{"product_ref": "bag-a", "quantity": 1}]
             )
         )
-        assert "resolve the earlier product first" in blocked_add
+        # A ref that was never shown is refused, and the refusal sends the
+        # model to the catalog rather than back to the shopper for a name.
+        assert "not a product shown to this shopper" in blocked_add
+        assert "search the catalog now" in blocked_add
 
         update_requests = []
 
@@ -7468,9 +7471,17 @@ class TestDeepAgentsRuntimeRefs:
             display_name="Green Meadow Sweater Top",
             price=Money(amount=49.99),
         )
+        # Every catalog product states its sizes. The others here state none,
+        # so they exercise the unstated-size path; this one exercises the gate.
+        dress = ProductSummary(
+            product_id="prod_dress",
+            display_name="The Office A-line Dress",
+            price=Money(amount=179.99),
+            attributes={"sizes": ["2", "4", "6"]},
+        )
         active_products = {
             item.product_id: ProductDetail.model_validate(item.model_dump())
-            for item in (product, bag, luminous, green)
+            for item in (product, bag, luminous, green, dress)
         }
         def fake_product_details(request, *args, **kwargs):
             product_detail = active_products.get(request.product_id)
@@ -7513,7 +7524,7 @@ class TestDeepAgentsRuntimeRefs:
         )
 
         runtime._conversation_products = SimpleNamespace(
-            resolve=lambda *_: _resolved_conversation_products(product, bag)
+            resolve=lambda *_: _resolved_conversation_products(product, bag, dress)
         )
         runtime._create_agent(State(user_id=111, query="hello"), identity)
         tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
@@ -7522,15 +7533,44 @@ class TestDeepAgentsRuntimeRefs:
         missing = tool_text(
             add_tool(items=[{"product_ref": "missing", "quantity": 1}])
         )
-        assert "resolve the earlier product first" in missing
+        assert "not a product shown to this shopper" in missing
+        assert "search the catalog now" in missing
         assert added == []
 
         tools_by_name["resolve_conversation_products_tool"](
             references=[
                 {"reference_id": "prod_flats", "product_ref": "prod_flats"},
                 {"reference_id": "prod_bag", "product_ref": "prod_bag"},
+                {"reference_id": "prod_dress", "product_ref": "prod_dress"},
             ]
         )
+        # A product sold in sizes may not reach the cart without one. Prose
+        # alone held this three times in four; the tool decides it from data.
+        sizeless = tool_text(
+            add_tool(items=[{"product_ref": "prod_dress", "quantity": 1}])
+        )
+        assert "SIZE REQUIRED" in sizeless
+        assert "2, 4, 6" in sizeless
+        assert added == []
+        wrong_size = tool_text(
+            add_tool(
+                items=[
+                    {"product_ref": "prod_dress", "quantity": 1, "size": "14"}
+                ]
+            )
+        )
+        assert "not sold" in wrong_size
+        assert added == []
+        sized = tool_text(
+            add_tool(
+                items=[
+                    {"product_ref": "prod_dress", "quantity": 1, "size": "4"}
+                ]
+            )
+        )
+        assert "SIZE REQUIRED" not in sized
+        assert len(added) == 1
+        added.clear()
         added_response = tool_text(
             add_tool(
                 items=[


### PR DESCRIPTION
Asked to add a product it had never shown, the assistant ended the turn offering to accept a product link it cannot read — with the search budget unspent. The product existed.

- Splits two cases that shared one answer: an **ambiguous** reference is a question, one that **never existed** is a search request.
- `cart-management` activated alone for "add X to my cart", and it cannot search — so the instruction to search was unreachable. It now co-activates `product-discovery`. **Tool grants are unchanged**; the cart skill still cannot search.
- Adds a deterministic size gate. Nothing required a size, so a dress sold in six sizes reached the cart with none. Every catalog product states its sizes (136 a range, 79 `onesize`, no gaps), so the tool decides from data rather than trusting the caller to have asked.
- Never adds a product the shopper has not been shown — unchanged, and now the refusal names the next action instead of asking for a link or a price.

Four live runs of the same request:

| | before | after |
|---|---|---|
| finds and shows the product | 0/4 | 4/4 |
| asks the size before adding | — | 4/4 |
| sizeless cart line | 1/4 | 0/4 |
