### PR TITLE
An atomic refusal does not forget what the shopper already answered

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1623,6 +1623,7 @@ class DeepAgentsRuntime:
                     request["quantity"],
                     request.get("quantity_stated_as"),
                     _shopper_words_this_conversation(state),
+                    active_detail.product,
                 )
                 if quantity_issue:
                     blocked.append(

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1650,13 +1650,13 @@ class DeepAgentsRuntime:
                     )
                 )
 
-            blocked.extend(
-                _cart_add_scope_failures(
-                    state.query,
-                    [(product_ref, product) for product_ref, product, _, _ in resolved],
-                    scope.product_evidence.values(),
-                )
+            scope_failures = _cart_add_scope_failures(
+                state.query,
+                [(product_ref, product) for product_ref, product, _, _ in resolved],
+                scope.product_evidence.values(),
             )
+            blocked.extend(message for _ref, message in scope_failures)
+            out_of_scope = {ref for ref, _message in scope_failures}
             if blocked:
                 state.cart = self._read_cart(identity.cart_user_id)
                 self._append_product_images(
@@ -1667,11 +1667,16 @@ class DeepAgentsRuntime:
                 # Nothing is written -- the add is all or nothing. But the items
                 # that were established travel with the refusal, so the question
                 # put to the shopper is only the one still open.
+                # An item can pass every per-item gate and still be refused
+                # below as outside this turn's request. Listing it as settled
+                # would tell the shopper not to ask again about the very thing
+                # that failed.
                 ready = [
                     f"- {product.display_name}"
                     + (f", size {size}" if size else "")
                     + f", qty {quantity}"
-                    for _ref, product, quantity, size in resolved
+                    for ref, product, quantity, size in resolved
+                    if ref not in out_of_scope
                 ]
                 return _format_cart_add_result(
                     [], failed + blocked, state.cart, ready

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1664,7 +1664,18 @@ class DeepAgentsRuntime:
                     state.cart,
                     scope.product_evidence.values(),
                 )
-                return _format_cart_add_result([], failed + blocked, state.cart)
+                # Nothing is written -- the add is all or nothing. But the items
+                # that were established travel with the refusal, so the question
+                # put to the shopper is only the one still open.
+                ready = [
+                    f"- {product.display_name}"
+                    + (f", size {size}" if size else "")
+                    + f", qty {quantity}"
+                    for _ref, product, quantity, size in resolved
+                ]
+                return _format_cart_add_result(
+                    [], failed + blocked, state.cart, ready
+                )
 
             added: list[str] = []
             committed: list[dict[str, Any]] = []

--- a/chain_server/src/response_format.py
+++ b/chain_server/src/response_format.py
@@ -253,7 +253,21 @@ def _format_product_refs(products: list[ProductSummary]) -> str:
     )
 
 
-def _format_cart_add_result(added: list[str], failed: list[str], cart: Cart) -> str:
+def _format_cart_add_result(
+    added: list[str],
+    failed: list[str],
+    cart: Cart,
+    ready: list[str] | None = None,
+) -> str:
+    """Report an add, including what was established but not written.
+
+    The add is all or nothing, so one unanswered item holds back the rest. That
+    is deliberate. What was not deliberate is that the held-back items vanished
+    from the result: a shopper who gave a correct size for the boots and a
+    letter size for the sweater was asked for both again, because nothing told
+    the model the boots were already settled.
+    """
+
     lines = ["CART_ADD_RESULT"]
     if added:
         lines.append("Added:")
@@ -261,6 +275,12 @@ def _format_cart_add_result(added: list[str], failed: list[str], cart: Cart) -> 
     if failed:
         lines.append("Failed:")
         lines.extend(failed)
+    if ready:
+        lines.append(
+            "Established, not added -- the add is all or nothing, so these are "
+            "waiting on the item above. Do not ask for these again:"
+        )
+        lines.extend(ready)
     lines.append("Current cart:")
     lines.append(_format_cart_lines(cart))
     lines.append("Cart total:")

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -4113,6 +4113,7 @@ def _cart_quantity_provenance_issue(
     quantity: int,
     stated_as: str | None,
     shopper_text: str,
+    product: Any = None,
 ) -> str:
     """Say why this quantity cannot be trusted, or "" if it can.
 
@@ -4126,9 +4127,13 @@ def _cart_quantity_provenance_issue(
         return ""
     if _shopper_said(stated_as, shopper_text, str(quantity)):
         return ""
+    # Named for the same reason a size refusal is: a batch refusal the model
+    # cannot attribute to an item becomes a confident guess in the reply.
+    named = getattr(product, "display_name", "") if product is not None else ""
+    subject = f" for '{named}'" if named else ""
     return (
-        f"QUANTITY NOT ESTABLISHED: the shopper did not ask for {quantity}. "
-        "Add one, or ask how many they want. Nothing was added."
+        f"QUANTITY NOT ESTABLISHED{subject}: the shopper did not ask for "
+        f"{quantity}. Add one, or ask how many they want. Nothing was added."
     )
 
 
@@ -4181,10 +4186,18 @@ def _cart_size_provenance_issue(
         return ""
     if _shopper_said(stated_as, shopper_text, chosen):
         return ""
+    # The product and its sizes travel with the refusal. Told only that a size
+    # was not established, and addressed by a PRODUCT_REF, the model had to work
+    # out which of two items had failed and what it could offer instead -- and
+    # got both wrong: it told a shopper size 6 was not sold for a boot sold in
+    # 5, 6, 7, 8, and blamed the item whose size had been stated correctly.
+    # Asking it to name "the sizes it is sold in" without supplying them is the
+    # same error in miniature.
     return (
-        f"SIZE NOT ESTABLISHED: the shopper did not ask for a size {chosen}. "
-        "Ask which size they want, naming the sizes it is sold in, and add it "
-        "when they answer. Nothing was added."
+        f"SIZE NOT ESTABLISHED for '{product.display_name}': the shopper did "
+        f"not ask for a size {chosen}. It is sold in {', '.join(advertised)}. "
+        "Ask which of those they want and add it when they answer. Nothing was "
+        "added."
     )
 
 

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3814,7 +3814,15 @@ def _cart_add_scope_failures(
     user_query: str,
     requested_products: list[tuple[str, ProductSummary]],
     available_products: Any,
-) -> list[str]:
+) -> list[tuple[str, str]]:
+    """Which requested products fall outside this turn's explicit request.
+
+    Returns the ref beside its message. The ref is what a caller needs to know
+    which item failed, and recovering it by reading the message back would be
+    parsing prose for control state -- which is the thing this codebase refuses
+    to do everywhere else.
+    """
+
     explicitly_named = _explicitly_named_products(user_query, available_products)
     if not explicitly_named:
         return []
@@ -3822,15 +3830,18 @@ def _cart_add_scope_failures(
     explicit_names = {
         _normalize_product_name(product.display_name) for product in explicitly_named
     }
-    failures = []
+    failures: list[tuple[str, str]] = []
     for product_ref, product in requested_products:
         if _normalize_product_name(product.display_name) in explicit_names:
             continue
         failures.append(
-            f"- PRODUCT_REF '{product_ref}': selected '{product.display_name}' is "
-            "outside the current explicit add request. The current request names: "
-            f"{_format_product_refs(explicitly_named)}. Retry with matching "
-            "PRODUCT_REF values only, or ask a clarification."
+            (
+                product_ref,
+                f"- PRODUCT_REF '{product_ref}': selected '{product.display_name}' "
+                "is outside the current explicit add request. The current request "
+                f"names: {_format_product_refs(explicitly_named)}. Retry with "
+                "matching PRODUCT_REF values only, or ask a clarification.",
+            )
         )
     return failures
 

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -614,6 +614,35 @@ class TestAtomicRefusalSaysWhatWasReady:
         # And it must not claim they went in.
         assert "Added:" not in result
 
+    def test_an_item_refused_as_out_of_scope_is_not_listed_as_settled(self) -> None:
+        """An item can pass every per-item gate and still be refused after them.
+
+        The scope check runs once, over everything resolved, and can block an
+        item that already passed size, quantity and product provenance. Listing
+        it as settled would tell the shopper not to ask again about the very
+        thing that failed -- a contradiction inside one message.
+        """
+
+        from chain_server.src.turn_support import _cart_add_scope_failures
+        from types import SimpleNamespace
+
+        dress = SimpleNamespace(
+            product_id="ref_dress", display_name="Office A-line Dress"
+        )
+        bag = SimpleNamespace(
+            product_id="ref_bag", display_name="Navy Leather Everyday Bag"
+        )
+        failures = _cart_add_scope_failures(
+            "add the Navy Leather Everyday Bag",
+            [("ref_dress", dress), ("ref_bag", bag)],
+            [dress, bag],
+        )
+
+        # The ref travels with the message, so the caller never has to read it
+        # back out of the prose.
+        assert [ref for ref, _message in failures] == ["ref_dress"]
+        assert all(isinstance(message, str) for _ref, message in failures)
+
     def test_nothing_established_says_nothing_extra(self) -> None:
         """One blocked item on its own must not grow a section about nobody."""
 

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -243,6 +243,24 @@ class TestSizeProvenance:
             kw.get("cart_line_size"),
         )
 
+    def test_a_refusal_names_the_product_and_the_sizes_it_sells(self) -> None:
+        """Told only that a size was not established, the model guessed twice.
+
+        A shopper answered "Sweater: M and Boots: 6" -- a format the assistant
+        itself had offered. The model turned M into 6 and the gate refused it,
+        correctly. But the refusal named no product and listed no sizes, so the
+        model attributed the failure to the boots and told the shopper size 6
+        was not sold for a boot the catalog sells in 5, 6, 7 and 8.
+
+        The refusal has to carry what the next sentence needs.
+        """
+
+        issue = self._issue(size="6", stated_as="Sweater: M", shopper_text="Sweater: M and Boots: 6")
+
+        assert issue, "an inferred size must still be refused"
+        assert "A Dress" in issue, "the refusal must say which product"
+        assert "2, 4, 6, 8, 10" in issue, "and which sizes it is sold in"
+
     def test_a_size_nobody_asked_for_is_refused(self) -> None:
         """The invented 6, recorded from a real conversation.
 
@@ -255,7 +273,7 @@ class TestSizeProvenance:
         issue = self._issue(size="6", shopper_text="add the Office A-line Dress")
 
         assert "SIZE NOT ESTABLISHED" in issue
-        assert "Ask which size" in issue
+        assert "Ask which of those they want" in issue
 
     def test_the_shoppers_own_words_are_enough(self) -> None:
         assert self._issue(
@@ -302,12 +320,24 @@ class TestQuantityProvenance:
             _cart_quantity_provenance_issue,
         )
 
-        return _cart_quantity_provenance_issue(quantity, stated_as, shopper_text)
+        from types import SimpleNamespace
+
+        return _cart_quantity_provenance_issue(
+            quantity,
+            stated_as,
+            shopper_text,
+            SimpleNamespace(display_name="A Dress"),
+        )
 
     def test_one_is_what_add_it_means(self) -> None:
         """The ordinary add asks nothing and must stay free."""
 
         assert self._issue(1, shopper_text="add it to my cart") == ""
+
+    def test_a_quantity_refusal_names_the_product(self) -> None:
+        """Same reason as the size: a batch refusal it cannot attribute is a guess."""
+
+        assert "A Dress" in self._issue(3, shopper_text="add it to my cart")
 
     def test_a_number_nobody_asked_for_is_refused(self) -> None:
         """Quantity had no guard at all -- the size at least had to be sold."""

--- a/tests/unit/chain_server/test_cart_sizes.py
+++ b/tests/unit/chain_server/test_cart_sizes.py
@@ -582,3 +582,41 @@ class TestProductProvenance:
             shopper_text="add it",
             evidence=self._evidence(self._product()),
         ) == ""
