### PR TITLE
fix: retrieve scales k by len(query) instead of local_queries

### DIFF
--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -644,7 +644,8 @@ class Retriever:
                 logging.info(f"CATALOG RETRIEVER | retrieve() | Starting image task...\n\t| {base64_string[:100]}")
             if verbose:
                 logging.info(f"CATALOG RETRIEVER | retrieve() | Obtained embedding...")
-            i2i_task = asyncio.to_thread(self.image_db.similarity_search_with_relevance_scores, base64_string, k=k*len(query))
+            search_k = k * len(local_queries)
+            i2i_task = asyncio.to_thread(self.image_db.similarity_search_with_relevance_scores, base64_string, k=search_k)
 
             unformatted_results = await asyncio.gather(*t2t_tasks, i2i_task)
         else:
@@ -655,7 +656,8 @@ class Retriever:
             for local_query in local_queries:
                 if verbose:
                     logging.info(f"\t| retrieve() | Launching text-only retrieval. Query type: {type(local_query)}, Query: {local_query}")
-                results.append(asyncio.to_thread(self.text_db.similarity_search_with_relevance_scores, local_query, k=k*len(query)))
+                search_k = k * len(local_queries)
+                results.append(asyncio.to_thread(self.text_db.similarity_search_with_relevance_scores, local_query, k=search_k))
             unformatted_results = await asyncio.gather(*results)
 
         sorted_unformatted_results = []


### PR DESCRIPTION
This PR addresses the following issue in `catalog_retriever/src/retriever.py`: retrieve scales k by len(query) instead of local_queries.

## Changes
- `catalog_retriever/src/retriever.py`: retrieve scales k by len(query) instead of local_queries.

## Details
```diff
--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -1,3 +1,5 @@
-            i2i_task = asyncio.to_thread(self.image_db.similarity_search_with_relevance_scores, base64_string, k=k*len(query))
-...
-                results.append(asyncio.to_thread(self.text_db.similarity_search_with_relevance_scores, local_query, k=k*len(query)))
+            search_k = k * len(local_queries)
+            i2i_task = asyncio.to_thread(self.image_db.similarity_search_with_relevance_scores, base64_string, k=search_k)
+...
+                search_k = k * len(local_queries)
+                results.append(asyncio.to_thread(self.text_db.similarity_search_with_relevance_scores, local_query, k=search_k))
```

## Tests
- `catalog_retriever/tests/test_retriever.py`

```diff
--- /dev/null
+++ b/catalog_retriever/tests/test_retriever.py
@@ -0,0 +1,62 @@
+import asyncio
+from types import SimpleNamespace
+
+from catalog_retriever.src.retriever import Retriever
+
+
+def _fake_doc():
+    return (
+        SimpleNamespace(
+            page_content="name | desc | bags,handbags\nPRICE: 9.99",
+            metadata={"pk": 1, "name": "bag", "price": 9.99, "image": "img"},
+        ),
+        0.9,
+    )
+
+
+def _make_retriever():
+    retriever = object.__new__(Retriever)
+    retriever.sim_threshold = 0.0
+
+    class FakeDB:
+        def __init__(self):
+            self.calls = []
+
+        def similarity_search_with_relevance_scores(self, query, k=4):
+            self.calls.append((query, k))
+            return [_fake_doc()]
+
+    retriever.text_db = FakeDB()
+    retriever.image_db = FakeDB()
+    return retriever
+
+
+def test_text_only_retrieve_with_empty_query_requests_nonzero_k():
+    retriever = _make_retriever()
+    asyncio.run(
+        retriever.retrieve(query=[], categories=["bag"], k=4, image_bool=False)
+    )
+    assert retriever.text_db.calls, "text_db should be queried for empty input"
+    for query, k in retriever.text_db.calls:
+        assert k > 0, f"search limit must be > 0, got {k}"
+    assert len(retriever.text_db.calls) == 1
+
+
+def test_image_branch_retrieve_with_empty_query_requests_nonzero_k():
+    retriever = _make_retriever()
+    asyncio.run(
+        retriever.retrieve(
+            query=[],
+            categories=[],
+            image="data:application/octet-stream;base64,AAA",
+            k=4,
+            image_bool=True,
+        )
+    )
+    assert retriever.image_db.calls, "image_db should be queried for empty input"
+    for query, k in retriever.image_db.calls:
+        assert k > 0, f"search limit must be > 0, got {k}"
+    assert len(retriever.image_db.calls) == 1
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).