### PR TITLE
A product the shopper only described is confirmed, not chosen

### DIFF
--- a/chain_server/src/conversation_products.py
+++ b/chain_server/src/conversation_products.py
@@ -218,11 +218,36 @@ class ConversationProductsClient:
             ) from exc
 
 
+#: Selectors that identify a product without the model choosing which one: the
+#: coordinates recorded when the products were shown -- which turn, which set,
+#: which position. A product_ref is deliberately not among them. The refs are
+#: printed into the prompt, so picking one out of four black dresses is the
+#: model choosing and then quoting itself, which is the move this exists to
+#: catch.
+_SYSTEM_SELECTORS = ("ordinal", "candidate_set_id", "turn_sequence")
+
+
+def _descriptor_value(descriptor: Any, name: str) -> Any:
+    if isinstance(descriptor, dict):
+        return descriptor.get(name)
+    return getattr(descriptor, name, None)
+
+
+def _identified_by_the_system(descriptor: Any) -> bool:
+    if descriptor is None:
+        return False
+    return any(
+        _descriptor_value(descriptor, name) is not None
+        for name in _SYSTEM_SELECTORS
+    )
+
+
 class ProductEvidence:
     """Products authorized for deterministic tools in the current turn."""
 
     def __init__(self, products: Iterable[ProductSummary] = ()) -> None:
         self._products = {product.product_id: product for product in products}
+        self._system_identified: set[str] = set()
 
     def add(self, products: Iterable[ProductSummary]) -> None:
         for product in products:
@@ -231,10 +256,29 @@ class ProductEvidence:
     def add_resolutions(
         self,
         resolutions: Iterable[ProductReferenceResolution],
+        descriptors: Iterable[Any] = (),
     ) -> None:
+        by_reference = {
+            _descriptor_value(descriptor, "reference_id"): descriptor
+            for descriptor in descriptors or ()
+        }
         for resolution in resolutions:
-            if resolution.status == "resolved" and len(resolution.matches) == 1:
-                self.add([resolution.matches[0].product])
+            if resolution.status != "resolved" or len(resolution.matches) != 1:
+                continue
+            product = resolution.matches[0].product
+            self.add([product])
+            # How the product was identified, not just that it was. A ref the
+            # system minted, or a position it recorded, is the system picking
+            # the product. A display name is the model asserting one -- which is
+            # right when the shopper said the name and wrong when they said
+            # "the black one" and the model chose which black one they meant.
+            if _identified_by_the_system(by_reference.get(resolution.reference_id)):
+                self._system_identified.add(product.product_id)
+
+    def identified_by_the_system(self, product_ref: str) -> bool:
+        """Whether the record picked this product, rather than the model."""
+
+        return (product_ref or "").strip() in self._system_identified
 
     def get(self, product_ref: str) -> ProductSummary | None:
         return self._products.get((product_ref or "").strip())

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -63,6 +63,9 @@ from .turn_support import (
     _cart_size_issue,
     _cart_line_size,
     _cart_quantity_provenance_issue,
+    _cart_product_provenance_issue,
+    _most_recently_shown,
+    _shopper_words_this_conversation,
     _cart_size_provenance_issue,
     _build_checkpointer,
     _cart_add_scope_failures,
@@ -1432,7 +1435,7 @@ class DeepAgentsRuntime:
                     "REFERENCE RESOLUTION UNAVAILABLE: Ask which earlier product "
                     "the shopper means; do not guess or search for a substitute."
                 )
-            scope.product_evidence.add_resolutions(result.results)
+            scope.product_evidence.add_resolutions(result.results, references)
             for resolution in result.results:
                 if resolution.status != "resolved":
                     continue
@@ -1508,19 +1511,20 @@ class DeepAgentsRuntime:
             def _resolve_from_conversation_index(product_ref: str):
                 """Look one ref up in the conversation's durable product index."""
 
+                descriptors = [
+                    ProductReferenceDescriptor(
+                        reference_id="cart-add",
+                        product_ref=product_ref,
+                    )
+                ]
                 try:
                     result = self._conversation_products.resolve(
                         identity.conversation_id,
-                        [
-                            ProductReferenceDescriptor(
-                                reference_id="cart-add",
-                                product_ref=product_ref,
-                            )
-                        ],
+                        descriptors,
                     )
                 except (ConversationProductsError, ValidationError):
                     return None
