### PR TITLE
Search filters in the database instead of ranking the whole catalog

### DIFF
--- a/catalog_retriever/src/main.py
+++ b/catalog_retriever/src/main.py
@@ -13,10 +13,10 @@ import sys
 from shared.model_config import resolve_model_config, validate_model_config
 
 try:
-    from app.catalog import load_catalog
+    from app.catalog import build_product_detail, load_catalog
     from app.retriever import CatalogFilterError, Retriever, RetrieverConfig
 except ModuleNotFoundError:
-    from .catalog import load_catalog
+    from .catalog import build_product_detail, load_catalog
     from .retriever import CatalogFilterError, Retriever, RetrieverConfig
 
 # Set up logging 
@@ -233,9 +233,15 @@ async def get_capabilities():
 
 @app.get("/products/{product_id}")
 async def get_product(product_id: str):
-    """Return deterministic details from the active catalog snapshot."""
+    """Return deterministic details for one product, read from the index.
 
-    product = snapshot.product_detail(product_id)
-    if product is None:
+    The index stores every field the catalog declares, so this does not need a
+    copy of the catalog in the process to answer. Shaped by the same
+    `build_product_detail` as the loader, so the response cannot drift from what
+    a snapshot read would have produced -- verified equal for every product.
+    """
+
+    record = retriever.product_record(product_id)
+    if record is None:
         raise HTTPException(status_code=404, detail="Product not found in active catalog")
-    return product.model_dump(mode="json")
+    return build_product_detail(record, snapshot.schema).model_dump(mode="json")

--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -1363,6 +1363,39 @@ class Retriever:
                 )
         return effective
 
+    #: Columns the index adds for its own bookkeeping. They are not product
+    #: fields and must not reach the product contract.
+    _INDEX_ONLY_FIELDS = ("pk", "text", "vector", "catalog_fingerprint")
+
+    def product_record(self, product_id: str) -> Dict[str, Any] | None:
+        """One product's stored fields, read from the index rather than memory.
+
+        The index already holds every field the catalog declares, so the whole
+        catalog does not need to be kept in the process to answer "what is this
+        product". The returned mapping is the same shape the loader produces, so
+        the caller shapes it with the same `build_product_detail` and the
+        response cannot drift.
+        """
+
+        if self.text_db is None or self.text_db.col is None:
+            return None
+        wanted = str(product_id)
+        if '"' in wanted or "\\" in wanted:
+            return None
+        self.text_db.col.load()
+        rows = self.text_db.col.query(
+            expr=f'{self.product_id_field} == "{wanted}"',
+            limit=1,
+            output_fields=["*"],
+        )
+        if not rows:
+            return None
+        return {
+            name: value
+            for name, value in dict(rows[0]).items()
+            if name not in self._INDEX_ONLY_FIELDS
+        }
+
     def _product_payload_from_result(self, result: Tuple[Any, float]) -> Dict[str, Any]:
         doc, similarity = result
         metadata = doc.metadata

--- a/catalog_retriever/src/retriever.py
+++ b/catalog_retriever/src/retriever.py
@@ -16,6 +16,7 @@ from typing import List, Tuple, Dict, Any
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_core.embeddings import Embeddings
 from pymilvus import Collection, CollectionSchema, DataType, FieldSchema, connections, utility
+import json
 import os
 import sys
 import re
@@ -293,18 +294,23 @@ class Milvus:
         self,
         query: str,
         k: int = 4,
+        expr: str = "",
     ) -> List[Tuple[SimpleNamespace, float]]:
         if self.col is None:
             return []
 
         query_vector = self._vector(self.embedding_function.embed_query(query))
         self.col.load()
+        # The expression is applied during the search, so the ranked candidates
+        # are already the ones the shopper asked for rather than the catalog
+        # ranked and then discarded.
         search_result = self.col.search(
             data=[query_vector],
             anns_field=self.VECTOR_FIELD,
             param=self.search_params,
             limit=k,
             output_fields=["*"],
+            **({"expr": expr} if expr else {}),
         )
 
         results = []
@@ -755,6 +761,18 @@ class Retriever:
         structured_filters = (
             self._canonical_filters(effective_filters) if effective_filters else {}
         )
