### PR TITLE
fix: milvus_from_csv swallows CSV read errors

### DIFF
--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -559,11 +559,12 @@ class Retriever:
             df = pd.read_csv(csv_path)
             logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | CSV read in.")
         except Exception as e:
-            logging.debug(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Error: {e} -- Failed to read CSV: {csv_path}.")            
+            logging.error(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Error: {e} -- Failed to read CSV: {csv_path}.")
             dir_contents = []
             for entry in os.listdir("."):
                 dir_contents.append(entry)
             logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Directory contents at failure: {dir_contents}")
+            raise
 
         # Create combined name and description strings
         metadatas = df.to_dict(orient="records")


### PR DESCRIPTION
This PR addresses the following issue in `catalog_retriever/src/retriever.py`: milvus_from_csv swallows CSV read errors.

## Changes
- `catalog_retriever/src/retriever.py`: milvus_from_csv swallows CSV read errors.

## Details
```diff
--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -1,10 +1,11 @@
-        # Get our pd dataframe
-        try:
-            df = pd.read_csv(csv_path)
-            logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | CSV read in.")
-        except Exception as e:
-            logging.debug(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Error: {e} -- Failed to read CSV: {csv_path}.")            
-            dir_contents = []
-            for entry in os.listdir("."):
-                dir_contents.append(entry)
-            logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Directory contents at failure: {dir_contents}")
+        # Get our pd dataframe
+        try:
+            df = pd.read_csv(csv_path)
+            logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | CSV read in.")
+        except Exception as e:
+            logging.error(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Error: {e} -- Failed to read CSV: {csv_path}.")
+            dir_contents = []
+            for entry in os.listdir("."):
+                dir_contents.append(entry)
+            logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Directory contents at failure: {dir_contents}")
+            raise
```

## Tests
- `catalog_retriever/tests/test_retriever.py`

```diff
--- /dev/null
+++ b/catalog_retriever/tests/test_retriever.py
@@ -0,0 +1,34 @@
+import pytest
+from unittest.mock import patch
+from catalog_retriever.src.retriever import Retriever, RetrieverConfig
+
+
+def test_milvus_from_csv_propagates_csv_read_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("EMBED_API_KEY", "fake-key")
+
+    config = RetrieverConfig(
+        text_embed_port="http://localhost:8000",
+        image_embed_port="http://localhost:8001",
+        text_model_name="text-model",
+        image_model_name="image-model",
+        db_port="http://localhost:19530",
+        db_name="test_db",
+        sim_threshold=0.0,
+        text_collection="text_collection",
+        image_collection="image_collection",
+    )
+
+    with patch("catalog_retriever.src.retriever.OpenAI"), \
+         patch("catalog_retriever.src.retriever.Milvus"), \
+         patch.object(Retriever, "embeddings_exist", return_value=False):
+        retriever = Retriever(config)
+        missing_csv = str(tmp_path / "missing.csv")
+
+        with pytest.raises(FileNotFoundError):
+            retriever.milvus_from_csv(missing_csv)
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).