### PR TITLE
An ambiguous reference lists the sizes it is ambiguous between

### DIFF
--- a/chain_server/src/conversation_products.py
+++ b/chain_server/src/conversation_products.py
@@ -240,6 +240,30 @@ class ProductEvidence:
 _NON_ATTRIBUTE_KEYS = frozenset({"catalog_text", "similarity", "taxonomy"})
 
 
+def _candidate_label(product: Any) -> str:
+    """Name a candidate with the sizes it is sold in, when the index has them.
+
+    The sizes are what let a stated size do the disambiguating, so they travel
+    with the name rather than waiting for a second tool call.
+    """
+
+    name = str(getattr(product, "display_name", "") or "")
+    sizes = _indexed_sizes(product)
+    return f"{name} (sizes {', '.join(sizes)})" if sizes else name
+
+
+def _indexed_sizes(product: Any) -> list[str]:
+    """Sizes recorded when this product was shown, in whatever shape."""
+
+    attributes = getattr(product, "attributes", None)
+    raw = attributes.get("sizes") if isinstance(attributes, dict) else None
+    if isinstance(raw, str):
+        raw = raw.split(",")
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(value).strip() for value in raw if str(value).strip()]
+
+
 def _presented_attribute_facts(product: Any) -> dict[str, str]:
     """Attributes the catalog confirmed when this product was shown."""
 
@@ -309,12 +333,24 @@ def format_product_resolution(result: ResolveConversationProductsResult) -> str:
             )
             continue
         if resolution.status == "ambiguous":
+            # Sizes are listed because the shopper has often already answered
+            # this. "Add the black one in a 2" after a turn showing black ankle
+            # boots in 5-9 and black dresses in 2-12 is not ambiguous about the
+            # category -- a 2 rules the boots out. Given only the names, the
+            # model had nothing to rule out with, so it named one candidate and
+            # asked which one was meant in the same sentence, and added nothing.
             names = ", ".join(
-                match.product.display_name for match in resolution.matches
+                _candidate_label(match.product) for match in resolution.matches
             )
             lines.append(
                 f"REFERENCE {resolution.reference_id}: CLARIFICATION REQUIRED "
-                f"({names}). Do not guess."
+                f"({names}). Do not guess. A size or other attribute the "
+                "shopper already stated rules out the candidates the catalog "
+                "cannot sell that way: say which you ruled out and why. If one "
+                "survives, name it as an assumption and invite correction -- "
+                "\"since you said a 2, I take it you mean X; tell me if not\" "
+                "-- rather than asking what they have answered. If several "
+                "survive, ask once, naming them."
             )
             continue
         if resolution.blocking_field:

--- a/tests/unit/chain_server/test_conversation_products.py
+++ b/tests/unit/chain_server/test_conversation_products.py
@@ -51,19 +51,29 @@ class _Session:
         return self.response
 
 
-def _product(product_id: str, display_name: str) -> ProductSummary:
+def _product(
+    product_id: str,
+    display_name: str,
+    sizes: list[str] | None = None,
+) -> ProductSummary:
     return ProductSummary(
         product_id=product_id,
         display_name=display_name,
         category="crossbody_bags",
         price=Money(amount=79),
         image_url=f"/images/{product_id}.png",
+        attributes={"sizes": sizes} if sizes else {},
     )
 
 
-def _match(product_id: str, display_name: str, position: int) -> dict[str, Any]:
+def _match(
+    product_id: str,
+    display_name: str,
+    position: int,
+    sizes: list[str] | None = None,
+) -> dict[str, Any]:
     return {
-        "product": _product(product_id, display_name).model_dump(mode="json"),
+        "product": _product(product_id, display_name, sizes).model_dump(mode="json"),
         "candidate_set_id": "set-2",
         "turn_sequence": 2,
         "position": position,
@@ -301,10 +311,10 @@ def test_result_formatter_resolves_one_and_requires_clarification_otherwise() ->
                 status="ambiguous",
                 matches=[
                     ConversationProductMatch.model_validate(
-                        _match("bag-2", "Cobalt Crossbody", 1)
+                        _match("bag-2", "Cobalt Crossbody", 1, ["2", "4"])
                     ),
                     ConversationProductMatch.model_validate(
-                        _match("bag-3", "Tan Shoulder Bag", 2)
+                        _match("bag-3", "Tan Shoulder Bag", 2, ["8", "10"])
                     ),
                 ],
                 match_count=2,
@@ -322,7 +332,11 @@ def test_result_formatter_resolves_one_and_requires_clarification_otherwise() ->
 
     assert "REFERENCE unique: RESOLVED\nPRODUCT_REF: bag-1" in rendered
     assert "REFERENCE ambiguous: CLARIFICATION REQUIRED" in rendered
-    assert "Cobalt Crossbody, Tan Shoulder Bag" in rendered
+    # Sizes travel with the names so a size the shopper already stated can do
+    # the disambiguating. Given names alone, the model named one candidate and
+    # asked which was meant in the same sentence, and added nothing.
+    assert "rules out the candidates the catalog cannot sell that way" in rendered
+    assert "Cobalt Crossbody (sizes 2, 4), Tan Shoulder Bag (sizes 8, 10)" in rendered
     assert "REFERENCE missing: NOT FOUND" in rendered
     # An ambiguous reference is a question; nothing found is a search. Both
     # used to say "do not guess" and stop, which left a shopper who named a


### PR DESCRIPTION
Asked which of several products the shopper meant, the model got their names and nothing else — so it had nothing to rule out with, and answered by naming one candidate and asking which was meant in the same sentence.

- Candidate names now carry the sizes the catalog sells them in, so a size the shopper already stated can do the disambiguating.
- The evidence asks for what was ruled out and why, and for a surviving single candidate to be stated as an assumption open to correction rather than posed as a question already answered.
- Adds information to an existing message. It gates nothing and cannot refuse an add.

Before, given names alone:

> I can add **Black Satin Lace-Up Dress** in **size 2** — which one did you mean by "the black one"?

**Scope:** this fires when the resolver reports `ambiguous`. It does **not** fix demo turn 19, where the model resolves a descriptive reference privately against the historical index and submits exact product names, so nothing is ever reported ambiguous.