### PR TITLE
A refusal tells the model which product it refused, and what it may offer instead

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1623,6 +1623,7 @@ class DeepAgentsRuntime:
                     request["quantity"],
                     request.get("quantity_stated_as"),
                     _shopper_words_this_conversation(state),
+                    active_detail.product,
                 )
                 if quantity_issue:
                     blocked.append(

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -4113,6 +4113,7 @@ def _cart_quantity_provenance_issue(
     quantity: int,
     stated_as: str | None,
     shopper_text: str,
+    product: Any = None,
 ) -> str:
     """Say why this quantity cannot be trusted, or "" if it can.
 
@@ -4126,9 +4127,13 @@ def _cart_quantity_provenance_issue(
         return ""
     if _shopper_said(stated_as, shopper_text, str(quantity)):
         return ""
+    # Named for the same reason a size refusal is: a batch refusal the model
+    # cannot attribute to an item becomes a confident guess in the reply.
+    named = getattr(product, "display_name", "") if product is not None else ""
+    subject = f" for '{named}'" if named else ""
     return (
-        f"QUANTITY NOT ESTABLISHED: the shopper did not ask for {quantity}. "
-        "Add one, or ask how many they want. Nothing was added."
+        f"QUANTITY NOT ESTABLISHED{subject}: the shopper did not ask for "
+        f"{quantity}. Add one, or ask how many they want. Nothing was added."
     )
 
 
@@ -4181,10 +4186,18 @@ def _cart_size_provenance_issue(
         return ""
     if _shopper_said(stated_as, shopper_text, chosen):
         return ""
+    # The product and its sizes travel with the refusal. Told only that a size
+    # was not established, and addressed by a PRODUCT_REF, the model had to work
+    # out which of two items had failed and what it could offer instead -- and
+    # got both wrong: it told a shopper size 6 was not sold for a boot sold in
+    # 5, 6, 7, 8, and blamed the item whose size had been stated correctly.
+    # Asking it to name "the sizes it is sold in" without supplying them is the
+    # same error in miniature.
     return (
-        f"SIZE NOT ESTABLISHED: the shopper did not ask for a size {chosen}. "
-        "Ask which size they want, naming the sizes it is sold in, and add it "
-        "when they answer. Nothing was added."
+        f"SIZE NOT ESTABLISHED for '{product.display_name}': the shopper did "
+        f"not ask for a size {chosen}. It is sold in {', '.join(advertised)}. "
+        "Ask which of those they want and add it when they answer. Nothing was "
+        "added."
     )
 
 

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -243,6 +243,24 @@ class TestSizeProvenance:
             kw.get("cart_line_size"),
         )
 
+    def test_a_refusal_names_the_product_and_the_sizes_it_sells(self) -> None:
+        """Told only that a size was not established, the model guessed twice.
+
+        A shopper answered "Sweater: M and Boots: 6" -- a format the assistant
+        itself had offered. The model turned M into 6 and the gate refused it,
+        correctly. But the refusal named no product and listed no sizes, so the
+        model attributed the failure to the boots and told the shopper size 6
+        was not sold for a boot the catalog sells in 5, 6, 7 and 8.
+
+        The refusal has to carry what the next sentence needs.
+        """
+
+        issue = self._issue(size="6", stated_as="Sweater: M", shopper_text="Sweater: M and Boots: 6")
+
+        assert issue, "an inferred size must still be refused"
+        assert "A Dress" in issue, "the refusal must say which product"
+        assert "2, 4, 6, 8, 10" in issue, "and which sizes it is sold in"
+
     def test_a_size_nobody_asked_for_is_refused(self) -> None:
         """The invented 6, recorded from a real conversation.
 
@@ -255,7 +273,7 @@ class TestSizeProvenance:
         issue = self._issue(size="6", shopper_text="add the Office A-line Dress")
 
         assert "SIZE NOT ESTABLISHED" in issue
-        assert "Ask which size" in issue
+        assert "Ask which of those they want" in issue
 
     def test_the_shoppers_own_words_are_enough(self) -> None:
         assert self._issue(
@@ -302,12 +320,24 @@ class TestQuantityProvenance:
             _cart_quantity_provenance_issue,
         )
 
-        return _cart_quantity_provenance_issue(quantity, stated_as, shopper_text)
+        from types import SimpleNamespace
+
+        return _cart_quantity_provenance_issue(
+            quantity,
+            stated_as,
+            shopper_text,
+            SimpleNamespace(display_name="A Dress"),
+        )
 
     def test_one_is_what_add_it_means(self) -> None:
         """The ordinary add asks nothing and must stay free."""
 
         assert self._issue(1, shopper_text="add it to my cart") == ""
+
+    def test_a_quantity_refusal_names_the_product(self) -> None:
+        """Same reason as the size: a batch refusal it cannot attribute is a guess."""
+
+        assert "A Dress" in self._issue(3, shopper_text="add it to my cart")
 
     def test_a_number_nobody_asked_for_is_refused(self) -> None:
         """Quantity had no guard at all -- the size at least had to be sold."""


### PR DESCRIPTION
When the cart refuses an item, the model has to explain that refusal to the shopper. It was refused **by an internal reference**, with no product name and no valid sizes — so it guessed, and guessed wrong.

## Before

A shopper answered **"Sweater: M and Boots: 6"**. The model turned `M` into `6`; the size gate refused it, correctly. The refusal:

```
SIZE NOT ESTABLISHED: the shopper did not ask for a size 6.
Ask which size they want, naming the sizes it is sold in.
```

The model could not tell which of the two items had failed, so it blamed the boots:

> "you asked for **Boots: 6**, but I need you to choose from the sizes the Yantra Leather Ankle Boots are sold in"

Those boots are sold in **5, 6, 7, 8**. The shopper was told something false about the catalog.

## After

```
SIZE NOT ESTABLISHED for 'Ultra Soft Cashmere Blend Sweater Blouse':
the shopper did not ask for a size 6. It is sold in 2, 4, 6, 8, 10, 12.
```

> "The sweater-blouse options we've looked at are listed in **numeric sizes (2, 4, 6, 8, 10, 12)** — I'm not seeing a letter size **M** available for them."

## What changed

- **The size refusal names the product and the sizes it sells.** Telling the model to name "the sizes it is sold in" while withholding them was the same error in miniature.
- **The quantity refusal names the product**, for the same reason.
- **The gate is untouched.** It caught a size the model inferred rather than the shopper choosing, and nothing here makes that easier to pass.

Two message strings and one call site. No skill file and no prompt changed.

## Why it generalises

> A prohibition leaves the model with nothing to say instead. A fact leaves it nothing to infer.

Any tool result that refuses, or returns nothing, should carry the material for the next sentence. The same shape exists in:

- zero-result searches that do not say what the catalog *does* hold (#182)
- ambiguous references listed by name only, when the record also holds the attributes that tell them apart
- reference-not-found, which names the field that failed but not the near-miss
- **any refusal addressed by `PRODUCT_REF` or `CART_LINE_ID`** rather than the name the shopper will hear — that indirection caused this bug, and it is greppable

Review question for a new tool result: *if the model had to explain this to a shopper, does it hold everything it needs — or must it remember, or guess?*

## Not fixed here

A batch add still refuses everything when one item is blocked, so the correctly-sized boots are still not added. That is #181.
