### PR TITLE
A want comes from the shopper, not from the assistant

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -61,6 +61,8 @@ from .turn_support import (
     RequestIdentity,
     _add_model_usage,
     _cart_size_issue,
+    _cart_line_size,
+    _cart_size_provenance_issue,
     _build_checkpointer,
     _cart_add_scope_failures,
     _cart_line_by_id,
@@ -1600,7 +1602,14 @@ class DeepAgentsRuntime:
                         "the new PRODUCT_REF before adding it."
                     )
                     continue
-                size_issue = _cart_size_issue(active_detail.product, size)
+                size_issue = _cart_size_issue(
+                    active_detail.product, size
+                ) or _cart_size_provenance_issue(
+                    size,
+                    request.get("size_stated_as"),
+                    state.query,
+                    _cart_line_size(state.cart, product.product_id),
+                )
                 if size_issue:
                     blocked.append(f"- PRODUCT_REF '{product_ref}': {size_issue}")
                     continue

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -62,6 +62,7 @@ from .turn_support import (
     _add_model_usage,
     _cart_size_issue,
     _cart_line_size,
+    _cart_quantity_provenance_issue,
     _cart_size_provenance_issue,
     _build_checkpointer,
     _cart_add_scope_failures,
@@ -1612,6 +1613,16 @@ class DeepAgentsRuntime:
                 )
                 if size_issue:
                     blocked.append(f"- PRODUCT_REF '{product_ref}': {size_issue}")
+                    continue
+                quantity_issue = _cart_quantity_provenance_issue(
+                    request["quantity"],
+                    request.get("quantity_stated_as"),
+                    state.query,
+                )
+                if quantity_issue:
+                    blocked.append(
+                        f"- PRODUCT_REF '{product_ref}': {quantity_issue}"
+                    )
                     continue
                 resolved.append(
                     (

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -1543,6 +1543,17 @@ class AddCartItemsToolItemInput(BaseModel):
             "the sizes differ per product and are in its details."
         ),
     )
+    size_stated_as: str | None = Field(
+        default=None,
+        max_length=200,
+        description=(
+            "The shopper's own words that gave this size, quoted from their "
+            "message -- 'size 8', 'in a 10 as well'. Required with a size "
+            "unless the same size is already on their cart line. A size they "
+            "did not ask for is not their size: when they have not said one, "
+            "leave both empty and ask."
+        ),
+    )
 
 
 @dataclass(frozen=True)
@@ -3772,6 +3783,7 @@ def _normalize_cart_add_tool_items(
                     if parsed.expected_display_name
                     else ""
                 ),
+                "size_stated_as": (parsed.size_stated_as or "").strip(),
             },
         )
         entry["quantity"] += quantity
@@ -3853,6 +3865,57 @@ def _same_product_display_name(expected: str, actual: str) -> bool:
 
 #: What the catalog carries for a product sold in exactly one size.
 _ONE_SIZE = "onesize"
