### PR TITLE
A filter belongs to the product it was given for

### DIFF
--- a/chain_server/skills/shopper/product-discovery/SKILL.md
+++ b/chain_server/skills/shopper/product-discovery/SKILL.md
@@ -80,11 +80,12 @@ Use for search, browse, and filter requests. Do not expose skill names or tool n
 
 ## Filter Discipline
 
+- A constraint belongs to the product it was said about, and to no other. "A dress in size 2 and shoes" sizes the dress; the shoes were given no size, so their scope carries none. Repeating it onto the shoes does not widen the search, it empties it. Ask for the missing size, or show the role unsized -- never borrow one from another role.
 - Interpret the shopper's meaning against the catalog capabilities and choose only exact advertised taxonomy values that faithfully match. Generic product language is not taxonomy evidence.
 - If an explicitly requested product type is not separately advertised, use one model-selected advertised parent category only when it is a faithful broader scope. Keep the requested type explicit, label results with their actual catalog categories, and say they are closest alternatives. If no faithful parent can be selected, ask one concise clarification without calling the search tool; never omit the type, silently choose a sibling, or claim catalog absence.
 - Use only advertised filter values from the catalog capabilities.
 - Subjective style or vibe language belongs in the semantic query, not `unadvertised_requirements`. That field is only for directly stated objective product requirements the catalog cannot enforce.
-- Preserve every explicit must-have. Use its exact advertised property in `required_constraints`, or `unadvertised_requirements` when the property is absent; let deterministic validation report what the catalog cannot enforce rather than omitting or weakening it.
+- Preserve every explicit must-have, on the role it was given for. Use its exact advertised property in `required_constraints`, or `unadvertised_requirements` when the property is absent; let deterministic validation report what the catalog cannot enforce rather than omitting or weakening it.
 - When one shopper constraint maps to multiple advertised enum values, include all faithful values in one list and one search rather than retrying one value at a time.
 - If the shopper names a preference the catalog cannot enforce as a hard filter, place it in the semantic query and tell the shopper it is a preference signal, not a guaranteed filter.
 - If the shopper states an unsupported constraint as a must-have, do not weaken it into a preference or search as though it were guaranteed. Say that the catalog cannot enforce it and ask whether the shopper wants a preference-only search.

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -1136,8 +1136,11 @@ def _search_catalog_tool_input_model(
                 ...,
                 description=(
                     "Catalog hard filters and any defining requirement the active "
-                    "catalog cannot enforce. Apply constraints only when the "
-                    "current turn states them for the target products; an anchor's "
+                    "catalog cannot enforce. A modifier belongs to the product it "
+                    "was said about: in 'a dress in size 2 and shoes', size 2 is "
+                    "the dress's and the shoes have no size. Apply constraints "
+                    "only when the current turn states them for the target "
+                    "products; an anchor's "
                     "attributes belong in semantic styling context unless the "
                     "shopper explicitly requests the same value. Use only the "
                     "advertised properties "
@@ -1210,7 +1213,13 @@ def _search_catalog_scopes_input_model(
                 description=(
                     "One search scope per advertised category. Each scope owns "
                     "its own taxonomy and constraints, so a filter for one role "
-                    "can never exclude another role's products."
+                    "can never exclude another role's products -- and equally, a "
+                    "filter the shopper gave for one role must not be repeated "
+                    "onto another. A filter this role was never given empties "
+                    "this role's results: 'a dress in size 2 and shoes' sizes "
+                    "the dress and says nothing about the shoes, so the shoes "
+                    "scope carries no size. Leave a constraint out rather than "
+                    "carry one across."
                 ),
             ),
         ),


### PR DESCRIPTION
A shopper says *"Cancun wedding next week, need a dress in size 2 and shoes"*. Size 2 is the dress's. The shoes were given no size — but the search request carried size 2 onto the shoes scope as well, and since no shoe in this catalog is sold in a 2, the shoes came back empty or wrong.

- **The size was not invented, it was misattributed.** Every existing guard asks whether a value is *valid* — advertised by the catalog, stated by the shopper. Size 2 passed both. Nothing asked the only question that mattered: *which product was it said about?*
- **The request could express the wrong thing and not the right one.** A scope could say "shoes, size 2". It had no way to carry "size 2, because it was said about the dress". Attribution was lost at the point the search request is built, so no downstream check could recover it.
- **A filter the shopper never gave does not widen a search, it empties one.** Repeating the dress's size onto footwear is not a harmless extra hint — it excludes every shoe.

**The change**

- The `scopes` field now states that a filter given for one role must not be repeated onto another, and that leaving a constraint out is correct when the shopper did not give it for that role.
- The `required_constraints` field now states that a modifier belongs to the product it was said about.
- The product-discovery skill gains the same rule as its first point of filter discipline, and its "preserve every explicit must-have" line now says **on the role it was given for**.

All three are in the channel the model actually fills in when it builds the request — the schema it reads while choosing scopes — rather than prose in a general instruction it has already read past. No phrase or word matching anywhere.

**Before / after**

Measured on the same phrasing against the running stack:

| | shoes scope |
|---|---|
| before | carried the dress's size on roughly a third of multi-scope attempts, returning nothing |
| after | left unsized in 6 of 6 attempts, with the dress correctly sized in all 6 |

Six clean attempts is evidence, not proof of zero. The dress is still sized, so nothing was traded away to get it.

**What this does not change**

- No gate is loosened. The size-provenance check on the cart write path is untouched.
- A size the shopper *does* give for a role is still applied to that role.