### PR TITLE
fix: overly broad pytest.raises(Exception) masks wrong failure mode

### DIFF
--- a/tests/unit/catalog_retriever/test_retriever.py
+++ b/tests/unit/catalog_retriever/test_retriever.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from catalog_retriever.src import retriever as retriever_mod
 from catalog_retriever.src.retriever import (
@@ -197,7 +198,7 @@ class TestMilvusAdapter:
 
 class TestRetrieverConfig:
     def test_all_fields_required(self) -> None:
-        with pytest.raises(Exception):  # pydantic ValidationError
+        with pytest.raises(ValidationError):
             RetrieverConfig()  # type: ignore[call-arg]
 
     def test_valid_config_builds(self) -> None:


### PR DESCRIPTION
This PR addresses the following issue in `tests/unit/catalog_retriever/test_retriever.py`: overly broad pytest.raises(Exception) masks wrong failure mode.

## Changes
- `tests/unit/catalog_retriever/test_retriever.py`: overly broad pytest.raises(Exception) masks wrong failure mode.

## Details
```diff
--- a/tests/unit/catalog_retriever/test_retriever.py
+++ b/tests/unit/catalog_retriever/test_retriever.py
@@ -1,9 +1,10 @@
-import pytest
-
-from catalog_retriever.src import retriever as retriever_mod
-...
-
-class TestRetrieverConfig:
-    def test_all_fields_required(self) -> None:
-        with pytest.raises(Exception):  # pydantic ValidationError
-            RetrieverConfig()  # type: ignore[call-arg]
+import pytest
+from pydantic import ValidationError
+
+from catalog_retriever.src import retriever as retriever_mod
+...
+
+class TestRetrieverConfig:
+    def test_all_fields_required(self) -> None:
+        with pytest.raises(ValidationError):
+            RetrieverConfig()  # type: ignore[call-arg]
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).