### PR TITLE
[parked] A search that finds nothing says what the catalog does hold

### DIFF
--- a/chain_server/src/catalog_search.py
+++ b/chain_server/src/catalog_search.py
@@ -128,6 +128,38 @@ class SearchContext:
     constraint_input_model: type[BaseModel]
 
 
+def _advertised_counts(
+    capabilities: Any,
+    taxonomy: dict[str, Any],
+) -> dict[str, int]:
+    """What the catalog holds for the taxonomy this search covered.
+
+    A search matching nothing is a fact about the query. Without the counts it
+    reads as a fact about the shop, and once did: "I'm not seeing any blouses,
+    camisoles, jumpsuits, skirts, or sweaters" about sixty-nine products.
+
+    Read off the advertised capabilities the service already publishes, so this
+    costs no second search.
+    """
+
+    categories = getattr(getattr(capabilities, "taxonomy", None), "categories", None)
+    if not categories:
+        return {}
+    wanted_categories = [str(v) for v in (taxonomy.get("category") or [])]
+    wanted_subcategories = [str(v) for v in (taxonomy.get("subcategory") or [])]
+    counts: dict[str, int] = {}
+    for category_name, category in categories.items():
+        subcategories = getattr(category, "subcategories", {}) or {}
+        for name in wanted_subcategories:
+            if name in subcategories:
+                counts[name] = subcategories[name].product_count
+        # Only when the shopper named no subcategory: naming both would report
+        # the category total beside its own parts, which reads as a contradiction.
+        if not wanted_subcategories and category_name in wanted_categories:
+            counts[category_name] = getattr(category, "product_count", 0)
+    return counts
+
+
 def _lock_taxonomy_constraint_values(
     repair: CatalogRepairState,
     scope_key: str | None,
@@ -1425,6 +1457,9 @@ def _rendered_evidence(ctx: SearchContext, attempt: _Attempt) -> StepResult:
             scope_complete=bool(request.scope_complete),
             budget_exhausted=bool(search_budget_exhausted),
             unconfirmed_requirements=unconfirmable_requirements,
+            advertised_counts=_advertised_counts(
+                ctx.capabilities, taxonomy_constraints
+            ),
             scope_outcome={
                 "outcome": "zero_results",
                 "requested_product_type": request.requested_product_type,
@@ -1441,6 +1476,20 @@ def _rendered_evidence(ctx: SearchContext, attempt: _Attempt) -> StepResult:
             _SEARCH_NO_MATCH_GROUNDING_NOTE,
             _format_search_taxonomy_evidence(evidence.taxonomy),
         ]
+        if evidence.advertised_counts:
+            # The true number, in the result the model actually reads. The note
+            # above already forbids concluding the catalog is empty, and that
+            # prohibition still produced "I'm not seeing any blouses,
+            # camisoles, jumpsuits, skirts, or sweaters" about sixty-nine
+            # products. A prohibition leaves the model with nothing to say
+            # instead; a count leaves it nothing to infer.
+            lines.append(
+                "CATALOG_STOCKS (advertised, none matched this scope): "
+                + ", ".join(
+                    f"{name} {count}"
+                    for name, count in sorted(evidence.advertised_counts.items())
+                )
+            )
         if scope_relation_evidence:
             lines.append(scope_relation_evidence)
         if evidence.confirmed_filters:

--- a/chain_server/src/tool_evidence.py
+++ b/chain_server/src/tool_evidence.py
@@ -66,6 +66,14 @@ class SearchEvidence:
     #: assumed. Empty once the audience is a stated constraint, because then
     #: there is no assumption left to disclose.
     assumed_audience: list[str] = field(default_factory=list)
+    #: What the catalog advertises for the taxonomy this search covered, as
+    #: {name: count}. Present only when the search matched nothing, which is
+    #: exactly when it is needed: told only that its query returned nothing, the
+    #: assistant said "I'm not seeing any blouses, camisoles, jumpsuits, skirts,
+    #: or sweaters" about a catalog holding sixty-nine of them. Forbidding that
+    #: conclusion in prose was already tried; this supplies the true number
+    #: instead, so there is nothing left to infer.
+    advertised_counts: dict[str, int] = field(default_factory=dict)
 
     def as_artifact(self) -> dict[str, Any]:
         return {
@@ -85,6 +93,7 @@ class SearchEvidence:
                 "scope_outcome": self.scope_outcome,
                 "unconfirmed_requirements": self.unconfirmed_requirements,
                 "assumed_audience": self.assumed_audience,
+                "advertised_counts": self.advertised_counts,
             }
         }
 

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3311,6 +3311,19 @@ def _customer_safe_search_evidence(payload: dict[str, Any]) -> str:
                 "CONFIRMED_SEARCH_FILTERS: "
                 + json.dumps(confirmed_filters, sort_keys=True)
             )