-                scope.product_evidence.add_resolutions(result.results)
+                scope.product_evidence.add_resolutions(result.results, descriptors)
                 return scope.product_evidence.get(product_ref)
 
             resolved: list[tuple[str, ProductSummary, int]] = []
@@ -1606,9 +1610,10 @@ class DeepAgentsRuntime:
                 size_issue = _cart_size_issue(
                     active_detail.product, size
                 ) or _cart_size_provenance_issue(
+                    active_detail.product,
                     size,
                     request.get("size_stated_as"),
-                    state.query,
+                    _shopper_words_this_conversation(state),
                     _cart_line_size(state.cart, product.product_id),
                 )
                 if size_issue:
@@ -1617,11 +1622,22 @@ class DeepAgentsRuntime:
                 quantity_issue = _cart_quantity_provenance_issue(
                     request["quantity"],
                     request.get("quantity_stated_as"),
-                    state.query,
+                    _shopper_words_this_conversation(state),
                 )
                 if quantity_issue:
                     blocked.append(
                         f"- PRODUCT_REF '{product_ref}': {quantity_issue}"
+                    )
+                    continue
+                product_issue = _cart_product_provenance_issue(
+                    active_detail.product,
+                    _shopper_words_this_conversation(state),
+                    scope.product_evidence,
+                    _most_recently_shown(state),
+                )
+                if product_issue:
+                    blocked.append(
+                        f"- PRODUCT_REF '{product_ref}': {product_issue}"
                     )
                     continue
                 resolved.append(

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -30,6 +30,8 @@ import os
 from pathlib import Path
 import re
 from collections.abc import Sequence
+from difflib import SequenceMatcher
+from types import SimpleNamespace
 from typing import Any, Literal
 import unicodedata
 import uuid
@@ -3799,6 +3801,12 @@ def _normalize_cart_add_tool_items(
         entry["quantity"] += quantity
         if not entry["expected_display_name"] and parsed.expected_display_name:
             entry["expected_display_name"] = parsed.expected_display_name.strip()
+        # Merged items share one entry, so a quotation on any of them is the
+        # quotation for the size or quantity they merged into. Keeping only the
+        # first item's dropped a later one that carried the shopper's words.
+        for field in ("size_stated_as", "quantity_stated_as"):
+            if not entry[field] and getattr(parsed, field, None):
+                entry[field] = str(getattr(parsed, field)).strip()
     return normalized
 
 
@@ -3877,12 +3885,227 @@ def _same_product_display_name(expected: str, actual: str) -> bool:
 _ONE_SIZE = "onesize"
 
 
-def _shopper_said(stated_as: str | None, shopper_text: str) -> bool:
-    """Whether these are really the shopper's words, from their own message."""
+#: The value, written the other way. Numbers only: a quantity of two is the
+#: same want whether the shopper typed it as a word or a digit.
+_SPELLED_NUMBERS = {
+    "1": "one", "2": "two", "3": "three", "4": "four", "5": "five",
+    "6": "six", "7": "seven", "8": "eight", "9": "nine", "10": "ten",
+    "11": "eleven", "12": "twelve",
+}
 
-    quoted = " ".join((stated_as or "").split())
-    return bool(
-        quoted and quoted.casefold() in " ".join(shopper_text.split()).casefold()
+
+def _shopper_words_this_conversation(state: Any) -> str:
+    """Everything the shopper has actually typed, this turn and before.
+
+    A size settled one turn ago -- "do you have it in a 6?" answered, then "yes,
+    add it" -- is established in the conversation and quotable from it. Reading
+    only the current message refused adds for sizes the shopper had already
+    given, which is the failure the cart reference had before it learned to look
+    further back than this turn.
+    """
+
+    parts = [str(getattr(state, "query", "") or "")]
+    for turn in getattr(state, "dialogue", None) or []:
+        text = getattr(turn, "shopper_text", "")
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts)
+
+
+def _shopper_said(stated_as: str | None, shopper_text: str, value: str) -> bool:
+    """Whether the shopper really said this, for this value.
+
+    Two checks, because either alone lets the wrong thing through. The words
+    must be theirs, or the model authorises itself. And the words must carry
+    the value they authorise: "3 of the flats" is a real quotation and it does
+    not say two, yet it opened the gate for a quantity of two.
+    """
+
+    quoted = " ".join((stated_as or "").split()).casefold()
+    wanted = " ".join((value or "").split()).casefold()
+    if not quoted or not wanted:
+        return False
+    # Shoppers write numbers both ways -- "add two of them" is as ordinary as
+    # "add 2". Only the value is spelled out here, never anything about intent.
+    spelled = _SPELLED_NUMBERS.get(wanted)
+    if wanted not in quoted and not (spelled and spelled in quoted):
+        return False
+    return quoted in " ".join(shopper_text.split()).casefold()
+
+
+#: A word carries no identifying weight below this, and the short ones collide
+#: with ordinary sentences: "the" and "a" both belong to "The Office A-line
+#: Dress" and to "add the black one in a 2", which is how a navy dress was
+#: fitted to a request for a black one.
+_MIN_NAMING_WORD = 4
+#: How close a shopper's word has to be to a product's. Absorbs a typo or a
+#: missing plural without inventing a match: "ofice" is 0.91 against "office".
+_NAMING_LIKENESS = 0.85
+#: A fit has to be worth something, and it has to be clearly better than the
+#: next one. The margin is what protects the shopper: a threshold alone always
+#: has a best candidate, and picking the best of two near-equals is the silent
+#: choice this exists to prevent.
+_NAMING_FLOOR = 0.25
+_NAMING_MARGIN = 0.20
+
+
+def _products_the_shopper_fits(
+    shopper_text: str,
+    candidates: Sequence[Any],
+) -> list[Any]:
+    """Which of these products the shopper's words could be pointing at.
+
+    One question, so a second implementation can answer it later without moving
+    the rule that uses it: exactly one fit resolves, anything else is asked
+    about. Today the reading is lexical; a semantic one would score the same
+    candidates the same way and still never pick.
+
+    Words are weighted by how many of the candidates use them, read off the
+    candidates rather than a list of stop words: among four dresses "dress"
+    says nothing and "vivienne" says everything, and among four bags it is the
+    other way round. Two black dresses make "black" worth half, which is why
+    "the black one" cannot settle between them.
+
+    Comparison is by likeness rather than equality, so "the Ofice dress" and
+    "the Office dress" both land on the same product where whole-name matching
+    refused them, and words that match nothing are simply ignored.
+
+    The decision is the gap to the next candidate, not the score. A score alone
+    always has a winner; a gap is the difference between "this is the one" and
+    "it could be either", and only the first should reach a cart.
+    """
+
+    def words(value: str) -> list[str]:
+        return [
+            word
+            for word in _normalize_product_name(value).split()
+            if len(word) >= _MIN_NAMING_WORD
+        ]
+
+    per_candidate = [words(candidate.display_name) for candidate in candidates]
+    shared: dict[str, int] = {}
+    for names in per_candidate:
+        for word in set(names):
+            shared[word] = shared.get(word, 0) + 1
+    said = words(shopper_text)
+
+    scored: list[tuple[float, Any]] = []
+    for candidate, names in zip(candidates, per_candidate):
+        total = sum(1 / shared[word] for word in names)
+        if not total:
+            continue
+        matched = sum(
+            1 / shared[word]
+            for word in names
+            if any(
+                SequenceMatcher(None, word, spoken).ratio() >= _NAMING_LIKENESS
+                for spoken in said
+            )
+        )
+        scored.append((matched / total, candidate))
+
+    scored.sort(key=lambda entry: entry[0], reverse=True)
+    if not scored:
+        return []
+    best_score, best = scored[0]
+    runner_up = scored[1][0] if len(scored) > 1 else 0.0
+    if best_score < _NAMING_FLOOR or best_score - runner_up < _NAMING_MARGIN:
+        return []
+    return [best]
+
+
+def _most_recently_shown(state: Any) -> list[dict]:
+    """The last set of products put in front of the shopper."""
+
+    sets = [
+        entry
+        for entry in (getattr(state, "historical_product_sets", None) or [])
+        if isinstance(entry, dict) and isinstance(entry.get("products"), list)
+    ]
+    if not sets:
+        return []
+    newest = max(sets, key=lambda entry: entry.get("turn_seq") or 0)
+    return [item for item in newest["products"] if isinstance(item, dict)]
+
+
+def _reference_candidates(
+    evidence: ProductEvidence,
+    recently_shown: Sequence[Any] = (),
+) -> list[Any]:
+    """The products a reference in this turn could be pointing at."""
+
+    candidates = list(evidence.values())
+    seen = {candidate.product_id for candidate in candidates}
+    for entry in recently_shown or ():
+        ref = entry.get("ref") if isinstance(entry, dict) else None
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if not ref or not name or ref in seen:
+            continue
+        seen.add(ref)
+        candidates.append(SimpleNamespace(product_id=ref, display_name=name))
+    return candidates
+
+
+def _cart_product_provenance_issue(
+    product: Any,
+    shopper_text: str,
+    evidence: ProductEvidence,
+    recently_shown: Sequence[Any] = (),
+) -> str:
+    """Say why this product cannot be trusted as the one meant, or "" if it can.
+
+    A shopper shown four black dresses says "add the black one in a 2", and the
+    assistant picks one. Every other check passes: the ref was really
+    established, the name matches that ref, the size is sold and they did say
+    "in a 2". The reference resolved correctly to the wrong product -- half the
+    runs of one demo script reached fourteen turns back for a navy dress.
+
+    Which product a description means is a judgement, and the model makes it.
+    What can be checked is whether anything confirmed it:
+
+    - the shopper named the product, in the words they actually used
+    - the record picked it, from a ref or the coordinates of a showing
+    - there was only one product it could have been
+
+    None of those, and the model chose between products it was shown without
+    saying so, which is the one thing it must not do silently.
+
+    Naming is read off the shopper's own message rather than a quotation the
+    model supplies, so there is nothing to fabricate and no optional field to
+    forget. The reading is the catalog-name matching this module already does
+    for the same purpose -- names found inside a sentence, so "add the
+    Southwest Bracelet" names one.
+    """
+
+    # What the shopper could plausibly have meant: what this turn established,
+    # and what they were last shown. Counting only this turn's evidence made
+    # the check vanish exactly when the model had already narrowed to one --
+    # four black dresses were on screen, the model resolved one of them, and
+    # with a single candidate there was nothing left to be ambiguous against.
+    candidates = _reference_candidates(evidence, recently_shown)
+    if len(candidates) <= 1:
+        return ""
+    # Named, not uniquely named: "add the dress and the bag" names two, and
+    # each is still the shopper's own choice. What must never pass is a product
+    # they named nothing about.
+    fits = _products_the_shopper_fits(shopper_text, candidates)
+    if len(fits) == 1 and fits[0].product_id == product.product_id:
+        return ""
+    if _explicitly_named_products(shopper_text, candidates):
+        # A full catalog name is naming even when several are named at once:
+        # "add the dress and the bag" is two choices, both the shopper's.
+        if any(
+            match.product_id == product.product_id
+            for match in _explicitly_named_products(shopper_text, candidates)
+        ):
+            return ""
+    if evidence.identified_by_the_system(product.product_id):
+        return ""
+    return (
+        f"PRODUCT NOT ESTABLISHED: the shopper did not name "
+        f"'{product.display_name}', and {len(candidates)} products are in play "
+        "this turn. Ask which one they mean, naming them, and add it when they "
+        "answer. Nothing was added."
     )
 
 
@@ -3901,7 +4124,7 @@ def _cart_quantity_provenance_issue(
 
     if quantity <= 1:
         return ""
-    if _shopper_said(stated_as, shopper_text):
+    if _shopper_said(stated_as, shopper_text, str(quantity)):
         return ""
     return (
         f"QUANTITY NOT ESTABLISHED: the shopper did not ask for {quantity}. "
@@ -3923,6 +4146,7 @@ def _cart_line_size(cart: Any, product_id: str) -> str | None:
 
 
 def _cart_size_provenance_issue(
+    product: Any,
     size: str | None,
     stated_as: str | None,
     shopper_text: str,
@@ -3936,21 +4160,26 @@ def _cart_size_provenance_issue(
     conversation with three dresses and one they never asked for.
 
     A size is a want, not a fact. The catalog says which sizes exist; only the
-    shopper says which one they want. So it comes from their words or from the
-    line already in their cart, and the model quotes them for it -- the same
-    move as expected_display_name, which states a claim the system can check
-    against its own record.
+    shopper says which one they want. So it comes from their words, from the
+    line already in their cart, or it is asked for.
 
-    Not a search for size-like words in their message: that would match the 6
-    in $69.99. The quotation has to be theirs.
+    Not a search of their message for size-like words: that would match the 6 in
+    $69.99. The model quotes them, and the quotation has to be theirs and has to
+    carry the size it authorises.
     """
 
     chosen = (size or "").strip()
     if not chosen:
         return ""
+    advertised = _advertised_sizes(product)
+    if not advertised or advertised == [_ONE_SIZE]:
+        # The catalog sells this in one size or states none. Nobody chose it,
+        # and asking a shopper what size handbag they want is worse than not
+        # asking -- the same carve-out the sold-size gate makes.
+        return ""
     if cart_line_size and chosen.casefold() == cart_line_size.casefold():
         return ""
-    if _shopper_said(stated_as, shopper_text):
+    if _shopper_said(stated_as, shopper_text, chosen):
         return ""
     return (
         f"SIZE NOT ESTABLISHED: the shopper did not ask for a size {chosen}. "

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -227,9 +227,16 @@ class TestSizeProvenance:
     """A size is a want, not a fact: only the shopper says which one."""
 
     def _issue(self, **kw):
+        from types import SimpleNamespace
+
         from chain_server.src.turn_support import _cart_size_provenance_issue
 
+        product = SimpleNamespace(
+            display_name="A Dress",
+            attributes={"sizes": kw.get("sizes", ["2", "4", "6", "8", "10"])},
+        )
         return _cart_size_provenance_issue(
+            product,
             kw.get("size", "8"),
             kw.get("stated_as"),
             kw.get("shopper_text", ""),
@@ -319,3 +326,229 @@ class TestQuantityProvenance:
         assert "QUANTITY NOT ESTABLISHED" in self._issue(
             5, stated_as="five of them", shopper_text="add the flats"
         )
+
+
+class TestProductProvenance:
+    """Which product a description means is a judgement; something must confirm it."""
+
+    def _product(self, ref="d0", name="Belle Noir Satin Gown"):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(product_id=ref, display_name=name)
+
+    def _dresses(self, n=4):
+        names = [
+            "Belle Noir Satin Gown",
+            "Black Satin Lace-Up Dress",
+            "Vivienne Lace Dress",
+            "Black Polka-Dotted Slip Dress",
+        ]
+        return [self._product(f"d{i}", names[i]) for i in range(n)]
+
+    def _evidence(self, *products, system_identified=()):
+        class _Evidence:
+            def values(self_inner):
+                return products
+
+            def identified_by_the_system(self_inner, ref):
+                return ref in system_identified
+
+        return _Evidence()
+
+    def _issue(self, **kw):
+        from chain_server.src.turn_support import (
+            _cart_product_provenance_issue,
+        )
+
+        return _cart_product_provenance_issue(
+            kw.get("product") or self._product(),
+            kw.get("shopper_text", ""),
+            kw["evidence"],
+            kw.get("recently_shown", ()),
+        )
+
+    def test_a_partial_name_is_still_a_naming(self) -> None:
+        """Shoppers shorten names, and a run of the name cannot be said by chance.
+
+        "the A line dress" carries 'a line' from The Office A-line Dress and
+        from no other candidate. Requiring the whole name refused the commonest
+        correct add; matching scattered words fitted a navy dress to "the black
+        one in a 2", because 'the' and 'a' belong to that name and to ordinary
+        sentences alike.
+        """
+
+        for words in (
+            "add the A line dress in a 2",
+            "A line dress please",
+            "add the Office dress",
+        ):
+            assert self._issue(
+                product=self._product("d4", "The Office A-line Dress"),
+                shopper_text=words,
+                evidence=self._evidence(
+                    self._product("d4", "The Office A-line Dress"),
+                    *self._dresses(4),
+                ),
+            ) == "", words
+
+    def test_ordinary_words_of_a_name_are_not_a_naming(self) -> None:
+        """'the' and 'a' belong to the name and to the sentence around it."""
+
+        assert "PRODUCT NOT ESTABLISHED" in self._issue(
+            product=self._product("d4", "The Office A-line Dress"),
+            shopper_text="add the black one in a 2",
+            evidence=self._evidence(
+                self._product("d4", "The Office A-line Dress"),
+                *self._dresses(4),
+            ),
+        )
+
+    def test_a_shortened_or_misspelt_name_still_names(self) -> None:
+        """Shoppers shorten names and mistype them, and still mean one product.
+
+        Whole-name matching refused "add the Southwest Bracelet" because the
+        catalog calls it "Southwest Bracelet"; a word-run rule then refused
+        "the noir one" because 'noir' is four letters. Likeness with a margin
+        takes both, and takes a typo with them.
+        """
+
+        for words in (
+            "add the A line dress in a 2",
+            "add the Office dress",
+            "add the Ofice dress",
+            "A line dress please",
+        ):
+            assert self._issue(
+                product=self._product("d4", "The Office A-line Dress"),
+                shopper_text=words,
+                evidence=self._evidence(
+                    self._product("d4", "The Office A-line Dress"),
+                    *self._dresses(4),
+                ),
+            ) == "", words
+
+    def test_the_last_products_shown_are_candidates_too(self) -> None:
+        """The check must not vanish because the model already narrowed.
+
+        Four black dresses were on screen. The model resolved one of them, so
+        this turn's evidence held a single product, nothing was ambiguous
+        against it, and the add went through silently -- the whole failure,
+        surviving the gate built to stop it.
+        """
+
+        issue = self._issue(
+            product=self._product("d1", "Black Satin Lace-Up Dress"),
+            shopper_text="add the black one in a size 8",
+            evidence=self._evidence(self._product("d1", "Black Satin Lace-Up Dress")),
+            recently_shown=[
+                {"ref": "d1", "name": "Black Satin Lace-Up Dress"},
+                {"ref": "d3", "name": "Black Polka-Dotted Slip Dress"},
+            ],
+        )
+
+        assert "PRODUCT NOT ESTABLISHED" in issue
+
+    def test_short_words_of_a_name_do_not_name_it(self) -> None:
+        """'the' and 'a' are part of the name and of every other sentence.
+
+        Counting them, "add the black one in a 2" fitted The Office A-line
+        Dress on 'the' and 'a' alone -- a navy dress, from fourteen turns
+        earlier, for a request about a black one.
+        """
+
+        assert "PRODUCT NOT ESTABLISHED" in self._issue(
+            product=self._product("d4", "The Office A-line Dress"),
+            shopper_text="add the black one in a 2",
+            evidence=self._evidence(
+                self._product("d4", "The Office A-line Dress"),
+                *self._dresses(4),
+            ),
+        )
+
+    def test_two_near_equal_candidates_are_asked_about(self) -> None:
+        """The margin, not the score, is what protects the shopper.
+
+        "the black one" fits two black dresses about equally. A threshold would
+        still have a best of the two and would add it -- which is exactly what
+        happened, fourteen turns from where the shopper was looking.
+        """
+
+        assert "PRODUCT NOT ESTABLISHED" in self._issue(
+            product=self._product("d1", "Black Satin Lace-Up Dress"),
+            shopper_text="add the black one in a 2",
+            evidence=self._evidence(*self._dresses(4)),
+        )
+
+    def test_a_shared_word_does_not_dilute_a_distinct_one(self) -> None:
+        """"the black polka dotted one" says black twice over and polka once.
+
+        Without discarding runs that two names share, 'black' would fit two
+        dresses, the count would be two, and a request that names one product
+        plainly would be answered with a question.
+        """
+
+        assert self._issue(
+            product=self._product("d3", "Black Polka-Dotted Slip Dress"),
+            shopper_text="add the black polka dotted one",
+            evidence=self._evidence(*self._dresses(4)),
+        ) == ""
+
+    def test_a_run_shared_by_two_candidates_is_refused(self) -> None:
+        """"the satin one" is a run of two names, so it names neither."""
+
+        assert "PRODUCT NOT ESTABLISHED" in self._issue(
+            product=self._product("d0", "Belle Noir Satin Gown"),
+            shopper_text="add the satin one in a 2",
+            evidence=self._evidence(*self._dresses(4)),
+        )
+
+    def test_a_description_that_fits_several_is_refused(self) -> None:
+        """The silent pick, recorded from the demo script.
+
+        Four black dresses had been shown. "add the black one in a 2" resolved
+        to a navy dress from fourteen turns earlier, and every check passed:
+        the ref was established, the name matched the ref, the size was sold
+        and the shopper really had said "in a 2".
+        """
+
+        issue = self._issue(
+            shopper_text="add the black one in a 2",
+            evidence=self._evidence(*self._dresses()),
+        )
+
+        assert "PRODUCT NOT ESTABLISHED" in issue
+        assert "Ask which one" in issue
+
+    def test_the_shopper_naming_it_is_enough(self) -> None:
+        assert self._issue(
+            shopper_text="add the Belle Noir Satin Gown in a 2",
+            evidence=self._evidence(*self._dresses()),
+        ) == ""
+
+    def test_a_name_they_never_said_is_not_a_naming(self) -> None:
+        """Otherwise the quotation is the model's word for its own choice."""
+
+        assert "PRODUCT NOT ESTABLISHED" in self._issue(
+            shopper_text="add the black one",
+            evidence=self._evidence(*self._dresses()),
+        )
+
+    def test_the_record_picking_it_is_enough(self) -> None:
+        """"that first one" is turn 2 of the 13-turn script.
+
+        The words name nothing, but the shopper gave a position and the record
+        resolved it. The system picked the product, not the model.
+        """
+
+        assert self._issue(
+            shopper_text="do you have that first one in a size 6",
+            evidence=self._evidence(*self._dresses(), system_identified={"d0"}),
+        ) == ""
+
+    def test_one_candidate_needs_no_words(self) -> None:
+        """"add it" after a single product is unambiguous whatever they said."""
+
+        assert self._issue(
+            shopper_text="add it",
+            evidence=self._evidence(self._product()),
+        ) == ""

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -7785,6 +7785,142 @@ class TestDeepAgentsRuntimeRefs:
         )
         assert "ALREADY ESTABLISHED THIS TURN" not in mixed
 
+    def test_a_product_the_shopper_only_described_is_not_added(
+        self,
+        base_config,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The silent pick, through the tool that would have committed it.
+
+        Four black dresses shown; "add the black one" resolved to one of them
+        and every other check passed. Naming none of them, and with the record
+        having picked none of them, the model chose -- which is the one thing it
+        must not do without saying so.
+        """
+
+        from chain_server.src import deepagents_runtime as runtime_mod
+        from chain_server.src import turn_support as runtime_mod_support
+
+        captured: Dict[str, Any] = {}
+        deepagents_mod = ModuleType("deepagents")
+        tools_mod = ModuleType("langchain_core.tools")
+        openai_mod = ModuleType("langchain_openai")
+
+        class FakeProfile:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        class FakeChatOpenAI:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        def fake_tool(*, args_schema=None, return_direct: bool = False, **_kw):
+            def decorate(fn):
+                fn.args_schema = args_schema
+                fn.return_direct = return_direct
+                return fn
+
+            return decorate
+
+        deepagents_mod.GeneralPurposeSubagentProfile = FakeProfile
+        deepagents_mod.HarnessProfile = FakeProfile
+        deepagents_mod.create_deep_agent = lambda **kwargs: (
+            captured.update(kwargs) or SimpleNamespace()
+        )
+        deepagents_mod.register_harness_profile = lambda *args, **kwargs: None
+        tools_mod.tool = fake_tool
+        openai_mod.ChatOpenAI = FakeChatOpenAI
+        monkeypatch.setitem(sys.modules, "deepagents", deepagents_mod)
+        monkeypatch.setitem(sys.modules, "langchain_core.tools", tools_mod)
+        monkeypatch.setitem(sys.modules, "langchain_openai", openai_mod)
+
+        gown = ProductSummary(
+            product_id="prod_gown",
+            display_name="Belle Noir Satin Gown",
+            price=Money(amount=129.99),
+        )
+        lace = ProductSummary(
+            product_id="prod_lace",
+            display_name="Vivienne Lace Dress",
+            price=Money(amount=169.99),
+        )
+        monkeypatch.setattr(
+            runtime_mod,
+            "execute_catalog_search",
+            lambda plan, url, **kw: SimpleNamespace(
+                result=SearchCatalogResult(ok=True, products=[gown, lace]),
+                fallback_attempted=False,
+                fallback_used=False,
+            ),
+        )
+        monkeypatch.setattr(
+            runtime_mod,
+            "get_product_details",
+            lambda request, *a, **k: GetProductDetailsResult(
+                ok=True,
+                product=ProductDetail.model_validate(
+                    (gown if request.product_id == "prod_gown" else lace).model_dump()
+                ),
+            ),
+        )
+        added: list[Any] = []
+        monkeypatch.setattr(
+            runtime_mod,
+            "add_cart_item",
+            lambda request, memory_port: added.append(request)
+            or CartMutationResult(ok=True, message="ok"),
+        )
+
+        runtime = runtime_mod.DeepAgentsRuntime(base_config)
+        runtime._read_cart = lambda user_id: Cart(contents=[])
+        runtime._catalog_capabilities = SimpleNamespace(
+            get=lambda **_: CatalogCapabilities(
+                catalog_id="fashion", retrieval_modes=["text"], filters={}
+            )
+        )
+        identity = runtime_mod_support.RequestIdentity(
+            session_id="session-a",
+            conversation_id="conversation-a",
+            cart_id="cart-a",
+            context_user_id=111,
+            cart_user_id=222,
+            request_id="request-a",
+        )
+        runtime._conversation_products = SimpleNamespace(
+            resolve=lambda *_: ResolveConversationProductsResult(
+                results=[
+                    ProductReferenceResolution(
+                        reference_id="black_one",
+                        status="not_found",
+                        matches=[],
+                        match_count=0,
+                        blocking_field=None,
+                    )
+                ]
+            )
+        )
+        runtime._create_agent(
+            State(user_id=111, query="add the black one"), identity
+        )
+        tools = {fn.__name__: fn for fn in captured["tools"]}
+        # Two products enter this turn by search, so the record picked neither.
+        tool_text(
+            tools["resolve_conversation_products_tool"](
+                references=[
+                    {"reference_id": "black_one", "display_name": "the black one"}
+                ]
+            )
+        )
+
+        response = tool_text(
+            tools["add_cart_items_tool"](
+                items=[{"product_ref": "prod_gown", "quantity": 1}]
+            )
+        )
+
+        assert "PRODUCT NOT ESTABLISHED" in response
+        assert added == []
+
     def test_a_product_never_shown_is_looked_up_in_the_catalog(
         self,
         base_config,
@@ -8279,7 +8415,7 @@ class TestDeepAgentsRuntimeRefs:
         runtime._conversation_products = SimpleNamespace(
             resolve=lambda *_: _resolved_conversation_products(product, bag, dress)
         )
-        runtime._create_agent(State(user_id=111, query="add the dress in a size 4 and 3 of the flats"), identity)
+        runtime._create_agent(State(user_id=111, query="add The Office A-line Dress in a size 4, 3 of the flats Felicity Flats and the Work Bag and the black one"), identity)
         tools_by_name = {fn.__name__: fn for fn in captured["tools"]}
         add_tool = tools_by_name["add_cart_items_tool"]
 
@@ -8342,6 +8478,7 @@ class TestDeepAgentsRuntimeRefs:
         assert "SIZE REQUIRED" not in sized
         assert len(added) == 1
         added.clear()
+
         added_response = tool_text(
             add_tool(
                 items=[
@@ -8489,8 +8626,12 @@ class TestDeepAgentsRuntimeRefs:
         )
 
         assert added == []
-        assert "outside the current explicit add request" in blocked_response
-        assert "Luminous Lace Blouse Sweater" in blocked_response
+        # Refused either way: the shopper did not name it, and it was not part
+        # of the explicit request. The provenance gate reaches it first.
+        assert (
+            "PRODUCT NOT ESTABLISHED" in blocked_response
+            or "outside the current explicit add request" in blocked_response
+        )
         assert "Green Meadow Sweater Top" in blocked_response
 
         mismatch_response = tool_text(


### PR DESCRIPTION
Shown four black dresses, a shopper says *"add the black one in a 2"* — and the assistant picks one. Half the runs of the demo script reached fourteen turns back for a **navy** dress and added it silently.

- **Every check already passed.** The ref was established, the name matched the ref, the size was sold, and the shopper really had said "in a 2". The reference resolved correctly to the wrong product.
- **An add now asks what confirmed the choice:** the shopper named the product, the record picked it from the coordinates of a showing, or there was only one it could have been. None of those, and the assistant asks which one.
- **Naming is read from the shopper's own message** — nothing for the model to quote, nothing optional to forget.
- **Words are weighted by how many candidates use them**, read off the candidates rather than a stop-word list: among four dresses "dress" says nothing and "vivienne" says everything, and two black dresses make "black" worth half.
- **Comparison is by likeness**, so *"the Ofice dress"* lands where *"the Office dress"* does.
- **The decision is the gap to the next candidate, not the score.** A score alone always has a winner; picking the better of two near-equals is the silent choice this exists to prevent.
- **Also fixes four faults in the merged size and quantity gates:** the leading article defeated naming; the cart-line exemption was dead; a size settled in an earlier turn could not be quoted; and a one-size handbag was asked what size it should be.

**Before**

> **Shopper:** add the black one in a 2
> **Assistant:** Added The Office A-line Dress (size 2) to your cart.

**After**

> **Shopper:** add the black one in a 2
> **Assistant:** Which "black one" would you like me to add in a 2?
> 1) Black Satin Lace-Up Dress  2) Black Polka-Dotted Slip Dress  3) Vivienne Lace Dress

---

*The four constants in the matcher are fitted to one catalog and about a dozen phrasings. The margin is the principle; the numbers are not, and a catalog with short distinguishing words — "tan", "red" — would need them revisited.*
