### PR TITLE
Standardise on nemotron-3-embed-1b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ export VLM_MODEL="${VLM_MODEL:-}"
 
 # ---------------------------------------------------------------------------
 # Text embedding
+#
+# Left empty, the model comes from shared/configs/models.yaml, which is
+# nvidia/nemotron-3-embed-1b. Set these only to point somewhere else.
+#
+# Changing the embedding model changes the vector dimension, so the Milvus
+# collection must be rebuilt. The catalog fingerprint includes the model name,
+# so the rebuild is automatic on the next start -- but it is not free, and a
+# collection built by another model rejects every query until it happens.
 # ---------------------------------------------------------------------------
 
 export TEXT_EMBED_BASE_URL="${TEXT_EMBED_BASE_URL:-}"

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 - [Milvus](https://milvus.io/): Vector database for similarity search
 
 ### Related Projects
-- [NVIDIA Retrieval QA](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nv-embedqa-e5-v5): Embedding model for semantic search
+- [Nemotron 3 Embed 1B](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-3-embed-1b): Embedding model for semantic search
 - [NV-CLIP](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nvclip): Visual understanding model for image retrieval
 - [Nemotron 3 Super](https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-3-super-120b-a12b): Large language model
 

--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -72,7 +72,10 @@ services:
       - shopping-network
 
   embedqa:
-    image: nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.0
+    # Per the published self-hosted deploy for nemotron-3-embed-1b:
+    #   https://build.nvidia.com/nvidia/nemotron-3-embed-1b/deploy?nim=self-hosted
+    image: nvcr.io/nim/nvidia/nemotron-3-embed-1b:latest
+    shm_size: "16gb"
     ports:
       - "8001:8000"
     environment:

--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -72,7 +72,7 @@ services:
       - shopping-network
 
   embedqa:
-    image: nvcr.io/nim/nvidia/nv-embedqa-e5-v5:1.6
+    image: nvcr.io/nim/nvidia/nemotron-3-embed-1b:2.2.0
     ports:
       - "8001:8000"
     environment:

--- a/docs/API.md
+++ b/docs/API.md
@@ -700,7 +700,7 @@ turns are not cut off before the SSE response is emitted.
     },
     "text_embedding": {
       "label": "Text embedding",
-      "model": "nvidia/nv-embedqa-e5-v5",
+      "model": "nvidia/nemotron-3-embed-1b",
       "source": "endpoint",
       "enabled": true
     }

--- a/notebook/1_Deploy_Retail_Shopping_Assistant.ipynb
+++ b/notebook/1_Deploy_Retail_Shopping_Assistant.ipynb
@@ -320,7 +320,7 @@
     "os.environ.setdefault(\"LLM_BASE_URL\", \"https://integrate.api.nvidia.com/v1\")\n",
     "os.environ.setdefault(\"LLM_MODEL\", \"nvidia/nemotron-3-super-120b-a12b\")\n",
     "os.environ.setdefault(\"TEXT_EMBED_BASE_URL\", \"https://integrate.api.nvidia.com/v1\")\n",
-    "os.environ.setdefault(\"TEXT_EMBED_MODEL\", \"nvidia/nv-embedqa-e5-v5\")\n",
+    "os.environ.setdefault(\"TEXT_EMBED_MODEL\", \"nvidia/nemotron-3-embed-1b\")\n",
     "os.environ.setdefault(\"IMAGE_EMBED_BASE_URL\", \"https://integrate.api.nvidia.com/v1\")\n",
     "os.environ.setdefault(\"IMAGE_EMBED_MODEL\", \"nvidia/nvclip\")\n",
     "os.environ.setdefault(\"RAILS_BASE_URL\", \"https://integrate.api.nvidia.com/v1\")\n",

--- a/shared/configs/models.yaml
+++ b/shared/configs/models.yaml
@@ -16,7 +16,7 @@ local_nims:
       compose_file: docker-compose-nim-local.yaml
       compose_service: embedqa
       base_url: "http://embedqa:8000/v1"
-      model: "nvidia/nv-embedqa-e5-v5"
+      model: "nvidia/nemotron-3-embed-1b"
 
     nvclip:
       compose_file: docker-compose-nim-local.yaml
@@ -58,7 +58,7 @@ models:
     base_url_env: TEXT_EMBED_BASE_URL
     base_url: "https://integrate.api.nvidia.com/v1"
     model_env: TEXT_EMBED_MODEL
-    model: "nvidia/nv-embedqa-e5-v5"
+    model: "nvidia/nemotron-3-embed-1b"
     api_key_env: EMBED_API_KEY
 
   image_embedding:

--- a/skills/retail-local-runner/scripts/local_runner.py
+++ b/skills/retail-local-runner/scripts/local_runner.py
@@ -238,7 +238,7 @@ def configure(args: argparse.Namespace) -> None:
                 f'export LLM_BASE_URL="{llm_url}"',
                 'export LLM_MODEL="nvidia/nemotron-3-super-120b-a12b"',
                 f'export TEXT_EMBED_BASE_URL="{text_embed_url}"',
-                'export TEXT_EMBED_MODEL="nvidia/nv-embedqa-e5-v5"',
+                'export TEXT_EMBED_MODEL="nvidia/nemotron-3-embed-1b"',
                 f'export IMAGE_EMBED_BASE_URL="{image_embed_url}"',
                 'export IMAGE_EMBED_MODEL="nvidia/nvclip"',
                 f'export RAILS_CONTENT_BASE_URL="{content_url}"',


### PR DESCRIPTION
`nv-embedqa-e5-v5` is deprecated and was still the default in every place the model is named. This replaces it with `nemotron-3-embed-1b` so a fresh deployment and a running one agree.

## What changed

- `shared/configs/models.yaml` — the default both services read
- `docker-compose-nim-local.yaml` — the local NIM service
- `README.md`, `docs/API.md`, the deploy notebook, the local runner
- `.env.example` — see below

No remaining references to `nv-embedqa-e5-v5` in the repo.

## The local NIM service

Taken from the published self-hosted deploy, not inferred:

```
docker run --gpus all --shm-size=16GB -e NGC_API_KEY \
  -v "$LOCAL_NIM_CACHE:/opt/nim/.cache" -u $(id -u) -p 8000:8000 \
  nvcr.io/nim/nvidia/nemotron-3-embed-1b:latest
```

- image tag is `latest`
- **`shm_size: 16gb` was missing** and is required; the other two NIM services in that file already set it
- the rest already matched — container on 8000, `NGC_API_KEY`, cache volume, invoking uid

The source URL is in the compose file so it does not have to be found again.

**One thing to decide:** this tracks `latest`, where the previous embedder pinned `1.6`. That is what the published deploy specifies, but it is a change in posture — worth overriding if reproducibility matters more than following the vendor.

## `.env.example`

It was silent on two things, because the variable is empty by default:

- **which model you get when it is left empty** — it falls through to `models.yaml`
- **that changing it changes the vector dimension**, so the Milvus collection is rebuilt

The catalog fingerprint includes the model name, so that rebuild is automatic on the next start. It is not free, and a collection built by a different model rejects every query until it happens.

## Note

PR #150 makes the same change against `main`, which is behind `staging`. This targets `staging` and should supersede it.