+
+
+class TestAtomicRefusalSaysWhatWasReady:
+    """The add is all or nothing; the refusal must still carry what was settled."""
+
+    def _result(self, ready=None):
+        from chain_server.src.response_format import _format_cart_add_result
+        from types import SimpleNamespace
+
+        cart = SimpleNamespace(contents=[], lines=[], total=None)
+        failed = [
+            "- PRODUCT_REF 'x': SIZE NOT ESTABLISHED for 'A Sweater': the "
+            "shopper did not ask for a size 6. It is sold in 2, 4, 6, 8."
+        ]
+        return _format_cart_add_result([], failed, cart, ready)
+
+    def test_an_established_item_is_reported_though_nothing_was_written(self) -> None:
+        """A shopper answered for both items and was asked for both again.
+
+        "Sweater: M and Boots: 6" -- the boots size was correct and sold. The
+        sweater's was not, so nothing was added, which is the intended
+        atomicity. But the boots vanished from the result, so the model had no
+        way to know they were settled and asked for that size a second time.
+        """
+
+        result = self._result(ready=["- Yantra Leather Ankle Boots, size 6, qty 1"])
+
+        assert "Yantra Leather Ankle Boots" in result
+        assert "Do not ask for these again" in result
+        # And it must not claim they went in.
+        assert "Added:" not in result
+
+    def test_nothing_established_says_nothing_extra(self) -> None:
+        """One blocked item on its own must not grow a section about nobody."""
+
+        result = self._result(ready=[])
+
+        assert "Established, not added" not in result

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -8463,6 +8463,24 @@ class TestDeepAgentsRuntimeRefs:
         )
         assert "SIZE NOT ESTABLISHED" in unasked
         assert added == []
