### PR TITLE
Product cards and the reply carry one order

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -65,6 +65,7 @@ from .turn_support import (
     _cart_quantity_provenance_issue,
     _cart_product_provenance_issue,
     _most_recently_shown,
+    _images_in_product_order,
     _in_presentation_order,
     _shopper_words_this_conversation,
     _cart_size_provenance_issue,
@@ -698,25 +699,12 @@ class DeepAgentsRuntime:
             raise
         # Re-raises whatever the turn raised, so failure handling is unchanged.
         output = await turn
-        # One order for both events: the cards and the sentences are the same
-        # list to a shopper, and "the second one" has to mean one product.
-        products = _in_presentation_order(
-            output.product_results or [], output.response or ""
-        )
+        products = output.product_results or []
         if products:
             yield json.dumps(
                 {"type": "products", "payload": products, "timestamp": time.time()}
             )
         images = output.retrieved or {}
-        shown = [
-            str(product.get("display_name") or "")
-            for product in products
-            if product.get("display_name")
-        ]
-        images = {
-            **{name: images[name] for name in shown if name in images},
-            **{name: url for name, url in images.items() if name not in set(shown)},
-        }
         yield json.dumps({"type": "images", "payload": images, "timestamp": time.time()})
         if output.response:
             yield json.dumps(
@@ -3101,6 +3089,18 @@ Rules:
         present_products: bool = True,
     ) -> bool:
         """Persist one terminal turn without changing its shopper response."""
+
+        # Ordered here, before the record is written and before the events are
+        # emitted, so the shopper, the durable index and the resolver all count
+        # the same list. Ordering only at the stream would have left "the second
+        # one" meaning the second shown to the shopper and the second ranked to
+        # the resolver.
+        state.product_results = _in_presentation_order(
+            state.product_results or [], state.response or ""
+        )
+        state.retrieved = _images_in_product_order(
+            state.retrieved or {}, state.product_results
+        )
 
         reason = termination_reason or str(
             state.agent_diagnostics.get("final_termination_reason") or "completed"

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -65,6 +65,7 @@ from .turn_support import (
     _cart_quantity_provenance_issue,
     _cart_product_provenance_issue,
     _most_recently_shown,
+    _in_presentation_order,
     _shopper_words_this_conversation,
     _cart_size_provenance_issue,
     _build_checkpointer,
@@ -697,12 +698,25 @@ class DeepAgentsRuntime:
             raise
         # Re-raises whatever the turn raised, so failure handling is unchanged.
         output = await turn
-        products = output.product_results or []
+        # One order for both events: the cards and the sentences are the same
+        # list to a shopper, and "the second one" has to mean one product.
+        products = _in_presentation_order(
+            output.product_results or [], output.response or ""
+        )
         if products:
             yield json.dumps(
                 {"type": "products", "payload": products, "timestamp": time.time()}
             )
         images = output.retrieved or {}
+        shown = [
+            str(product.get("display_name") or "")
+            for product in products
+            if product.get("display_name")
+        ]
+        images = {
+            **{name: images[name] for name in shown if name in images},
+            **{name: url for name, url in images.items() if name not in set(shown)},
+        }
         yield json.dumps({"type": "images", "payload": images, "timestamp": time.time()})
         if output.response:
             yield json.dumps(

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3692,6 +3692,45 @@ def _tool_search_mode(value: str | None) -> str | None:
 _NON_ATTRIBUTE_SEARCH_KEYS = frozenset({"catalog_text", "similarity", "taxonomy"})
 
 
+def _in_presentation_order(
+    products: list[dict[str, Any]],
+    reply: str,
+) -> list[dict[str, Any]]:
+    """The shown products, ordered as the reply presents them.
+
+    The cards and the words are the same list to a shopper, so "the second one"
+    has to mean one product. They were two orders: the cards followed the
+    catalog's ranking and the sentences followed whatever the model wrote, and
+    across recorded turns they disagreed about half the time.
+
+    The order is settled once, here, where the reply and the products are both
+    in hand -- so every consumer downstream renders one order rather than
+    each choosing its own.
+
+    This looks for the exact display names the service itself produced. It reads
+    nothing else out of the reply, and decides nothing but sequence: a product
+    the reply never names keeps its ranking, after the ones it does.
+    """
+
+    if not products or not reply:
+        return products
+    mentioned: list[tuple[int, int, dict[str, Any]]] = []
+    unmentioned: list[tuple[int, dict[str, Any]]] = []
+    for rank, product in enumerate(products):
+        name = str(product.get("display_name") or "")
+        at = reply.find(name) if name else -1
+        if at >= 0:
+            mentioned.append((at, rank, product))
+        else:
+            unmentioned.append((rank, product))
+    # Rank breaks ties, so two products named in the same breath keep the
+    # catalog's order between them.
+    mentioned.sort(key=lambda item: (item[0], item[1]))
+    return [product for _at, _rank, product in mentioned] + [
+        product for _rank, product in unmentioned
+    ]
+
+
 def _search_attribute_facts(product: Any) -> dict[str, str]:
     """Structured attributes the catalog confirmed for one search hit.
 

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -3731,6 +3731,32 @@ def _in_presentation_order(
     ]
 
 
+def _images_in_product_order(
+    images: dict[str, str],
+    products: list[dict[str, Any]],
+) -> dict[str, str]:
+    """The image map, following the product order, keeping every entry.
+
+    The cards render from this map, so it has to agree with the list beside it.
+    Anything it holds that the products do not name is kept at the end rather
+    than dropped: it was shown, and losing it would remove a card rather than
+    move one.
+    """
+
+    if not images:
+        return images
+    named = [
+        str(product.get("display_name") or "")
+        for product in products
+        if str(product.get("display_name") or "") in images
+    ]
+    seen = set(named)
+    return {
+        **{name: images[name] for name in named},
+        **{name: url for name, url in images.items() if name not in seen},
+    }
+
+
 def _search_attribute_facts(product: Any) -> dict[str, str]:
     """Structured attributes the catalog confirmed for one search hit.
 

--- a/tests/unit/chain_server/test_presentation_order.py
+++ b/tests/unit/chain_server/test_presentation_order.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The cards and the sentences are one list, so they carry one order."""
+
+from __future__ import annotations
+
+from chain_server.src.turn_support import _in_presentation_order
+
+
+def _p(name: str) -> dict:
+    return {"display_name": name}
+
+
+def test_products_follow_the_order_the_reply_presents_them() -> None:
+    """Measured across recorded turns, the two orders disagreed about half the
+    time. A shopper counting cards and a shopper counting sentences then mean
+    different products by "the second one"."""
+
+    products = [_p("Satin Effect Midi Skirt"), _p("Polished Pearl Skirt"), _p("Jasmine Silk Skirt")]
+    reply = "I'd start with the Jasmine Silk Skirt, then the Polished Pearl Skirt, then the Satin Effect Midi Skirt."
+
+    assert [p["display_name"] for p in _in_presentation_order(products, reply)] == [
+        "Jasmine Silk Skirt",
+        "Polished Pearl Skirt",
+        "Satin Effect Midi Skirt",
+    ]
+
+
+def test_a_product_the_reply_never_names_keeps_its_ranking_behind_the_named() -> None:
+    """It was still shown, so it is still offered -- just not ahead of the ones
+    the shopper was actually told about."""
+
+    products = [_p("Alpha Dress"), _p("Beta Dress"), _p("Gamma Dress")]
+    reply = "The Gamma Dress is the closest match."
+
+    assert [p["display_name"] for p in _in_presentation_order(products, reply)] == [
+        "Gamma Dress",
+        "Alpha Dress",
+        "Beta Dress",
+    ]
+
+
+def test_two_products_named_in_the_same_breath_keep_the_catalog_order() -> None:
+    """Nothing in the sentence separates them, so ranking is the tiebreak."""
+
+    products = [_p("Alpha Dress"), _p("Beta Dress")]
+    reply = "Both the Beta Dress and Alpha Dress work."
+
+    ordered = [p["display_name"] for p in _in_presentation_order(products, reply)]
+    assert ordered == ["Beta Dress", "Alpha Dress"]
+
+
+def test_a_reply_that_names_nothing_leaves_the_ranking_alone() -> None:
+    products = [_p("Alpha Dress"), _p("Beta Dress")]
+
+    assert _in_presentation_order(products, "Here are some options.") == products
+
+
+def test_an_empty_reply_leaves_the_ranking_alone() -> None:
+    products = [_p("Alpha Dress")]
+
+    assert _in_presentation_order(products, "") == products
+
+
+def test_no_products_is_not_an_error() -> None:
+    assert _in_presentation_order([], "anything") == []

--- a/tests/unit/chain_server/test_presentation_order.py
+++ b/tests/unit/chain_server/test_presentation_order.py
@@ -65,3 +65,32 @@ def test_an_empty_reply_leaves_the_ranking_alone() -> None:
 
 def test_no_products_is_not_an_error() -> None:
     assert _in_presentation_order([], "anything") == []
+
+
+def test_the_images_follow_the_products_and_lose_nothing() -> None:
+    """The cards render from this map, so it must agree with the list beside it."""
+
+    from chain_server.src.turn_support import _images_in_product_order
+
+    images = {"Alpha Dress": "/a.jpg", "Beta Dress": "/b.jpg", "Gamma Dress": "/g.jpg"}
+    products = [_p("Gamma Dress"), _p("Alpha Dress"), _p("Beta Dress")]
+
+    assert list(_images_in_product_order(images, products)) == [
+        "Gamma Dress",
+        "Alpha Dress",
+        "Beta Dress",
+    ]
+
+
+def test_an_image_the_products_do_not_name_is_kept_at_the_end() -> None:
+    """It was shown. Dropping it would remove a card rather than move one."""
+
+    from chain_server.src.turn_support import _images_in_product_order
+
+    images = {"Alpha Dress": "/a.jpg", "Orphan Dress": "/o.jpg"}
+    products = [_p("Alpha Dress")]
+
+    ordered = _images_in_product_order(images, products)
+
+    assert list(ordered) == ["Alpha Dress", "Orphan Dress"]
+    assert ordered["Orphan Dress"] == "/o.jpg"

--- a/ui/src/chatbox.css
+++ b/ui/src/chatbox.css
@@ -437,11 +437,48 @@ html {
   padding-top: 2px;
 }
 
+.product-detail-panel__detail {
+  /* Scrolls on its own, so a long description no longer starves the list.
+     The max-height keeps a dragged pixel height from starving it again when
+     the window is made smaller -- the browser clamps it without any resize
+     listener. 102px is the list minimum plus the handle. */
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  max-height: calc(100% - 102px);
+  min-height: 140px;
+  overflow-y: auto;
+}
+
+.product-detail-panel__resizer {
+  background: var(--line);
+  cursor: row-resize;
+  flex: 0 0 6px;
+  position: relative;
+  touch-action: none;
+}
+
+.product-detail-panel__resizer::after {
+  background: var(--panel-soft);
+  border-radius: 2px;
+  content: "";
+  height: 2px;
+  left: 50%;
+  position: absolute;
+  top: 2px;
+  transform: translateX(-50%);
+  width: 28px;
+}
+
+.product-detail-panel__resizer:hover {
+  background: var(--brand, #76b900);
+}
+
 .product-detail-panel__recent {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  min-height: 0;
+  min-height: 96px;
   padding: 14px;
 }
 

--- a/ui/src/components/ProductDetailPanel.tsx
+++ b/ui/src/components/ProductDetailPanel.tsx
@@ -86,9 +86,6 @@ const ProductDetailPanel: React.FC<ProductDetailPanelProps> = ({
               {selectedProduct.price && (
                 <span>{formatPrice(selectedProduct.price)}</span>
               )}
-              {selectedProduct.availability && (
-                <span>{formatAvailability(selectedProduct.availability)}</span>
-              )}
               {selectedProduct.brand && <span>{selectedProduct.brand}</span>}
             </div>
 
@@ -164,14 +161,6 @@ const formatPrice = (price: ProductPrice): string => {
   } catch {
     return `$${price.amount.toFixed(2)}`;
   }
-};
-
-const formatAvailability = (availability: string): string => {
-  return availability
-    .split("_")
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
 };
 
 const getCatalogFacts = (product: ProductSummary | null): string[] => {

--- a/ui/src/components/ProductDetailPanel.tsx
+++ b/ui/src/components/ProductDetailPanel.tsx
@@ -5,9 +5,13 @@
  * Product inspection panel for catalog results returned by the assistant.
  */
 
-import React from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { ProductDetailPanelProps, ProductPrice, ProductSummary } from "../types";
 import { getDefaultImage } from "../config/config";
+
+/** Neither half of the panel may be driven to nothing by a drag. */
+const MIN_DETAIL_HEIGHT = 140;
+const MIN_RECENT_HEIGHT = 96;
 
 const ProductDetailPanel: React.FC<ProductDetailPanelProps> = ({
   selectedProduct,
@@ -17,8 +21,55 @@ const ProductDetailPanel: React.FC<ProductDetailPanelProps> = ({
   const displayImage = selectedProduct?.productUrl || getDefaultImage();
   const catalogFacts = getCatalogFacts(selectedProduct);
 
+  // The detail area used to take whatever height its content wanted, so a
+  // product with a long description squeezed the list below it to nothing and
+  // there was no longer anything to scroll. Its height is a split the shopper
+  // sets instead, and neither half can be driven to zero.
+  const panelRef = useRef<HTMLElement | null>(null);
+  const [detailHeight, setDetailHeight] = useState<number | null>(null);
+
+  const startResize = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    event.preventDefault();
+    const handle = event.currentTarget;
+    const { pointerId } = event;
+    handle.setPointerCapture(pointerId);
+
+    const onMove = (move: PointerEvent) => {
+      const bounds = panel.getBoundingClientRect();
+      const next = move.clientY - bounds.top;
+      const largest = bounds.height - MIN_RECENT_HEIGHT;
+      setDetailHeight(Math.max(MIN_DETAIL_HEIGHT, Math.min(next, largest)));
+    };
+    const onUp = () => {
+      // Releasing a pointer that has already gone throws, and a cancelled
+      // gesture never sends pointerup -- both would leave the handle dragging
+      // for the rest of the session.
+      try {
+        handle.releasePointerCapture(pointerId);
+      } catch {
+        /* already released */
+      }
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      handle.removeEventListener("pointercancel", onUp);
+    };
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+    handle.addEventListener("pointercancel", onUp);
+  }, []);
+
   return (
-    <aside className="product-detail-panel" aria-label="Product detail panel">
+    <aside
+      className="product-detail-panel"
+      aria-label="Product detail panel"
+      ref={panelRef}
+    >
+      <div
+        className="product-detail-panel__detail"
+        style={detailHeight === null ? undefined : { flex: `0 0 ${detailHeight}px` }}
+      >
       <div className="product-detail-panel__media">
         <img src={displayImage} alt={selectedProduct?.productName || "Product preview"} />
       </div>
@@ -65,6 +116,17 @@ const ProductDetailPanel: React.FC<ProductDetailPanelProps> = ({
           </>
         )}
       </div>
+      </div>
+
+      {products.length > 0 && (
+        <div
+          className="product-detail-panel__resizer"
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize product details"
+          onPointerDown={startResize}
+        />
+      )}
 
       {products.length > 0 && (
         <div className="product-detail-panel__recent" aria-label="Recent catalog results">

--- a/ui/src/components/chatbox/chatbox.tsx
+++ b/ui/src/components/chatbox/chatbox.tsx
@@ -269,6 +269,8 @@ const Chatbox: React.FC<ChatboxProps> = ({
   const [lastAssistantIndex, setLastAssistantIndex] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const productsByNameRef = useRef<Map<string, ProductSummary>>(new Map());
+  //: Display order for the panel: most recent turn first, catalog rank within it.
+  const productOrderRef = useRef<string[]>([]);
   const currentTurnHasMedia = useRef(false);
   const currentTurnGuardrails = useRef(isGuardrailsOn);
   const inFlightRef = useRef<AbortController | null>(null);
@@ -472,11 +474,23 @@ const Chatbox: React.FC<ChatboxProps> = ({
   };
 
   const mergeProductResults = (products: ProductSummary[]): ProductSummary[] => {
-    products.forEach((product) => {
-      productsByNameRef.current.set(productKey(product.productName), product);
+    const arriving = products.map((product) => productKey(product.productName));
+    products.forEach((product, index) => {
+      productsByNameRef.current.set(arriving[index], product);
     });
 
-    const nextProducts = Array.from(productsByNameRef.current.values());
+    // The panel is titled "Recent results", so the newest turn goes on top --
+    // but within a turn the catalog's ranking is kept, because the first result
+    // is the best match and reversing the whole list would put the worst one
+    // first and select it.
+    productOrderRef.current = [
+      ...arriving,
+      ...productOrderRef.current.filter((key) => !arriving.includes(key)),
+    ];
+
+    const nextProducts = productOrderRef.current
+      .map((key) => productsByNameRef.current.get(key))
+      .filter((product): product is ProductSummary => Boolean(product));
     onProductsUpdate(nextProducts);
 
     const hasSelectedProduct =
@@ -820,6 +834,7 @@ const Chatbox: React.FC<ChatboxProps> = ({
     setModelUsage({});
     setSessionUsage(sessionUsageRef.current);
     productsByNameRef.current.clear();
+    productOrderRef.current = [];
     onProductSelect(null);
     onProductsUpdate([]);
     if (clearIdentity) {


### PR DESCRIPTION
To a shopper, the product cards and the product names in the reply are the same list. "The second one" has to mean one product.

They were two orders: the cards followed the catalog's ranking, the sentences followed whatever the model wrote. Across the turns already recorded, **they disagreed in 46 of 96**.

```
cards : Satin Effect Midi Skirt, Polished Pearl Skirt, Jasmine Silk Skirt
text  : Jasmine Silk Skirt, Polished Pearl Skirt, Satin Effect Midi Skirt
```

## What was done

- **The order is settled once, at turn finalisation** — before the record is persisted and before the events are emitted — so the shopper, the durable index and the resolver all count the same list. Ordinals are derived by position from that record, so ordinal 1 is now the first product the shopper saw.
- **A product the reply never names keeps its ranking**, behind the ones it does. It was still shown, so it is still offered.
- **The image map follows the product order and keeps every entry.** One it does not name goes to the end rather than being dropped — that would remove a card rather than move one.
- **"Recent results" shows the most recent turn first**, with the catalog's ranking kept inside each turn. A plain reverse would have put the worst match on top, and the panel selects its first item.
- **The detail area scrolls on its own, and a drag handle sets the split.** The list had stopped scrolling because it had nothing left to scroll: the image and detail body took whatever height their content wanted and the list got the remainder. Neither half can now be driven to zero, and a dragged height is clamped in CSS so shrinking the window cannot starve the list again.

## Not in this change

- When a reply offers complete outfits — "option 1: this dress with these shoes and this bag" — the cards are still one flat row. Grouping per option is a better answer for that shape and is a separate change.
- The split is not remembered across a reload, and the drag handle has no keyboard equivalent.
