### PR TITLE
A cart ref from an earlier turn is resolved, not searched for

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1298,18 +1298,32 @@ class DeepAgentsRuntime:
             for (product_ref, size), request in requested_items.items():
                 product = scope.product_evidence.get(product_ref)
                 if product is None:
-                    # Read as a hint rather than an instruction, this ended the
-                    # turn: asked to add a product that was never shown, the
-                    # model passed the name here as a ref, saw the refusal, and
-                    # asked the shopper to supply the exact catalogue name --
-                    # which is the assistant's job, with a search budget unspent.
+                    # Two different situations reach here, and naming only one
+                    # of them stranded the other.
+                    #
+                    # A ref the shopper was never shown: the model passes the
+                    # product's name, and told only that a name is not a ref it
+                    # asked the shopper for the exact catalogue name -- the
+                    # assistant's own job, with a search budget unspent.
+                    #
+                    # A ref shown in an *earlier* turn: evidence is rebuilt per
+                    # turn, so a real ref from last turn is absent from this
+                    # one. "Add it in a 10 as well" carried the correct ref for
+                    # a dress added moments earlier, was told to go searching,
+                    # and gave up -- so a shopper asking for a second size got
+                    # "the add didn't go through".
                     failed.append(
-                        f"- PRODUCT_REF '{product_ref}': not a product shown to "
-                        "this shopper, and a name is never a PRODUCT_REF. If it "
-                        "names a product, search the catalog now and show the "
-                        "closest matches, then ask which to add. Never add a "
-                        "product the shopper has not been shown, and do not ask "
-                        "them for a catalogue name, a link, or a price."
+                        f"- PRODUCT_REF '{product_ref}': not established in "
+                        "this turn. If this product was shown earlier in the "
+                        "conversation, resolve it first and add the PRODUCT_REF "
+                        "that comes back -- evidence is per turn, so a "
+                        "reference from an earlier turn has to be resolved "
+                        "again. If it is a product name rather than a "
+                        "reference, or was never shown at all, search the "
+                        "catalog now and show the closest matches, then ask "
+                        "which to add. Never add a product the shopper has not "
+                        "been shown, and do not ask them for a catalogue name, "
+                        "a link, or a price."
                     )
                     continue
                 expected_name = request.get("expected_display_name") or ""

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -3381,7 +3381,11 @@ class TestDeepAgentsRuntimeRefs:
         )
         # A ref that was never shown is refused, and the refusal sends the
         # model to the catalog rather than back to the shopper for a name.
-        assert "not a product shown to this shopper" in blocked_add
+        assert "not established in this turn" in blocked_add
+        # Both recoveries are named. Naming only the search one stranded a
+        # correct ref from an earlier turn: "add it in a 10 as well" was
+        # told to go searching, and gave up.
+        assert "resolve it first" in blocked_add
         assert "search the catalog now" in blocked_add
 
         update_requests = []
@@ -7533,7 +7537,8 @@ class TestDeepAgentsRuntimeRefs:
         missing = tool_text(
             add_tool(items=[{"product_ref": "missing", "quantity": 1}])
         )
-        assert "not a product shown to this shopper" in missing
+        assert "not established in this turn" in missing
+        assert "resolve it first" in missing
         assert "search the catalog now" in missing
         assert added == []
 


### PR DESCRIPTION
*"Actually add it in a 10 as well"* carried the correct `PRODUCT_REF` for a dress added one turn earlier, and was refused — then told to go searching, so it gave up: *"the add didn't go through."*

- Product evidence is rebuilt **per turn**, so a valid ref from the previous turn is absent from this one. That part is correct.
- The refusal named only the **search** recovery, because it was written for the case where the model passes a product *name* instead of a ref.
- It now names **both**: a product shown earlier is resolved again; a name, or something never shown, is searched for.
- The refusal itself is unchanged — nothing is added that the shopper has not seen.
- Both tests now require both recovery paths, so neither can be dropped again.

| | before | after |
|---|---|---|
| "add it in a 10 as well" | "the add didn't go through" | second line added |
| cart after the sequence | one line, size 8 | two lines, sizes 8 and 10 |
