### PR TITLE
Changing a size never empties the cart

### DIFF
--- a/chain_server/skills/shopper/cart-management/SKILL.md
+++ b/chain_server/skills/shopper/cart-management/SKILL.md
@@ -29,6 +29,14 @@ Handle explicit cart operations. Do not expose tool names or internal identifier
 - Call `add_cart_items_tool` only when the shopper explicitly says to add, buy, or put an item in the cart.
 - Styling approval, product discussion, or "I like it" is NOT add intent.
 - If the add scope is ambiguous ("add those", "add them all"), ask one concise clarification naming the candidates before calling the tool.
+- A size the shopper has not named for THIS purchase is not their size. A size
+  they used to filter a search earlier is a search filter, not a decision to buy
+  that size. When they have not said which size they want, ask -- naming the
+  sizes the product is sold in. Guessing puts a size in their cart they never
+  chose.
+- When they DO name a size, act on it. Do not ask again. A bare "size 8" after
+  you offered the sizes is an answer, not a new question: add it. Asking twice
+  reads as not listening, and the shopper's instruction goes unfulfilled.
 - Pass `PRODUCT_REF` values established by current-turn search or successful
   historical-product resolution — never product names.
 - For multiple items, call `add_cart_items_tool` once with the full list.

--- a/chain_server/skills/shopper/cart-management/SKILL.md
+++ b/chain_server/skills/shopper/cart-management/SKILL.md
@@ -38,6 +38,10 @@ Handle explicit cart operations. Do not expose tool names or internal identifier
 - Call `get_cart_tool` first to get current `CART_LINE_ID` values before calling `remove_cart_item_tool` or `update_cart_items_tool`.
 - Never guess a `CART_LINE_ID` from a product name.
 - Use `update_cart_items_tool` for quantity changes. Use `remove_cart_item_tool` for removals. Do not remove-and-re-add to change quantity.
+- A size is a different line, not a different quantity. To change a size: add the
+  new size first, confirm it is in the cart, then remove the old line. Never
+  remove first — a failure between the two must leave the shopper with an extra
+  line, never with nothing.
 
 ## Result Reporting
 

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1292,11 +1292,39 @@ class DeepAgentsRuntime:
             if not requested_items:
                 return "Cart add failed: provide at least one PRODUCT_REF to add."
 
+            def _resolve_from_conversation_index(product_ref: str):
+                """Look one ref up in the conversation's durable product index."""
+
+                try:
+                    result = self._conversation_products.resolve(
+                        identity.conversation_id,
+                        [
+                            ProductReferenceDescriptor(
+                                reference_id="cart-add",
+                                product_ref=product_ref,
+                            )
+                        ],
+                    )
+                except (ConversationProductsError, ValidationError):
+                    return None
+                scope.product_evidence.add_resolutions(result.results)
+                return scope.product_evidence.get(product_ref)
+
             resolved: list[tuple[str, ProductSummary, int]] = []
             failed: list[str] = []
             blocked: list[str] = []
             for (product_ref, size), request in requested_items.items():
                 product = scope.product_evidence.get(product_ref)
+                if product is None:
+                    # The conversation's product index is the identity lane: it
+                    # is durable, scoped to this conversation, and printed into
+                    # the prompt every turn -- which is where the model read
+                    # this ref. Evidence is rebuilt per turn, so a ref shown two
+                    # turns ago is absent from it, and refusing on that basis
+                    # rejected a ref the shopper had genuinely been shown.
+                    # This is a lookup in the conversation's own record, not a
+                    # catalog search.
+                    product = _resolve_from_conversation_index(product_ref)
                 if product is None:
                     # Two different situations reach here, and naming only one
                     # of them stranded the other.

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1519,12 +1519,29 @@ class DeepAgentsRuntime:
             )
 
         def _update_cart_items_impl(cart_line_id: str, quantity: int):
