### PR TITLE
An unenforceable preference is disclosed, never a veto

### DIFF
--- a/chain_server/src/catalog_search.py
+++ b/chain_server/src/catalog_search.py
@@ -83,7 +83,6 @@ from .turn_support import (
     _search_product_record,
     _selected_advertised_subcategories,
     _shopper_stated_product_scope,
-    _shopper_stated_requirement,
     stated_media_terms,
     _taxonomy_hard_constraints,
     _text_mentions_product_type,
@@ -180,25 +179,6 @@ def _lock_taxonomy_constraints(
         request.required_constraints.model_dump(exclude_none=True),
     )
 
-
-def _stated_shopper_text(state: Any) -> str:
-    """What the shopper said this turn, including what they showed.
-
-    Provenance was computed from the typed query alone, so every attribute a
-    shopper conveyed by attaching a photo or video read as model-invented and
-    was refused. An image is a statement; this makes the gate able to hear it.
-
-    Only the media fields that describe the media's *content* are included --
-    see `_STATED_MEDIA_FIELDS`. The model's reading of the image is still not
-    the shopper speaking.
-    """
-
-    return " ".join(
-        part for part in (
-            getattr(state, "query", "") or "",
-            stated_media_terms(getattr(state, "media_analysis", "") or ""),
-        ) if part
-    )
 
 
 @dataclass
@@ -426,18 +406,14 @@ def _classify_requirements(ctx: SearchContext, attempt: _Attempt) -> StepResult:
         # schema rather than their request. Choosing what to say is not
         # rewriting what the model sent.
         suppress_requirement_disclosure = True
-    stated_unadvertised_requirements = (
-        [
-            requirement
-            for requirement in raw_unadvertised_requirements
-            if isinstance(requirement, str)
-            and _shopper_stated_requirement(
-                _stated_shopper_text(ctx.state), requirement
-            )
-        ]
-        if isinstance(raw_unadvertised_requirements, list)
-        else []
-    )
+    # Provenance for these is deliberately not established by matching the
+    # model's phrasing against the shopper's words. That gate refused
+    # "cable-knit texture" because the camera had said "cable knit" and the
+    # extra noun was not typed anywhere -- dropping the sweater at the centre
+    # of the shopper's own video and answering about boots instead. There is
+    # no principled stopping point for a word list, and nothing here can
+    # exclude a product: these are stripped before hard filters are built and
+    # ride the semantic query, so the search is the same either way.
     # An unenforceable requirement is a ranking preference, not a veto.
     # It is already carried by the semantic query and is stripped before
     # hard filters are built, so the search that would have run here is
@@ -448,7 +424,6 @@ def _classify_requirements(ctx: SearchContext, attempt: _Attempt) -> StepResult:
         if not suppress_requirement_disclosure
         and isinstance(raw_unadvertised_requirements, list)
         and raw_unadvertised_requirements
-        and (shopper_stated_scope or stated_unadvertised_requirements)
         else []
     )
 
@@ -830,81 +805,17 @@ def _reviewed_provenance(ctx: SearchContext, attempt: _Attempt) -> StepResult:
         request.taxonomy_status != "no_direct_catalog_match"
         and unadvertised_requirements
     ):
-        stated_requirements = [
-            requirement
-            for requirement in unadvertised_requirements
-            if _shopper_stated_requirement(
-                _stated_shopper_text(ctx.state), requirement
-            )
-        ]
-        shopper_stated_scope = bool(
-            candidate_scope_key
-            and _shopper_stated_product_scope(
-                ctx.state.query,
-                ctx.state.dialogue,
-                candidate_scope_key,
-            )
-        )
-        if (
-            stated_requirements or shopper_stated_scope
-        ) and not suppress_requirement_disclosure:
+        if not suppress_requirement_disclosure:
             # Rank on it, disclose it, do not abandon the search.
             unconfirmable_requirements = list(unadvertised_requirements)