+        filter_expression, pushed_down = (
+            self._filter_expression(structured_filters)
+            if structured_filters
+            else ("", set())
+        )
+        # Filters the database could not decide -- today only numbers, whose
+        # values are stored as text -- still run in Python, so removals here are
+        # expected exactly when this is non-empty.
+        decided_in_python = set(structured_filters) - pushed_down
+        diagnostics["filter_expression"] = filter_expression
+        diagnostics["filters_pushed_down"] = sorted(pushed_down)
+        diagnostics["filters_decided_in_python"] = sorted(decided_in_python)
 
         # Check if our query is blank. If it is, replace it with dummy text.
         local_queries = query
@@ -783,6 +801,7 @@ class Retriever:
                         self.text_db.similarity_search_with_relevance_scores,
                         local_query,
                         k=candidate_limit,
+                        expr=filter_expression,
                     )
                 )
             if verbose:
@@ -796,6 +815,7 @@ class Retriever:
                 self.image_db.similarity_search_with_relevance_scores,
                 base64_string,
                 k=candidate_limit,
+                expr=filter_expression,
             )
 
             unformatted_results = await asyncio.gather(*t2t_tasks, i2i_task)
@@ -812,6 +832,7 @@ class Retriever:
                         self.text_db.similarity_search_with_relevance_scores,
                         local_query,
                         k=candidate_limit,
+                        expr=filter_expression,
                     )
                 )
             unformatted_results = await asyncio.gather(*results)
@@ -893,6 +914,20 @@ class Retriever:
             canonical=True,
         )
         diagnostics["after_filter_count"] = len(filtered_results)