+
+
+def _cart_line_size(cart: Any, product_id: str) -> str | None:
+    """The size already on this shopper's line for this product, if any."""
+
+    for line in getattr(cart, "contents", None) or []:
+        if not isinstance(line, dict):
+            continue
+        if str(line.get("product_id") or "") == product_id:
+            size = str(line.get("size") or "").strip()
+            if size:
+                return size
+    return None
+
+
+def _cart_size_provenance_issue(
+    size: str | None,
+    stated_as: str | None,
+    shopper_text: str,
+    cart_line_size: str | None,
+) -> str:
+    """Say why this size cannot be trusted, or "" if it can.
+
+    The gate below asks whether a size is present and sold. It cannot ask who
+    chose it, so a size the shopper never mentioned passed every check: "add
+    the Office A-line Dress" put a size 6 in the cart, and the shopper left the
+    conversation with three dresses and one they never asked for.
+
+    A size is a want, not a fact. The catalog says which sizes exist; only the
+    shopper says which one they want. So it comes from their words or from the
+    line already in their cart, and the model quotes them for it -- the same
+    move as expected_display_name, which states a claim the system can check
+    against its own record.
+
+    Not a search for size-like words in their message: that would match the 6
+    in $69.99. The quotation has to be theirs.
+    """
+
+    chosen = (size or "").strip()
+    if not chosen:
+        return ""
+    if cart_line_size and chosen.casefold() == cart_line_size.casefold():
+        return ""
+    quoted = " ".join((stated_as or "").split())
+    if quoted and quoted.casefold() in " ".join(shopper_text.split()).casefold():
+        return ""
+    return (
+        f"SIZE NOT ESTABLISHED: the shopper did not ask for a size {chosen}. "
+        "Ask which size they want, naming the sizes it is sold in, and add it "
+        "when they answer. Nothing was added."
+    )
 
 
 def _cart_size_issue(product: Any, size: str | None) -> str:

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -1525,6 +1525,15 @@ class AddCartItemsToolItemInput(BaseModel):
         ge=1,
         description="Quantity of this product to add.",
     )
+    quantity_stated_as: str | None = Field(
+        default=None,
+        max_length=200,
+        description=(
+            "The shopper's own words asking for more than one, quoted from "
+            "their message -- 'two of them', 'add 3'. Required above quantity "
+            "1. One is what 'add it' means; any more is a number they chose."
+        ),
+    )
     expected_display_name: str | None = Field(
         default=None,
         description=(
@@ -3784,6 +3793,7 @@ def _normalize_cart_add_tool_items(
                     else ""
                 ),
                 "size_stated_as": (parsed.size_stated_as or "").strip(),
+                "quantity_stated_as": (parsed.quantity_stated_as or "").strip(),
             },
         )
         entry["quantity"] += quantity
@@ -3867,6 +3877,38 @@ def _same_product_display_name(expected: str, actual: str) -> bool:
 _ONE_SIZE = "onesize"
 
 
+def _shopper_said(stated_as: str | None, shopper_text: str) -> bool:
+    """Whether these are really the shopper's words, from their own message."""
+
+    quoted = " ".join((stated_as or "").split())
+    return bool(
+        quoted and quoted.casefold() in " ".join(shopper_text.split()).casefold()
+    )
+
+
+def _cart_quantity_provenance_issue(
+    quantity: int,
+    stated_as: str | None,
+    shopper_text: str,
+) -> str:
+    """Say why this quantity cannot be trusted, or "" if it can.
+
+    The sibling of the size. "Add it" means one, so one needs nothing; any more
+    is a number the shopper chose, and a number they did not choose is theirs to
+    pay for. Nothing else guards it -- quantity is a plain integer on the tool,
+    where the size at least had to be sold by the catalog.
+    """
+
+    if quantity <= 1:
+        return ""
+    if _shopper_said(stated_as, shopper_text):
+        return ""
+    return (
+        f"QUANTITY NOT ESTABLISHED: the shopper did not ask for {quantity}. "
+        "Add one, or ask how many they want. Nothing was added."
+    )
+
+
 def _cart_line_size(cart: Any, product_id: str) -> str | None:
     """The size already on this shopper's line for this product, if any."""
 