+        counts = payload.get("advertised_counts") or {}
+        if counts:
+            # The true number, not merely a prohibition on inferring one. The
+            # rule above -- that this establishes nothing about the catalog --
+            # was already stated and still produced "I'm not seeing any
+            # blouses, camisoles, jumpsuits, skirts, or sweaters" about
+            # sixty-nine products.
+            lines.append(
+                "CATALOG_STOCKS (advertised, none matched this scope): "
+                + ", ".join(
+                    f"{name} {count}" for name, count in sorted(counts.items())
+                )
+            )
         relation = _scope_relation_line(payload, has_products=False)
         if relation:
             lines.append(relation)

--- a/tests/unit/chain_server/test_catalog_zero_results.py
+++ b/tests/unit/chain_server/test_catalog_zero_results.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""An empty search is a fact about the query, not about the shop."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from chain_server.src.catalog_search import _advertised_counts
+from chain_server.src.turn_support import _customer_safe_search_evidence
+
+
+def _capabilities():
+    """The shape the catalog service already publishes."""
+
+    return SimpleNamespace(
+        taxonomy=SimpleNamespace(
+            categories={
+                "apparel": SimpleNamespace(
+                    product_count=102,
+                    subcategories={
+                        "skirts": SimpleNamespace(product_count=39),
+                        "sweaters": SimpleNamespace(product_count=18),
+                        "blouses": SimpleNamespace(product_count=9),
+                    },
+                )
+            }
+        )
+    )
+
+
+def test_the_counts_come_from_what_the_catalog_advertises() -> None:
+    """A search matching nothing must still know what the shop holds.
+
+    A live session said "I am not seeing any blouses, camisoles, jumpsuits,
+    skirts, or sweaters" about a catalog holding sixty-nine of them.
+    """
+
+    counts = _advertised_counts(
+        _capabilities(),
+        {"category": ["apparel"], "subcategory": ["skirts", "sweaters"]},
+    )
+
+    assert counts == {"skirts": 39, "sweaters": 18}
+
+
+def test_a_category_search_reports_the_category() -> None:
+    """No subcategory named, so the category total is the honest figure."""
+
+    counts = _advertised_counts(_capabilities(), {"category": ["apparel"]})
+
+    assert counts == {"apparel": 102}
+
+
+def test_a_category_and_its_parts_are_not_reported_together() -> None:
+    """Reporting 102 beside 39 and 18 reads as a contradiction."""
+
+    counts = _advertised_counts(
+        _capabilities(),
+        {"category": ["apparel"], "subcategory": ["skirts"]},
+    )
+
+    assert counts == {"skirts": 39}
+
+
+def test_the_zero_result_evidence_carries_the_number() -> None:
+    """The rule was already stated in prose and still produced the falsehood.
+
+    Forbidding the wrong conclusion is not the same as supplying the right
+    fact. This asserts the fact reaches the model.
+    """
+
+    summary = _customer_safe_search_evidence(
+        {
+            "outcome": "zero_results",
+            "taxonomy": {"subcategory": ["skirts"]},
+            "advertised_counts": {"skirts": 39},
+        }
+    )
+
+    assert "CATALOG_STOCKS" in summary
+    assert "skirts 39" in summary
+
+
+def test_nothing_advertised_says_nothing() -> None:
+    """An unknown taxonomy must not grow an empty, confusing line."""
+
+    summary = _customer_safe_search_evidence(
+        {"outcome": "zero_results", "taxonomy": {}, "advertised_counts": {}}
+    )
+
+    assert "CATALOG_STOCKS" not in summary


### PR DESCRIPTION
**Parked, not ready to merge.**

The defect this was written for was real and observed live — "I'm not seeing any blouses, camisoles, jumpsuits, skirts, or sweaters" about a catalog holding sixty-nine of them. But it was never attributed properly.

That session ran against a `catalog-retriever` image built five weeks earlier, whose search results carried **no product attributes at all**. After rebuilding from source, the behaviour is correct **without** this branch. A/B'd on `origin/staging` at `88552ee`:

- *"do you have any gold skirts"* → "I'm not finding any skirts listed with **gold** as the primary color right now", then four skirts. Absence scoped to the colour, not the category.
- *"now build me a completely separate outfit"* (the compound turn that failed live) → sweater + skirt + flats, under budget.

Both correct, with no `CATALOG_STOCKS` anywhere in the build.

The case as originally written was weak: the "before" came from a live session on stale code, and the "after" was a different query chosen afterwards. Two anecdotes, not a comparison. No A/B was run before opening it.

**This is unproven rather than wrong.** Carrying the advertised count on a zero-result is defensible — a prohibition leaves the model nothing true to say instead. But nothing yet shows it changes an answer.

**To revive:** find a query where the current build still reports a thin result as an absence, and A/B that query with and without this branch. If no such query exists, close it.