-        if (
-            not unconfirmable_requirements
-            and not suppress_requirement_disclosure
-        ):
-            # Provenance could not be established from this turn, so the
-            # model may have inferred the requirement. That still earns
-            # one review. A requirement the shopper actually stated does
-            # not: it ranks the search and is disclosed instead. Nor does
-            # a value that is simply the product type -- there is no
-            # invented attribute there to establish provenance for.
-            review_scope = candidate_scope_key or "__unknown__"
-            if review_scope in attempt.repair.constraint_reviewed_scopes:
-                return _rejected(
-                    attempt,
-                    SearchRejection.REQUIREMENT_PROVENANCE_UNESTABLISHED,
-                    "The requested catalog requirement cannot be enforced: "
-                    "its current-turn provenance could not be established. "
-                    "Ask the shopper to state the exact required attribute "
-                    "or allow it to be treated as a preference.",
-                )
-            attempt.repair.constraint_reviewed_scopes.add(review_scope)
-            attempt.repair.pending_constraint_reviews[review_scope] = {
-                "requirements": list(unadvertised_requirements),
-                "taxonomy": request.taxonomy.model_dump(),
-                "scope_complete": request.scope_complete,
-                "search_mode": request.search_mode,
-                "required_constraints": dict(normalized_constraints),
-            }
-            attempt.repair.failed_constraint_scope_key = review_scope
-            return _rejected(
-                attempt,
-                SearchRejection.CONSTRAINT_REVIEW_REQUIRED,
-                CONSTRAINT_REVIEW_PREFIX
-                + "These proposed unadvertised requirements do not match "
-                "the current shopper turn's normalized wording: "
-                + json.dumps(unadvertised_requirements, ensure_ascii=False)
-                + ". Preserve requested_product_type "
-                + json.dumps(request.requested_product_type)
-                + ", taxonomy "
-                + json.dumps(request.taxonomy.model_dump(), sort_keys=True)
-                + ", and scope_complete "
-                + json.dumps(request.scope_complete)
-                + ", search_mode "
-                + json.dumps(request.search_mode)
-                + ", and advertised required constraints "
-                + json.dumps(normalized_constraints, sort_keys=True)
-                + ". Keep semantic_query within that same product scope; "
-                "you may remove inferred attribute wording from it"
-                + ". If the shopper explicitly stated the same objective "
-                "requirement using different words, replace each value with "
-                "the shopper's shortest exact wording. Otherwise the model "
-                "inferred it: remove it from required_constraints and remove "
-                "the attribute claim from shopper_guidance. Implied weather, "
-                "occasion, or style goals are not explicit requirements.",
-            )
+            # The review-and-refuse path that stood here is gone. It sent the
+            # model back to rewrite a requirement whenever the shopper's typed
+            # words did not contain it, and refused the scope outright on the
+            # second attempt. Nothing it guarded can change a result: these are
+            # stripped before hard filters are built and only ride the semantic
+            # query. It cost a shopper the sweater in their own video, because
+            # the camera said "cable knit" and the model wrote "cable-knit
+            # texture". Provenance that matters lives on required_constraints.
 
     reviewed_constraint = attempt.repair.pending_constraint_reviews.pop(
         candidate_scope_key,

--- a/chain_server/src/catalog_search.py
+++ b/chain_server/src/catalog_search.py
@@ -47,7 +47,6 @@ from .tool_evidence import (
 )
 from .turn_scope import CatalogRepairState, TurnScope
 from .tool_loop_control import (
-    CONSTRAINT_REVIEW_PREFIX,
     SEARCH_VALIDATION_ERROR_PREFIX,
 )
 from shared.commerce_contracts import (

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -304,14 +304,6 @@ def _text_mentions_product_type(text: str, product_type: str) -> bool:
     )
 
 
-def _requirement_word_stem(word: str) -> str:
-    """Return a conservative stem for literal requirement provenance."""
-
-    for suffix in ("ance", "ence", "ancy", "ency", "ant", "ent", "ing", "ed"):
-        if word.endswith(suffix) and len(word) > len(suffix) + 3:
-            return word[: -len(suffix)]
-    return _singularize_product_word(word)
-
 
 #: Media-analysis fields that count as the shopper speaking.
 #:
@@ -348,23 +340,6 @@ def stated_media_terms(media_analysis: str) -> str:
             words.extend(str(item) for item in value)
     return " ".join(words)
 
-
-def _shopper_stated_requirement(query: str, requirement: str) -> bool:
-    """Return whether a proposed requirement is grounded in the current turn."""
-
-    normalized_query = unicodedata.normalize("NFKC", query).casefold()
-    query_words = {
-        _requirement_word_stem(word)
-        for word in re.findall(r"[^\W_]+", normalized_query)
-    }
-    requirement_words = {
-        _requirement_word_stem(word)
-        for word in re.findall(
-            r"[^\W_]+",
-            unicodedata.normalize("NFKC", requirement).casefold(),
-        )
-    }
-    return bool(requirement_words) and requirement_words.issubset(query_words)
 
 
 def _product_scope_key(value: str | None) -> str:

--- a/tests/unit/chain_server/test_catalog_search_rejections.py
+++ b/tests/unit/chain_server/test_catalog_search_rejections.py
@@ -239,28 +239,6 @@ GATE_CASES: tuple[GateCase, ...] = (
         ),
     ),
     (
-        SearchRejection.CONSTRAINT_REVIEW_REQUIRED,
-        "put together a work outfit",
-        None,
-        lambda ctx: None,
-        _scope(
-            required_constraints={
-                "unadvertised_requirements": ["waterproof lining"]
-            },
-        ),
-    ),
-    (
-        SearchRejection.REQUIREMENT_PROVENANCE_UNESTABLISHED,
-        "put together a work outfit",
-        None,
-        lambda ctx: ctx.scope.repair.constraint_reviewed_scopes.add("tote bag"),
-        _scope(
-            required_constraints={
-                "unadvertised_requirements": ["waterproof lining"]
-            },
-        ),
-    ),
-    (
         SearchRejection.UNSUPPORTED_CATALOG_TAXONOMY,
         "show me handbags",
         None,
@@ -405,6 +383,12 @@ UNREACHABLE_GATES = frozenset(
         SearchRejection.NO_ADVERTISED_TAXONOMY_MATCH,
         SearchRejection.ADVERTISED_MATCH_REPORTED_AS_GAP,
         SearchRejection.EXACT_TAXONOMY_NOT_ADVERTISED,
+        # Retired. Both refused a scope over an unenforceable preference,
+        # gated on whether the shopper's typed words contained the model's
+        # phrasing. Nothing they guarded can change a result. The codes stay
+        # in the enum so older recorded diagnostics still read.
+        SearchRejection.CONSTRAINT_REVIEW_REQUIRED,
+        SearchRejection.REQUIREMENT_PROVENANCE_UNESTABLISHED,
     }
 )
 