@@ -3908,8 +3950,7 @@ def _cart_size_provenance_issue(
         return ""
     if cart_line_size and chosen.casefold() == cart_line_size.casefold():
         return ""
-    quoted = " ".join((stated_as or "").split())
-    if quoted and quoted.casefold() in " ".join(shopper_text.split()).casefold():
+    if _shopper_said(stated_as, shopper_text):
         return ""
     return (
         f"SIZE NOT ESTABLISHED: the shopper did not ask for a size {chosen}. "

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -221,3 +221,67 @@ class TestCartSizeGate:
         assert _cart_size_issue(self._product("2, 4, 6"), "4") == ""
         assert "SIZE REQUIRED" in _cart_size_issue(self._product("2, 4, 6"), None)
 
+
+
+class TestSizeProvenance:
+    """A size is a want, not a fact: only the shopper says which one."""
+
+    def _issue(self, **kw):
+        from chain_server.src.turn_support import _cart_size_provenance_issue
+
+        return _cart_size_provenance_issue(
+            kw.get("size", "8"),
+            kw.get("stated_as"),
+            kw.get("shopper_text", ""),
+            kw.get("cart_line_size"),
+        )
+
+    def test_a_size_nobody_asked_for_is_refused(self) -> None:
+        """The invented 6, recorded from a real conversation.
+
+        "add the Office A-line Dress to my cart" -- no size anywhere -- and the
+        reply was "now in your cart, 1 x size 6". Every check passed: 6 is a
+        real size for that dress, in range and in stock. The shopper left with
+        three dresses and $360 they never asked for.
+        """
+
+        issue = self._issue(size="6", shopper_text="add the Office A-line Dress")
+
+        assert "SIZE NOT ESTABLISHED" in issue
+        assert "Ask which size" in issue
+
+    def test_the_shoppers_own_words_are_enough(self) -> None:
+        assert self._issue(
+            size="8", stated_as="size 8", shopper_text="size 8"
+        ) == ""
+
+    def test_the_words_may_be_part_of_a_longer_message(self) -> None:
+        assert self._issue(
+            size="10",
+            stated_as="in a 10 as well",
+            shopper_text="actually add it in a 10 as well",
+        ) == ""
+
+    def test_a_quotation_the_shopper_never_said_is_refused(self) -> None:
+        """The only way past this is to invent a quote, and it is checked."""
+
+        assert "SIZE NOT ESTABLISHED" in self._issue(
+            size="6", stated_as="size 6", shopper_text="add the dress"
+        )
+
+    def test_the_size_already_on_their_line_needs_no_quote(self) -> None:
+        """Adding another of what they already have is not a new choice."""
+
+        assert self._issue(
+            size="8", shopper_text="add another one", cart_line_size="8"
+        ) == ""
+
+    def test_a_different_size_from_the_one_in_the_cart_still_needs_words(self) -> None:
+        assert "SIZE NOT ESTABLISHED" in self._issue(
+            size="10", shopper_text="add another one", cart_line_size="8"
+        )
+
+    def test_a_product_with_no_size_is_untouched(self) -> None:
+        """Bags, jewellery and sunglasses are onesize and ask nothing."""
+
+        assert self._issue(size=None, shopper_text="add the tote") == ""

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -285,3 +285,37 @@ class TestSizeProvenance:
         """Bags, jewellery and sunglasses are onesize and ask nothing."""
 
         assert self._issue(size=None, shopper_text="add the tote") == ""
+
+
+class TestQuantityProvenance:
+    """The sibling of the size: a number the shopper did not choose."""
+
+    def _issue(self, quantity, stated_as=None, shopper_text=""):
+        from chain_server.src.turn_support import (
+            _cart_quantity_provenance_issue,
+        )
+
+        return _cart_quantity_provenance_issue(quantity, stated_as, shopper_text)
+
+    def test_one_is_what_add_it_means(self) -> None:
+        """The ordinary add asks nothing and must stay free."""
+
+        assert self._issue(1, shopper_text="add it to my cart") == ""
+
+    def test_a_number_nobody_asked_for_is_refused(self) -> None:
+        """Quantity had no guard at all -- the size at least had to be sold."""
+
+        issue = self._issue(3, shopper_text="add the flats to my cart")
+
+        assert "QUANTITY NOT ESTABLISHED" in issue
+        assert "ask how many" in issue
+
+    def test_the_shoppers_own_words_are_enough(self) -> None:
+        assert self._issue(
+            2, stated_as="two of them", shopper_text="add two of them please"
+        ) == ""
+
+    def test_a_quantity_the_shopper_never_said_is_refused(self) -> None:
+        assert "QUANTITY NOT ESTABLISHED" in self._issue(
+            5, stated_as="five of them", shopper_text="add the flats"
+        )

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -8279,7 +8279,7 @@ class TestDeepAgentsRuntimeRefs:
         runtime._conversation_products = SimpleNamespace(
             resolve=lambda *_: _resolved_conversation_products(product, bag, dress)
         )
-        runtime._create_agent(State(user_id=111, query="add the dress in a size 4"), identity)
+        runtime._create_agent(State(user_id=111, query="add the dress in a size 4 and 3 of the flats"), identity)
         tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
         add_tool = tools_by_name["add_cart_items_tool"]
 
@@ -8348,6 +8348,7 @@ class TestDeepAgentsRuntimeRefs:
                     {
                         "product_ref": "prod_flats",
                         "quantity": 2,
+                        "quantity_stated_as": "3 of the flats",
                         "expected_display_name": "Felicity Flats",
                     },
                     {"product_ref": "missing", "quantity": 1},

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -8279,7 +8279,7 @@ class TestDeepAgentsRuntimeRefs:
         runtime._conversation_products = SimpleNamespace(
             resolve=lambda *_: _resolved_conversation_products(product, bag, dress)
         )
-        runtime._create_agent(State(user_id=111, query="hello"), identity)
+        runtime._create_agent(State(user_id=111, query="add the dress in a size 4"), identity)
         tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
         add_tool = tools_by_name["add_cart_items_tool"]
 
@@ -8315,10 +8315,27 @@ class TestDeepAgentsRuntimeRefs:
         )
         assert "not sold" in wrong_size
         assert added == []
-        sized = tool_text(
+        # A size with nothing behind it is refused now, whether or not the
+        # catalog sells it: "add the Office A-line Dress" put a size 6 in a
+        # cart nobody asked for, and every check passed because 6 was real.
+        unasked = tool_text(
             add_tool(
                 items=[
                     {"product_ref": "prod_dress", "quantity": 1, "size": "4"}
+                ]
+            )
+        )
+        assert "SIZE NOT ESTABLISHED" in unasked
+        assert added == []
+        sized = tool_text(
+            add_tool(
+                items=[
+                    {
+                        "product_ref": "prod_dress",
+                        "quantity": 1,
+                        "size": "4",
+                        "size_stated_as": "size 4",
+                    }
                 ]
             )
         )


### PR DESCRIPTION
A shopper said *"add the Office A-line Dress to my cart"* and the reply was *"now in your cart, 1 × size 6"*. They never named a size. They left with three dresses and $360 they had not asked for.

- **Nothing refused it.** `6` is a real size for that dress, in range and in stock. The gate could see that a size was present and sold — not that nobody chose it.
- **Where the 6 came from:** the search that found the dress returned its size list, `2, 4, 6, 8, 10, 12`. The model read *available* as *chosen*.
- **The catalog is authoritative about products; the shopper about what they want.** A size list and a quantity are facts about what is possible. Which size, and how many, are wants — and nothing enforced that direction.
- **A cart add now carries the shopper's own words** for the size and, above one, for the quantity. The runtime checks the quotation is really theirs.
- **A size already on their cart line needs no quote**, because adding another of what they have is not a new choice. Neither does quantity 1 — that is what "add it" means.
- **Nothing scans their message for size-like words.** That would match the `6` in `$69.99`. The model supplies the quotation; the system verifies it against the message.
- **The rule is not new.** The cart skill has said *"a size the shopper has not named for THIS purchase is not their size"* since the size work landed. It was prose, so it held for a day and then did not — exactly as the other half of that rule did before it was moved into code.

**Before**

> **Shopper:** add the Office A-line Dress to my cart
> **Assistant:** The Office A-line Dress is now in your cart — 1 × size 6 at $179.99.

**After**

> **Shopper:** add the Office A-line Dress to my cart
> **Assistant:** I can add The Office A-line Dress ($179.99), but it needs a size first. Which size: 2, 4, 6, 8, 10, or 12?