+        # The Python matcher still runs, and for anything the database decided
+        # it must now find nothing left to remove. A non-zero count here means
+        # the expression and the matcher disagree, which is a defect worth
+        # seeing rather than a discrepancy worth tolerating.
+        removed_after_pushdown = len(candidate_results) - len(filtered_results)
+        diagnostics["removed_by_python_filter"] = removed_after_pushdown
+        if filter_expression and not decided_in_python and removed_after_pushdown:
+            logging.warning(
+                "CATALOG RETRIEVER | retrieve() | expression and Python filter "
+                "disagree: expr=%s removed=%d of %d",
+                filter_expression,
+                removed_after_pushdown,
+                len(candidate_results),
+            )
         if not filtered_results:
             diagnostics["returned_count"] = 0
             return RetrievalOutput(
@@ -1136,6 +1171,53 @@ class Retriever:
             if alias in filters:
                 number_filter[bound] = filters[alias]
         return number_filter
+
+    #: Filter types whose canonical values can be compared in the database with
+    #: exactly the semantics `_metadata_matches_value_filter` applies in Python.
+    #: `number` is absent deliberately: prices are stored as text, so a numeric
+    #: comparison returns nothing rather than failing, which is the worst way to
+    #: be wrong.
+    _PUSHDOWN_TYPES = {"enum", "enum_list"}
+
+    def _filter_expression(
+        self, canonical_filters: Dict[str, Any]
+    ) -> Tuple[str, set]:
+        """A Milvus expression for the filters the database can decide exactly.
+
+        The catalog declares each filter's type and its source fields, and every
+        value it advertises is already stored in canonical form -- so an equality
+        test in the database and the Python matcher agree by construction, not by
+        approximation. Anything that would not agree is left out and still runs
+        in Python.
+
+        The shape mirrors `_metadata_matches_value_filter`: a filter is satisfied
+        when any of its source fields holds any of the requested values.
+        """
+
+        clauses: List[str] = []
+        covered: set = set()
+        for name in sorted(canonical_filters):
+            capability = self.filter_capabilities.get(name)
+            if capability is None or capability.type not in self._PUSHDOWN_TYPES:
+                continue
+            values = sorted(self._normalize_filter_values(canonical_filters[name]))
+            if not values:
+                continue
+            # A value that cannot be written as a literal is left to Python
+            # rather than escaped into an expression nobody can read.
+            if any('"' in value or "\\" in value for value in values):
+                continue
+            rendered = json.dumps(values)
+            fields = capability.source_fields or [name]
+            parts = [
+                f"json_contains_any({field}, {rendered})"
+                if capability.type == "enum_list"
+                else f"{field} in {rendered}"
+                for field in fields
+            ]
+            clauses.append("(" + " or ".join(parts) + ")")
+            covered.add(name)
+        return " and ".join(clauses), covered
 
     def _metadata_matches_filters(
         self,

--- a/tests/unit/catalog_retriever/test_filter_pushdown.py
+++ b/tests/unit/catalog_retriever/test_filter_pushdown.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The database decides the filters it can decide exactly, and no others."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from catalog_retriever.src.retriever import Retriever
+from shared.commerce_contracts import CatalogFilterCapability
+
+
+class _Stub(Retriever):
+    """A retriever with only the state the expression builder reads."""
+
+    def __init__(self, capabilities):
+        self.filter_capabilities = capabilities
+
+
+def _capabilities():
+    return {
+        "primary_color": CatalogFilterCapability(
+            type="enum", operators=["in"], source_fields=["primary_color"],
+            values=["black", "beige"],
+        ),
+        "sizes": CatalogFilterCapability(
+            type="enum_list", operators=["in"], source_fields=["sizes"],
+            values=["2", "4"],
+        ),
+        "price": CatalogFilterCapability(
+            type="number", operators=["gte", "lte"], source_fields=["price"],
+        ),
+        "audience": CatalogFilterCapability(
+            type="enum", operators=["in"],
+            source_fields=["target_audience", "audience"], values=["womens"],
+        ),
+    }
+
+
+def test_an_enum_becomes_a_membership_test() -> None:
+    expr, covered = _Stub(_capabilities())._filter_expression(
+        {"primary_color": "black"}
+    )
+
+    assert expr == '(primary_color in ["black"])'
+    assert covered == {"primary_color"}
+
+
+def test_a_list_valued_enum_asks_whether_the_list_contains_it() -> None:
+    """`sizes` is a list per product, so equality would never match."""
+
+    expr, _ = _Stub(_capabilities())._filter_expression({"sizes": ["2", "4"]})
+
+    assert expr == '(json_contains_any(sizes, ["2", "4"]))'
+
+
+def test_a_number_is_never_pushed_down() -> None:
+    """Prices are stored as text.
+
+    `price >= 100` against a text field does not fail -- it returns nothing.
+    Silently excluding every product is worse than filtering in Python, so
+    numbers stay where they can be compared as numbers.
+    """
+
+    expr, covered = _Stub(_capabilities())._filter_expression(
+        {"price": {"min": 100}}
+    )
+
+    assert expr == ""
+    assert covered == set()
+
+
+def test_several_source_fields_satisfy_the_filter_if_any_of_them_match() -> None:
+    """Mirrors the Python matcher, which unions the values across source fields."""
+
+    expr, _ = _Stub(_capabilities())._filter_expression({"audience": "womens"})
+
+    assert expr == (
+        '(target_audience in ["womens"] or audience in ["womens"])'
+    )
+
+
+def test_filters_combine_with_and() -> None:
+    expr, covered = _Stub(_capabilities())._filter_expression(
+        {"primary_color": "black", "sizes": "2"}
+    )
+
+    # Ordered by filter name, so the same request always builds the same
+    # expression -- which makes it comparable between runs.
+    assert expr == (
+        '(primary_color in ["black"]) and (json_contains_any(sizes, ["2"]))'
+    )
+    assert covered == {"primary_color", "sizes"}
+
+
+def test_a_mixed_request_pushes_down_only_what_it_can() -> None:
+    """The number stays behind, and the caller is told so."""
+
+    expr, covered = _Stub(_capabilities())._filter_expression(
+        {"primary_color": "black", "price": {"max": 150}}
+    )
+
+    assert expr == '(primary_color in ["black"])'
+    assert covered == {"primary_color"}
+
+
+def test_a_value_that_cannot_be_written_as_a_literal_is_left_to_python() -> None:
+    """Rather than escaping a quote into an expression nobody can read."""
+
+    expr, covered = _Stub(_capabilities())._filter_expression(
+        {"primary_color": 'bl"ack'}
+    )
+
+    assert expr == ""
+    assert covered == set()
+
+
+def test_an_unknown_filter_is_ignored_by_the_builder() -> None:
+    """Validation refuses those earlier; the builder must not invent a clause."""
+
+    expr, covered = _Stub(_capabilities())._filter_expression({"nonesuch": "x"})
+
+    assert expr == ""
+    assert covered == set()

--- a/tests/unit/catalog_retriever/test_retriever.py
+++ b/tests/unit/catalog_retriever/test_retriever.py
@@ -1105,8 +1105,11 @@ class TestRetrieve:
     ) -> None:
         captured: Dict[str, Any] = {}
 
-        def _search(query: str, k: int = 4) -> List[Tuple[Any, float]]:
+        def _search(
+            query: str, k: int = 4, expr: str = ""
+        ) -> List[Tuple[Any, float]]:
             captured["query"] = query
+            captured["expr"] = expr
             return [(_doc("A"), 0.9)]
 
         retriever.text_db.similarity_search_with_relevance_scores = _search


### PR DESCRIPTION
The capabilities endpoint publishes the categories, subcategories and legal filter values, and the search tool is already constrained to them. The last step was missing: those filters never reached the database. Every search ranked the whole catalog and discarded the non-matches in Python.

## How a search works now

**1. The catalog publishes its shape.** `/capabilities` is generated from the data and its schema sidecar — no catalog values in code:

```
primary_color   type=enum       operators=[in]   values=[beige, black, blue, brown, gold, …]
apparel         subcategories=[blouses, camisoles, dresses, jumpsuits, skirts, sweaters, …]
```

**2. The tool schema is built from that**, so the model can only ask for a filter and a value that exist. Anything else is refused before a search happens.

**3. The validated filters become a database expression:**

```
request   categories=["dresses"]  filters={"primary_color":"black","sizes":"2"}

expression  (primary_color in ["black"])
        and (json_contains_any(sizes, ["2"]))
        and (subcategory in ["dresses"])
```

**4. Milvus applies it during the vector search**, so only matching products are ranked:

```
pushed down : primary_color, sizes, subcategory      left to python: none
candidates  : 5   ->  after python filter: 5         (was 215 before this change)
returned    : Black Satin Lace-Up Dress, Black Polka-Dotted Slip Dress, Belle Noir Satin Gown
```

The narrowing is real, not a post-filter: a search for *"sparkly diamond earrings"* filtered to boots returns four boots, none of which appear in the unfiltered top-4. Ranking everything and filtering afterwards would have returned nothing.

## What was done

- **Search filters in the database.** The expression is built from filters already validated against capabilities and applied during the vector search.
- **What can be pushed down is decided by the declared filter type**, never by field name: `enum` becomes a membership test, `enum_list` a containment test.
- **Numbers are deliberately left in Python.** Prices are stored as text, and `price >= 100` against a text field does not fail — it returns nothing. Every budget search would have looked like an empty catalog.
- **The Python matcher still runs as a check.** When the database decided every filter it must find nothing left to remove; a disagreement is logged rather than tolerated.
- **Product lookups read the index.** `/products/{id}` no longer needs a copy of the catalog in memory, and is shaped by the same `build_product_detail` as the loader, so the response cannot drift.
- **New diagnostics**: the expression, what was pushed down, what was left to Python, and how many rows Python removed.

## Why the pushdown is exact

Every value the catalog advertises was checked across all 215 products and 23 filters, and all are already stored in canonical form. So a database equality test and `_metadata_matches_value_filter` agree by construction rather than by approximation.

## Why this matters for scaling

The product lookup used to answer from `products_by_id`, an in-memory copy of the entire catalog held for the life of the process. That is why the catalog had to be resident at all: nothing else could say what a product is.

It now reads the index. That changes what a replica is:

- **Every replica no longer carries the catalog.** Memory per pod stops scaling with catalog size, so pods stay small and uniform and horizontal scaling is a matter of adding replicas rather than sizing them.
- **Replicas share one source of truth.** Two pods cannot disagree about a product because neither holds its own copy; both read the same collection.
- **Startup no longer has to load the catalog before serving reads.** That matters for rolling deploys, restarts and autoscaling, where slow start is what makes a pod look unhealthy.
- **The catalog can grow without changing the deployment.** A larger catalog is a larger collection, not a larger pod.

The snapshot is still loaded at startup, because indexing needs the records to embed them. This removes the dependency for **serving**, which is the part that runs on every replica.
