### PR TITLE
"This catalog does not carry it" is an answer the shopper can hear

### DIFF
--- a/chain_server/src/catalog_search.py
+++ b/chain_server/src/catalog_search.py
@@ -555,7 +555,12 @@ def _validated_request(ctx: SearchContext, attempt: _Attempt) -> StepResult:
                     "advertised subcategory that role covers. Choose from "
                     "these currently advertised subcategories: "
                     + json.dumps(advertised_choices, ensure_ascii=False)
-                    + "."
+                    + ". If the role is not a kind of any of them, do not "
+                    "choose one: name it in not_covered and tell the shopper "
+                    "this catalog does not carry it. Offering only the list "
+                    "read as an instruction to pick from it -- asked to "
+                    "compare two aprons, a catalog with no aprons produced an "
+                    "empty taxonomy five turns running rather than saying so."
                 )
                 constraints = (
                     required_constraints.model_dump(exclude_none=True)

--- a/chain_server/src/catalog_search.py
+++ b/chain_server/src/catalog_search.py
@@ -37,6 +37,7 @@ from .catalog_request import (
 )
 from .control_signals import (
     ControlSignal,
+    NOT_CARRIED_KEY,
     REJECTIONS_KEY,
     SearchRejection,
     control,
@@ -241,6 +242,10 @@ class _Attempt:
     #: The nine gates below all render one prefix, so the text they hand the
     #: model cannot say which one refused; this can.
     rejection_code: str | None = None
+    #: The shopper's own word for a product type this catalog advertises
+    #: nothing for. A rejection says the arguments were wrong; this says the
+    #: thing does not exist here, which is an answer rather than an error.
+    not_carried: str | None = None
     request: Any = None
     result: Any = None
     search_budget_exhausted: Any = None
@@ -586,6 +591,28 @@ def _validated_request(ctx: SearchContext, attempt: _Attempt) -> StepResult:
                         "directly stated for the selected role; remove one "
                         "inferred from season, weather, occasion, or style."
                     )
+            elif shopper_stated_scope and _advertised_scope_match(
+                requested_product_type,
+                capabilities,
+            ) is None:
+                # The same dead end, reached by the other door: a type the
+                # shopper names is classified exact_requested_type, never
+                # agent_selected_type, so it took none of the guidance above and
+                # heard only that its arguments failed validation.
+                #
+                # Whether it is carried is not in doubt here -- nothing this
+                # catalog advertises matches the word -- so this is recorded as
+                # a fact rather than left to the model to volunteer. The
+                # guidance stops it substituting a different product for the one
+                # the shopper asked about.
+                attempt.not_carried = str(requested_product_type)
+                repair_guidance = (
+                    " This catalog advertises nothing of that kind, so there is "
+                    "no taxonomy that would make this search valid. Do not "
+                    "substitute a product type the shopper did not ask for: "
+                    "tell them plainly it is not carried, and offer the "
+                    "advertised kinds only if they ask what there is instead."
+                )
         constraint_lock = ""
         try:
             validated_constraints = ctx.constraint_input_model.model_validate(
@@ -1681,7 +1708,21 @@ def search_catalog(
             ):
                 outcomes[index] = outcome
 
-    rendered: list[str] = []
+    notices: list[str] = []
+    # What the tool established itself, before anything the model volunteered:
+    # a scope whose product type this catalog advertises nothing for. Its call
+    # was rejected on its arguments, but "we do not carry aprons" is a current
+    # fact about the catalog and the shopper is owed it either way.
+    not_carried = [
+        attempt.not_carried for attempt in attempts if attempt.not_carried
+    ]
+    if not_carried:
+        notices.append(
+            "NOT_CARRIED: this catalog advertises nothing of these kinds, so "
+            "no search of it can succeed. Tell the shopper plainly that it is "
+            "not carried: " + ", ".join(dict.fromkeys(not_carried))
+        )
+    rendered: list[str] = list(notices)
     if not_covered:
         # The shopper asked for something no advertised category covers. It
         # costs no retrieval, but recording it is what stops the request being
@@ -1708,10 +1749,45 @@ def search_catalog(
         single = outcomes[0] if outcomes[0] is not None else _RENDER_STEP(ctx, attempts[0])
         if single is None:
             single = "Catalog search returned nothing."
-        return _with_scope_rejections(single, codes)
+        # A one-scope call took its own text and left `rendered` behind, so a
+        # notice raised for that scope never reached the model.
+        if notices:
+            text, artifact = (
+                single if isinstance(single, tuple) else (single, None)
+            )
+            single = ("\n\n".join([*notices, text]), artifact) if artifact else (
+                "\n\n".join([*notices, text])
+            )
+        return _with_not_carried(
+            _with_scope_rejections(single, codes),
+            not_carried,
+        )
     merged = _merged_artifacts(artifacts)
     text = "\n\n".join(rendered)
-    return _with_scope_rejections((text, merged) if merged else text, codes)
+    return _with_not_carried(
+        _with_scope_rejections((text, merged) if merged else text, codes),
+        not_carried,
+    )
+
+
+def _with_not_carried(
+    result: StepResult,
+    not_carried: list[str],
+) -> StepResult:
+    """Carry the not-carried product types out on the artifact.
+
+    A reader that has to tell "the arguments were wrong" from "the thing does
+    not exist here" cannot do it from the rejection codes: both are the same
+    schema mismatch. This is the distinction, recorded rather than inferred.
+    """
+
+    if not not_carried:
+        return result
+    text, artifact = result if isinstance(result, tuple) else (result, None)
+    return text, {
+        **(artifact or {}),
+        NOT_CARRIED_KEY: list(dict.fromkeys(not_carried)),
+    }
 
 
 def _with_scope_rejections(

--- a/chain_server/src/control_signals.py
+++ b/chain_server/src/control_signals.py
@@ -86,6 +86,27 @@ EFFECTS_KEY = "committed_effects"
 #: turned that scope back -- ``None`` for a scope that was not turned back.
 REJECTIONS_KEY = "scope_rejections"
 
+#: Artifact key holding the product types this catalog advertises nothing for,
+#: as established by the search tool itself rather than volunteered by the
+#: model. "We do not carry aprons" is a current fact about the catalog, so it
+#: is recorded like any other tool evidence and survives the call being
+#: rejected on its arguments.
+NOT_CARRIED_KEY = "not_carried_product_types"
+
+
+def not_carried_of(message: Any) -> list[Any]:
+    """Read the product types one tool message reported as not carried."""
+
+    artifact = (
+        message.get("artifact")
+        if isinstance(message, dict)
+        else getattr(message, "artifact", None)
+    )
+    if not isinstance(artifact, dict):
+        return []
+    recorded = artifact.get(NOT_CARRIED_KEY)
+    return list(recorded) if isinstance(recorded, list) else []
+
 
 def control(text: str, *signals: ControlSignal) -> tuple[str, dict[str, Any]]:
     """Return one tool result whose control outcome is typed, not parsed.

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -1875,8 +1875,32 @@ def _rejected_catalog_search_response(
         tool_name == "search_catalog_tool" and status == "rejected"
         for tool_name, status in business_calls
     ):
+        if _search_reported_not_covered(messages):
+            # The scopes were invalid, but the call also named what this catalog
+            # does not carry, and NOT_COVERED evidence went back to the model.
+            # That is a fact for the model to speak to, not a reason to seize
+            # the turn: asked to compare two aprons in a catalog with none, the
+            # model correctly sent not_covered and had its answer replaced by
+            # "I couldn't complete a valid catalog search", five turns running.
+            return None
         return _REJECTED_CATALOG_SEARCH_RESPONSE
     return None
+
+
+def _search_reported_not_covered(messages: Any) -> bool:
+    """Whether a search this turn named product kinds the catalog lacks."""
+
+    for message in messages:
+        if _message_type(message) != "ai":
+            continue
+        for raw_call in (_value(message, "tool_calls") or []):
+            call = raw_call if isinstance(raw_call, dict) else {}
+            if (call.get("name") or "") != "search_catalog_tool":
+                continue
+            args = call.get("args")
+            if isinstance(args, dict) and args.get("not_covered"):
+                return True
+    return False
 
 
 def _catalog_repair_clarification_response(

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -65,6 +65,7 @@ from .conversation_memory import (
     FinalTurnStatus,
 )
 from .control_signals import (
+    not_carried_of,
     rejections_of,
 )
 from .tool_evidence import (
@@ -1883,6 +1884,15 @@ def _rejected_catalog_search_response(
             # model correctly sent not_covered and had its answer replaced by
             # "I couldn't complete a valid catalog search", five turns running.
             return None
+        if _search_reported_not_carried(messages):
+            # The same fact, established by the tool rather than volunteered by
+            # the model. Leaving it to the model meant leaving it to chance:
+            # replayed five times, it filled `not_covered` unprompted in four
+            # and in the fifth wrote the right answer -- "aprons aren't a
+            # product type this store carries" -- only to have it replaced by
+            # the refusal. Nothing about a catalog that carries no aprons
+            # differed between those runs.
+            return None
         return _REJECTED_CATALOG_SEARCH_RESPONSE
     return None
 
@@ -1900,6 +1910,19 @@ def _search_reported_not_covered(messages: Any) -> bool:
             args = call.get("args")
             if isinstance(args, dict) and args.get("not_covered"):
                 return True
+    return False
+
+
+def _search_reported_not_carried(messages: Any) -> bool:
+    """Whether the search tool established a product type as not carried."""
+
+    for message in messages:
+        if _message_type(message) != "tool":
+            continue
+        if (_value(message, "name") or "") != "search_catalog_tool":
+            continue
+        if not_carried_of(message):
+            return True
     return False
 
 

--- a/tests/unit/chain_server/test_catalog_search_rejections.py
+++ b/tests/unit/chain_server/test_catalog_search_rejections.py
@@ -21,7 +21,11 @@ import pytest
 from chain_server.src import catalog_search as catalog_search_mod
 from chain_server.src.agenttypes import State
 from chain_server.src.catalog_search import SearchContext, search_catalog
-from chain_server.src.control_signals import REJECTIONS_KEY, SearchRejection
+from chain_server.src.control_signals import (
+    NOT_CARRIED_KEY,
+    REJECTIONS_KEY,
+    SearchRejection,
+)
 from chain_server.src.turn_scope import TurnScope
 from chain_server.src.turn_support import _search_catalog_tool_input_model
 from shared.commerce_contracts import (
@@ -511,3 +515,53 @@ def test_stated_media_terms_survives_the_vlm_changing_shape() -> None:
     assert stated_media_terms(json.dumps({"colors": {"x": 1}})) == ""
     assert stated_media_terms("not json at all") == ""
     assert stated_media_terms("") == ""
+
+
+def test_a_product_type_the_catalog_lacks_is_recorded_as_a_fact() -> None:
+    """A rejection said the arguments were wrong. It never said aprons.
+
+    Asked to compare two aprons in a catalog that carries none, the model sent
+    an empty taxonomy -- the only honest one -- and got a schema error back.
+    Whether the catalog carries aprons is not in doubt at that point: nothing it
+    advertises matches the word. So the tool states it, rather than leaving the
+    model to volunteer ``not_covered`` on a retry it does not always make.
+    """
+
+    ctx = _context("compare the Everyday Cotton Apron and the Linen Kitchen Apron")
+
+    result = search_catalog(
+        ctx,
+        [
+            _scope(
+                semantic_query="Everyday Cotton Apron",
+                requested_product_type="apron",
+                taxonomy={"category": [], "subcategory": []},
+            )
+        ],
+    )
+
+    text, artifact = result if isinstance(result, tuple) else (result, None)
+    assert (artifact or {}).get(NOT_CARRIED_KEY) == ["apron"]
+    # The model is told in the same call, not only through the artifact.
+    assert "NOT_CARRIED" in text
+    assert _rejection_codes(result) == [SearchRejection.CAPABILITIES_SCHEMA_MISMATCH]
+
+
+def test_an_advertised_type_rejected_on_its_taxonomy_is_not_called_uncarried() -> None:
+    """The catalog carries tote bags; only these arguments were wrong.
+
+    Recording every schema mismatch as "not carried" would tell shoppers a
+    catalog lacks what it sells, and would disarm the guard that stops a turn
+    whose searches were all refused.
+    """
+
+    ctx = _context("show me tote bags")
+
+    result = search_catalog(
+        ctx,
+        [_scope(taxonomy={"category": ["bags"], "subcategory": ["hatboxes"]})],
+    )
+
+    text, artifact = result if isinstance(result, tuple) else (result, None)
+    assert NOT_CARRIED_KEY not in (artifact or {})
+    assert "NOT_CARRIED" not in text

--- a/tests/unit/chain_server/test_deepagents_observability.py
+++ b/tests/unit/chain_server/test_deepagents_observability.py
@@ -1243,3 +1243,58 @@ async def test_a_shopper_who_hangs_up_stops_the_turn_they_abandoned(
     await asyncio.sleep(0.4)
 
     assert len(steps) < 5, "the abandoned turn kept working after the hang-up"
+
+
+def test_a_refused_search_that_named_an_uncarried_type_keeps_its_answer() -> None:
+    """The tool established the fact; the model should get to speak to it.
+
+    Every scope was refused, so the turn was seized and the model's own words
+    were replaced with "I couldn't complete a valid catalog search". Replayed
+    five times against a catalog with no aprons, one of those discarded answers
+    read: "aprons aren't a product type this store carries". Nothing about the
+    catalog differed between the runs that survived and the one that did not --
+    only whether the model happened to fill an optional argument.
+    """
+
+    messages = {
+        "messages": [
+            HumanMessage(content="REQUEST ID: current-request"),
+            _search_call("uncarried-search"),
+            ToolMessage(
+                content="NOT_CARRIED: ... apron",
+                name="search_catalog_tool",
+                tool_call_id="uncarried-search",
+                artifact={
+                    "scope_rejections": ["capabilities_schema_mismatch"],
+                    "not_carried_product_types": ["apron"],
+                },
+            ),
+        ]
+    }
+
+    assert (
+        _rejected_catalog_search_response(messages, request_id="current-request")
+        is None
+    )
+
+
+def test_a_refused_search_over_a_carried_type_still_fails_closed() -> None:
+    """Without this the guard is gone: every refusal would keep its answer."""
+
+    messages = {
+        "messages": [
+            HumanMessage(content="REQUEST ID: current-request"),
+            _search_call("carried-search"),
+            ToolMessage(
+                content=SEARCH_VALIDATION_ERROR_PREFIX + "{} with error: invalid",
+                name="search_catalog_tool",
+                tool_call_id="carried-search",
+                artifact={"scope_rejections": ["capabilities_schema_mismatch"]},
+            ),
+        ]
+    }
+
+    assert (
+        _rejected_catalog_search_response(messages, request_id="current-request")
+        == _REJECTED_CATALOG_SEARCH_RESPONSE
+    )


### PR DESCRIPTION
Asked to compare two aprons in a catalog that sells no aprons, the assistant answered *"I couldn't complete a valid catalog search for that request"* — five turns running.

- **"We don't carry it" is now reachable.** The repair guidance for an unusable taxonomy listed the advertised subcategories and stopped, which reads as *pick from this list*. It now names the third option: `not_covered`.
- **The answer is no longer discarded.** When every search call was rejected, the turn was seized with a generic failure — even when the call had already reported what the catalog does not carry.
- **A product the shopper names takes the same path as one the assistant chose.** A composed role is classified `agent_selected_type` and got that guidance; a shopper-named product is classified `exact_requested_type` and got none of it. That is the apron case.
- **The tool states the fact instead of the model volunteering it.** When the requested type matches nothing the catalog advertises, whether it is carried is not in doubt — the search records it, so the answer no longer depends on the model filling an optional argument.
- **A refusal over a product the catalog does carry still fails closed**, so the assistant cannot answer out of thin air when a search was genuinely malformed.
- **Nothing matches words.** Carried-or-not is decided against the catalog's own advertised taxonomy, so a catalog that starts selling aprons needs no change here. The fact travels as a typed artifact, never as parsed tool text.

**Before**

> **Shopper:** I'm choosing between the "Everyday Cotton Apron" and the "Linen Kitchen Apron" — compare them on price, materials and care.
> **Assistant:** I couldn't complete a valid catalog search for that request, so I don't have catalog results to show. Please try again or ask me to search a different advertised product type.

**After**

> **Shopper:** I'm choosing between the "Everyday Cotton Apron" and the "Linen Kitchen Apron" — compare them on price, materials and care.
> **Assistant:** I can't compare those two using this catalog's facts, because this store doesn't carry aprons — so there are no catalog records for either one. What's here is apparel, bags, eyewear, footwear and jewelry. If you paste the specs from wherever you're shopping, I can still do the value comparison for weekly use.