+        # Two items, one settled and one not. The add is all or nothing, so
+        # nothing is written -- but the settled item has to travel with the
+        # refusal. A shopper who answered "Sweater: M and Boots: 6" gave a
+        # correct size for the boots and was asked for it a second time,
+        # because the held-back item vanished from the result.
+        held_back = tool_text(
+            add_tool(
+                items=[
+                    {"product_ref": "prod_bag", "quantity": 1},
+                    {"product_ref": "prod_dress", "quantity": 1, "size": "4"},
+                ]
+            )
+        )
+        assert "SIZE NOT ESTABLISHED" in held_back
+        assert "Work Bag" in held_back
+        assert "Do not ask for these again" in held_back
+        assert "Added:" not in held_back
+        assert added == []
         sized = tool_text(
             add_tool(
                 items=[


### PR DESCRIPTION
The cart add is all or nothing: if one item cannot be established, nothing is written. That is deliberate — a partly-applied cart is worse than none.

The bug was that the items which *were* established then vanished from the result, so the shopper was asked twice for an answer they had already given.

## Before

A shopper answered **"Sweater: M and Boots: 6"**. The sweater's size was the model's inference and was refused, so nothing was added — correct. But the refusal reported only the failure, and the boots (correctly sized, correctly stated) disappeared. So:

> "Reply in this format and I'll add both: Sweater: [2/4/6/8/10/12], **Boots: [size from the available options]**"

The boots size was already settled. It was asked for again.

## After

The refusal carries what was established:

```
Established, not added — the add is all or nothing, so these are waiting
on the item above. Do not ask for these again:
- Yantra Leather Ankle Boots, size 6, qty 1
```

Nothing is written, and the result never claims otherwise. Only the open question is put to the shopper.

## What changed

- **Established items travel with the refusal**, in their own section, marked as not added.
- **An item refused as out of scope is excluded from that list.** The scope check runs after the per-item gates, so an item can pass size, quantity and product provenance and still be refused. Listing it as settled would contradict the refusal in the same message.
- **`_cart_add_scope_failures` returns the ref beside its message**, so the caller knows which item failed without reading it back out of the prose.

## Atomicity is unchanged

Nothing is written when any item is blocked. Atomicity is a property of the write; it is not a reason to forget what the shopper said.

## Note

The "established, not added" path did not appear in any recorded run — it needs a two-item add where exactly one item fails, which none of the current scripts produce. It is covered by tests through the real cart tool, but has not been seen in a live conversation.
