### PR TITLE
A forecast names the place it chose, not just the place it found

### DIFF
--- a/chain_server/src/response_format.py
+++ b/chain_server/src/response_format.py
@@ -511,12 +511,17 @@ def _format_weather_result(result: Any) -> str:
             parts.append("as " + ", ".join(day.precipitation_types))
         lines.append("  " + "; ".join(parts))
     lines.append(
-        "SAY_WHICH_PLACE: name the place the provider resolved, so a shopper "
-        "who meant a different one can correct you. If what came back is "
-        "broader than a town -- a country or a region, like Italia or "
-        "Toscana -- then these numbers describe that whole area and nowhere "
-        "in particular: say so plainly, and ask which city they will be in "
-        "before dressing them for the weather."
+        "SAY_WHICH_PLACE: open by naming the place these numbers are for, as "
+        "the place you chose to look up rather than as settled fact, and "
+        "invite the correction in the same breath -- \"using Rome for the "
+        "forecast; say if you meant somewhere else\". Naming it is not enough "
+        "on its own: a shopper who said only \"Italy\" never chose the city "
+        "you picked, and live, one who meant Florence was given Rome's "
+        "forecast at 73-101F as though it were where they would be. If what "
+        "came back is broader than a town -- a country or a region, like "
+        "Italia or Toscana -- then these numbers describe that whole area and "
+        "nowhere in particular: say so plainly, and ask which city they will "
+        "be in before dressing them for the weather."
     )
     # The provider's own label and link travel with the data, so the terms are
     # met by whatever provider answered rather than by a constant here.

--- a/tests/unit/chain_server/test_weather_evidence.py
+++ b/tests/unit/chain_server/test_weather_evidence.py
@@ -95,7 +95,12 @@ def test_the_resolved_place_is_named_so_it_can_be_corrected() -> None:
     evidence = _format_weather_result(_result())
 
     assert "Cancun, Quintana Roo, Mexico" in evidence
-    assert "correct you" in evidence
+    assert "invite the correction" in evidence
+    # Naming the place was not enough on its own. Told to name it, the model
+    # named it -- "For Roma, Lazio, Italia ... 73-101F" -- and presented it as
+    # established fact, to a shopper who had said only "Italy" and meant
+    # Florence. The place has to arrive as the assistant's own choice.
+    assert "rather than as settled fact" in evidence
     # A country resolves as readily as a city and there is no signal to tell
     # them apart: the provider returns "Italia" for Italy and plain "Cancun"
     # for Cancun, while the region Tuscany comes back better qualified than


### PR DESCRIPTION
Asked what to wear for a weekend in **Italy**, the assistant fetched the forecast for `"Rome, Italy"` and opened with *"For Roma, Lazio, Italia … 73–101°F"*. The shopper meant Florence.

- The disclosure already existed and the model was obeying it — told to name the place, it named it. **Naming is not enough**: the place has to arrive as the assistant's own choice, or a city nobody asked for reads as established fact.
- One clause in the evidence `SAY_WHICH_PLACE` already carries. No new rule, no gate, no new state.
- The broad-area half is untouched — it came from `1c4aad4`, scored 6/6, and still holds.

Four live runs of *"we're going to Italy next weekend, what do I wear"*:

| | before | after |
|---|---|---|
| named the place as its own choice | 0/4 | 4/4 |
| invented a city | 1/1 | 0/4 |

> "Using **Italy ("Italia")** for the forecast (if you tell me your city — Rome vs Milan vs the coast can feel really different — I'll tailor this)"

This mitigates rather than prevents. Nothing stops the model choosing a city; the choice is now visible and correctable in one turn.