### PR TITLE
The opening states an assumption, it does not ask who you are

### DIFF
--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3369,12 +3369,16 @@ def _assumed_audience_line(payload: dict[str, Any]) -> str:
         "that came back is for " + ", ".join(sorted(audience)) + ". Open by "
         "naming that as what you have assumed the shopper is looking for -- "
         "\"assuming you're looking for ... clothes\" -- and invite them to "
-        "correct it. It is an assumption about what they want, not a note "
-        "about the shop's style or about what this reply happened to return, "
-        "and not a question about who they are. Say which of these suit a "
-        "wider audience if any do. Put it in a shopper's words, never a "
-        "catalog label: a value such as adult_all_genders is said as pieces "
-        "anyone can wear."
+        "correct it. One clause, then get on with the answer. It is an "
+        "assumption about what they want, not a note about the shop's style "
+        "or about what this reply happened to return. Never turn it into a "
+        "question, or a guess, about who the shopper is or who they are "
+        "buying for: a shopper who says \"I need something to wear\" has "
+        "already said it is for them, and being asked whether they are "
+        "shopping for someone else reads as not listening. Say nothing about "
+        "which pieces suit a wider audience -- that is how the catalog tags "
+        "its bags, not something anyone asked. Put it in a shopper's words, "
+        "never a catalog label."
     )
 
 

--- a/tests/unit/chain_server/test_assumed_audience.py
+++ b/tests/unit/chain_server/test_assumed_audience.py
@@ -282,12 +282,21 @@ def test_the_disclosure_is_an_assumption_about_the_shopper() -> None:
     assert "assuming you're looking for" in line
     assert "invite them to correct it" in line
     assert "not a note about the shop's style" in line
-    assert "not a question about who they are" in line
+    assert "about who the shopper is" in line
+    # Live, one clause after the shopper said "I need something to wear", the
+    # reply asked "(I can adjust if you're shopping for someone else)".
+    assert "already said it is for them" in line
     # The shopper stands in a shop, not in front of a query planner. A live
     # reply read "I tried the closest available search in apparel with the
     # filter adult all-genders, and that search returned zero results".
     assert "never a catalog label" in line
-    assert "pieces anyone can wear" in line
+    # And says nothing about which pieces suit a wider audience. That clause
+    # produced "I also have a few bags that anyone can wear (the crossbody
+    # styles)" as the second sentence of a wedding-outfit reply -- all 38
+    # adult_all_genders products are bags and sunglasses, and sunglasses are
+    # tagged both ways, so it can only ever report the catalog's own tagging.
+    assert "Say nothing about which pieces suit a wider audience" in line
+    assert "pieces anyone can wear" not in line
 
 
 def test_a_conversation_already_told_is_not_told_again(


### PR DESCRIPTION
*"I have a wedding to go to and **I** need something to wear"* opened with:

> "Assuming you're looking for **women's wedding-guest outfit pieces** (I can adjust if you're shopping for someone else). I also have a few **bags that anyone can wear** (the crossbody styles)."

- The parenthetical asks who the shopper is buying for, one clause after they said "I". The instruction **already forbade this** — drift from an existing rule, not a missing one. It now names the failure.
- The second sentence came from *"say which of these suit a wider audience if any do"*. On this catalog that can only report tagging: all 38 `adult_all_genders` products are bags and sunglasses, and sunglasses are tagged both ways. **Removed.**
- **Unchanged:** the disclosure itself, and the refusal to read the shopper's prose to work out who an item is for. It still fires once per conversation.

Four live runs of the same opener, all four now one clause:

> "Assuming you're looking for women's wedding-guest clothing, a dress is an easy one-and-done starting point—then you can keep shoes and accessories simple."