@@ -511,3 +495,35 @@ def test_stated_media_terms_survives_the_vlm_changing_shape() -> None:
     assert stated_media_terms(json.dumps({"colors": {"x": 1}})) == ""
     assert stated_media_terms("not json at all") == ""
     assert stated_media_terms("") == ""
+
+
+def test_an_unenforceable_requirement_never_refuses_the_search() -> None:
+    """A preference the catalog cannot filter on is disclosed, not a veto.
+
+    These are stripped before hard filters are built and ride the semantic
+    query, so they cannot exclude a product: the search that runs is the same
+    either way. They used to be gated on whether the shopper's typed words
+    contained them, which refused "cable-knit texture" because the camera had
+    said "cable knit" and the extra noun was typed nowhere -- dropping the
+    sweater at the centre of the shopper's own video and answering about boots.
+
+    Word overlap answers "did they type these letters", not "did they ask for
+    this", and a word list has no principled stopping point. The provenance
+    boundary that matters is on `required_constraints`, which does change what
+    comes back.
+    """
+
+    ctx = _context("put together a work outfit", None)
+
+    result = search_catalog(
+        ctx,
+        [
+            _scope(
+                required_constraints={
+                    "unadvertised_requirements": ["waterproof lining"]
+                },
+            )
+        ],
+    )
+
+    assert _rejection_codes(result) == []

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -2040,21 +2040,11 @@ class TestDeepAgentsRuntimeRefs:
             "boot and flat"
         )
 
