### PR TITLE
The eval client outwaits the server it is measuring

### DIFF
--- a/tests/evaluation/eval_config.yaml
+++ b/tests/evaluation/eval_config.yaml
@@ -34,8 +34,11 @@ target_agent:
   base_url: "http://localhost:8009"
   endpoint: "/query/timing"
   # Must exceed the target's turn budget with room for transport, or the client
-  # aborts turns the assistant would have completed.
-  timeout_seconds: 120
+  # aborts turns the assistant would have completed. The budget is
+  # deepagents_execution_timeout_seconds, which a deployment may raise by env:
+  # at 150 a 120s client here aborted a scenario mid-conversation, and the
+  # challenger then wrote its next turn around the error it saw.
+  timeout_seconds: 210
   guardrails: false
 
 run:


### PR DESCRIPTION
The eval client gave up at **120s** while the chain server’s own turn budget was **150s**.

- A scenario was aborted mid-conversation by the client, not by the assistant.
- The challenger writes each turn from what it just saw, so it then composed its remaining turns around an error the assistant never produced — the run scored a bug that does not exist.
- The two numbers are coupled: this must exceed `deepagents_execution_timeout_seconds`, which a deployment can raise by env. **210** leaves headroom over the 150 in use, and the coupling is now documented next to the value.

One line of config plus the comment explaining why it cannot be lowered in isolation.