-            """Change the quantity of an item already in the cart, or remove it
-            by setting quantity to 0. Use ONLY when the shopper explicitly asks
-            to change a quantity or remove by quantity. Do NOT use for initial
-            adds — use add_cart_items_tool. Do NOT guess the CART_LINE_ID; call
-            get_cart_tool first if you do not have one.
+            """Change the quantity of an item already in the cart. Use ONLY when
+            the shopper explicitly asks to change a quantity. Do NOT use for
+            initial adds — use add_cart_items_tool. Do NOT guess the
+            CART_LINE_ID; call get_cart_tool first if you do not have one.
             """
+
+            if quantity == 0:
+                # A size is a different line, not a different quantity, and the
+                # cart has no operation for changing one. Asked for a size 8
+                # against a line added as a size 2, the model reached for the
+                # only move available -- quantity 0 -- which deleted the line,
+                # and then never added the replacement. The shopper corrected
+                # their size and lost the item.
+                return (
+                    "CART_UPDATE_REFUSED: quantity 0 would delete this line, and "
+                    "this tool changes quantities. If the shopper is changing a "
+                    "SIZE, a size is a different line: add the new size with "
+                    "add_cart_items_tool FIRST, confirm it is in the cart, then "
+                    "remove the old line with remove_cart_item_tool. Never the "
+                    "other way round -- a failure between the two must leave the "
+                    "shopper with an extra line, never with nothing. If they "
+                    "simply want the line gone, use remove_cart_item_tool."
+                )
 
             result = update_cart_item(
                 UpdateCartItemInput(

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -19,6 +19,7 @@ import pathlib
 from chain_server.src.turn_support import _normalize_cart_add_tool_items
 from types import SimpleNamespace
 from chain_server.src.turn_support import _cart_size_issue
+import inspect
 
 
 def test_two_sizes_of_one_product_are_two_lines() -> None:
@@ -219,3 +220,4 @@ class TestCartSizeGate:
 
         assert _cart_size_issue(self._product("2, 4, 6"), "4") == ""
         assert "SIZE REQUIRED" in _cart_size_issue(self._product("2, 4, 6"), None)
+

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -3429,6 +3429,24 @@ class TestDeepAgentsRuntimeRefs:
         assert "Silk Dress → qty 2" in update_response
         assert "CART_LINE_ID: Silk Dress" in update_response
         assert update_requests[0][0].quantity == 2
+
+        # A size is a different line, not a different quantity, and the cart has
+        # no operation for changing one. Asked for a size 8 against a line added
+        # as a size 2, the model reached for quantity 0 -- the only move
+        # available -- which deleted the line, and never added the replacement.
+        # Live, the cart went from one line to empty and the shopper was asked
+        # whether they would like the size 8 added.
+        calls_before_zero = len(update_requests)
+        zero_response = tool_text(
+            tools_by_name["update_cart_items_tool"](
+                cart_line_id="line_silk", quantity=0
+            )
+        )
+        assert zero_response.startswith("CART_UPDATE_REFUSED")
+        assert "add the new size with" in zero_response
+        assert "remove_cart_item_tool" in zero_response
+        # and nothing was sent to the cart service
+        assert len(update_requests) == calls_before_zero
         assert update_requests[0][1] == base_config.memory_port
 
     def test_shopper_agent_tool_registry_matches_registered_tool_names(self) -> None:


### PR DESCRIPTION
A shopper corrected their size and lost the item. The dress had been added in a size 2; they said *"size 8"*; the reply was *"your cart is empty (the previously added size 2 was removed)."*

- **A size change never removes before it adds.** A size is a different line, not a different quantity, so the assistant had no operation for the change and reached for the only move available — which deleted the line and never re-added it. Setting a quantity to zero through the agent is refused, and the refusal names the safe order: add the new size, confirm it, then remove the old line.
- **The cart recognises a product the shopper was already shown.** It validated references against the current turn's working set, which is empty when a turn begins — so a reference printed into the assistant's own prompt was refused, and the turn was spent recovering from it. It now falls back to the conversation's durable product index.
- **This is a lookup, not a search.** Nothing new is retrieved, and nothing reaches the cart that the shopper has not been shown.
- **A size used to narrow an earlier search is not a decision to buy that size.** Carried forward, it put a size 2 in a cart nobody asked for. When no size has been named, the assistant asks, naming the sizes the product is sold in.
- **When a size is named, it acts.** A bare *"size 8"* after being offered the sizes is an answer, not a new question.
- **The cart panel is untouched.** Stepping a quantity to zero in the UI still deletes a line, as it always did.

**Before**

> **Shopper:** Actually make that a size 8.
> **Assistant:** Your cart is empty (the previously added size 2 was removed).

**After**

> **Shopper:** Actually make that a size 8.
> **Assistant:** Added the Woven Floral Maxi Dress in a size 8 and removed the size 2 — your cart has one dress, size 8, $199.99.
