### PR TITLE
fix: milvus_from_csv crashes with NameError when CSV read fails

### DIFF
--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -564,6 +564,7 @@ class Retriever:
             for entry in os.listdir("."):
                 dir_contents.append(entry)
             logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Directory contents at failure: {dir_contents}")
+            raise
 
         # Create combined name and description strings
         metadatas = df.to_dict(orient="records")


### PR DESCRIPTION
This PR addresses the following issue in `catalog_retriever/src/retriever.py`: milvus_from_csv crashes with NameError when CSV read fails.

## Changes
- `catalog_retriever/src/retriever.py`: milvus_from_csv crashes with NameError when CSV read fails.

## Details
```diff
--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -1,6 +1,7 @@
-            dir_contents = []
-            for entry in os.listdir("."):
-                dir_contents.append(entry)
-            logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Directory contents at failure: {dir_contents}")
-
-        # Create combined name and description strings
+            dir_contents = []
+            for entry in os.listdir("."):
+                dir_contents.append(entry)
+            logging.info(f"CATALOG RETRIEVER | Retriever.milvus_from_csv() | Directory contents at failure: {dir_contents}")
+            raise
+
+        # Create combined name and description strings
```

## Tests
- `catalog_retriever/tests/test_retriever.py`

```diff
--- /dev/null
+++ b/catalog_retriever/tests/test_retriever.py
@@ -0,0 +1,42 @@
+import pytest
+from unittest.mock import MagicMock
+from catalog_retriever.src.retriever import Retriever, RetrieverConfig
+
+
+def test_milvus_from_csv_propagates_read_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("EMBED_API_KEY", "test-key")
+    config = RetrieverConfig(
+        text_embed_port="http://localhost:8000/v1",
+        image_embed_port="http://localhost:8001/v1",
+        text_model_name="test-text",
+        image_model_name="test-image",
+        db_port="http://localhost:19530",
+        db_name="test",
+        sim_threshold=0.5,
+        text_collection="text",
+        image_collection="image",
+    )
+    monkeypatch.setattr(
+        "catalog_retriever.src.retriever.OpenAI", lambda **kwargs: MagicMock()
+    )
+    monkeypatch.setattr("catalog_retriever.src.retriever.Milvus", MagicMock)
+    monkeypatch.setattr(Retriever, "embeddings_exist", lambda self: False)
+
+    retriever = Retriever(config)
+
+    original = FileNotFoundError("no such csv")
+
+    def fake_read_csv(path):
+        raise original
+
+    monkeypatch.setattr("catalog_retriever.src.retriever.pd.read_csv", fake_read_csv)
+
+    with pytest.raises(FileNotFoundError, match="no such csv"):
+        retriever.milvus_from_csv(str(tmp_path / "missing.csv"))
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).