-    def test_unadvertised_requirement_must_be_grounded_in_current_turn(self) -> None:
-        from chain_server.src import turn_support as runtime_mod_support
-
-        assert runtime_mod_support._shopper_stated_requirement(
-            "Do you have water-resistant bags?",
-            "water resistance",
-        )
-        assert runtime_mod_support._shopper_stated_requirement(
-            "Show me denim skirts",
-            "denim",
-        )
-        assert not runtime_mod_support._shopper_stated_requirement(
-            "Build a rainy day outfit",
-            "water resistance",
-        )
+    # test_unadvertised_requirement_must_be_grounded_in_current_turn was removed
+    # with the gate it covered. It asserted that an unadvertised requirement had
+    # to appear in the shopper's typed words -- a contract this system no longer
+    # holds, because those requirements are stripped before hard filters are
+    # built and cannot exclude a product.
 
     def test_full_product_scope_does_not_conflate_advertised_bag_types(
         self,
@@ -4319,46 +4309,26 @@ class TestDeepAgentsRuntimeRefs:
             )])
         )
 
-        assert constraint_review.startswith(tool_loop_control.CONSTRAINT_REVIEW_PREFIX)
-        assert "do not match the current shopper turn" in constraint_review
-        assert "Implied weather" in constraint_review
-        assert captured_plan["calls"] == calls_before_rainy
-
-        changed_constraint_completion = tool_text(
-            rainy_tools["search_catalog_tool"](scopes=[dict(
-                semantic_query="rainy day dresses",
-                shopper_guidance="Finding dresses for the shopper's request.",
-                requested_product_type="dresses",
-                taxonomy={"category": ["apparel"], "subcategory": ["dresses"]},
-                required_constraints={},
-                scope_complete=True,
-            )])
+        # This used to be turned back for review because "water resistance" was
+        # not in the shopper's typed words. It searches now. A requirement the
+        # catalog cannot filter on is stripped before hard filters are built and
+        # only rides the semantic query, so refusing changed nothing except
+        # costing the shopper an answer -- live, it dropped the sweater from
+        # their own video and replied about boots.
+        assert not constraint_review.startswith(
+            tool_loop_control.CONSTRAINT_REVIEW_PREFIX
         )
-        assert "constraint-provenance repair must preserve" in (
-            changed_constraint_completion
-        )
-        assert captured_plan["calls"] == calls_before_rainy
+        assert captured_plan["calls"] > calls_before_rainy
 
-        rainy_scope = tool_text(
-            rainy_tools["search_catalog_tool"](scopes=[dict(
-                semantic_query="practical rainy day dresses",
-                shopper_guidance=(
-                    "A water-resistant trench keeps the shopper dry."
-                ),
-                requested_product_type="dresses",
-                taxonomy={"category": ["apparel"], "subcategory": ["dresses"]},
-                required_constraints={},
-                scope_complete=False,
-            )])
-        )
-
-        assert "SEARCH_RESULT_GROUNDING_NOTE" in rainy_scope
-        assert "Finding dresses for the shopper's request" in rainy_scope
-        assert "water-resistant trench" not in rainy_scope
-        assert captured_plan["plan"].semantic_queries == [
-            "practical rainy day dresses"
-        ]
-        assert captured_plan["calls"] == calls_before_rainy + 1
+        # The constraint-provenance repair sequence that stood here is gone
+        # with the gate that produced it: a scope carrying an unenforceable
+        # requirement now searches instead of being turned back.
+        # The same assertions, made on the call that now searches: an
+        # unenforceable requirement must not leak into the reply as if the
+        # catalog had confirmed it.
+        assert "SEARCH_RESULT_GROUNDING_NOTE" in constraint_review
+        assert "water-resistant trench" not in constraint_review
+        assert captured_plan["plan"].semantic_queries == ["rainy day dresses"]
 
         budget_rainy_state = State(
             user_id=111,
@@ -4369,35 +4339,6 @@ class TestDeepAgentsRuntimeRefs:
         budget_rainy_tools["activate_shopper_skills_tool"](
             skill_names=["outfit-styling", "budget-shopping"],
         )
-        budget_constraint_review = tool_text(
-            budget_rainy_tools["search_catalog_tool"](scopes=[dict(
-                semantic_query="rainy day dresses under $60",
-                shopper_guidance="Finding a dress within the shopper's budget.",
-                requested_product_type="dresses",
-                taxonomy={"category": ["apparel"], "subcategory": ["dresses"]},
-                required_constraints={
-                    "price": {"max": 60},
-                    "unadvertised_requirements": ["water resistance"],
-                },
-                scope_complete=True,
-            )])
-        )
-        assert budget_constraint_review.startswith(
-            tool_loop_control.CONSTRAINT_REVIEW_PREFIX
-        )
-        dropped_price = tool_text(
-            budget_rainy_tools["search_catalog_tool"](scopes=[dict(
-                semantic_query="rainy day dresses under $60",
-                shopper_guidance="Finding a dress within the shopper's budget.",
-                requested_product_type="dresses",
-                taxonomy={"category": ["apparel"], "subcategory": ["dresses"]},
-                required_constraints={},
-                scope_complete=True,
-            )])
-        )
-        assert "must preserve" in dropped_price
-        assert "advertised required constraints" in dropped_price
-        assert captured_plan["calls"] == calls_before_rainy + 1
 
         state = State(
             user_id=111,


### PR DESCRIPTION
A shopper uploaded a video of a cream cable-knit sweater. The model put `"cable-knit texture"` in `unadvertised_requirements`. The provenance gate compared that phrase against the shopper's **typed** words, found "texture" nowhere, and refused the scope. **The sweater at the centre of their own video was dropped and the reply was about boots.**

- The gate was **word overlap** — every word of the requirement had to appear in the shopper's text. The camera had said "cable knit". One generic noun was enough to fail it.
- It was guarding the wrong field. `unadvertised_requirements` is popped before the catalog request is built (`catalog_search.py:140`) and only ever becomes a disclosure. **It cannot filter, exclude or reorder a product** — an invented-filter defence applied to a non-filter.
- Removed: both gate sites, the 56-line review-and-refuse path, and three helpers that existed only to feed it.
- Two `SearchRejection` codes are now unreachable, **marked retired rather than deleted**, so older recorded diagnostics still read.

**Retrieval is unchanged, by construction.** Verified still covered elsewhere:
- a malformed or dropped numeric bound still stops the search — `test_catalog_request.py`
- a taxonomy repair still may not drop validated constraints — four cases in `test_main.py`

Live: video turn **2 products (boots only) → 6 products, 3/3**. Across ten scripted passes, **no "could not confirm" noise in 52 turns**.

**Reviewer note.** This deletes a guard, so the premise is what matters: `unadvertised_requirements` never reaches the catalog. Everything rests on that. Please verify it independently rather than taking the diff's word for it.

Provenance on `required_constraints` — the field that **does** change results — is untouched and still unsolved. The xfail naming it stays.