### PR TITLE
The schema advertises the catalog; the body adjudicates it

### DIFF
--- a/chain_server/src/tool_loop_control.py
+++ b/chain_server/src/tool_loop_control.py
@@ -249,8 +249,8 @@ class ToolLoopControlMiddleware(AgentMiddleware):
                 continue
             if SEARCH_SCOPE_COMPLETE_PREFIX in content:
                 self._synthesis_required = True
-            elif content.startswith(
-                (SEARCH_VALIDATION_ERROR_PREFIX, CONSTRAINT_REVIEW_PREFIX)
+            elif _validation_error_body(content) or content.startswith(
+                CONSTRAINT_REVIEW_PREFIX
             ):
                 self._queue_repair(messages, tool_call_id, content)
             elif "SEARCH_RESULT_GROUNDING_NOTE" in content:
@@ -609,10 +609,24 @@ def _singularize_scope_word(word: str) -> str:
     return word
 
 
+def _validation_error_body(content: str) -> str:
+    """The validator's verdict inside a tool message, or "" if there is none.
+
+    The verdict does not always start the message. When a scope names a kind the
+    catalog does not carry, the body says so first and appends the mismatch --
+    so a `startswith` test misses it, no repair is queued, and the bounded-repair
+    accounting never runs. Matching anywhere is how `SEARCH_SCOPE_COMPLETE` is
+    already read, and for the same reason.
+    """
+
+    index = content.find(SEARCH_VALIDATION_ERROR_PREFIX)
+    return content[index:] if index >= 0 else ""
+
+
 def _sanitize_repair_feedback(content: str) -> str:
     """Remove rejected arguments and retain only safe schema field names."""
 
-    feedback = content.strip()
+    feedback = (_validation_error_body(content) or content).strip()
     if feedback.startswith(SEARCH_VALIDATION_ERROR_PREFIX):
         feedback = feedback.removeprefix(SEARCH_VALIDATION_ERROR_PREFIX).strip()
         if feedback.startswith("{"):
@@ -634,6 +648,11 @@ def _native_validation_fields(content: str) -> set[str]:
     _, separator, validation_error = content.rpartition(" with error:\n")
     if not separator:
         return set()
+    # Under the scoped contract every location reads `scopes.<n>.<field>`, so
+    # the first segment is always "scopes" and nothing ever matched. The result
+    # was an empty set, read by the caller as "nothing identifiable", and the
+    # model was told only that validation had failed -- `BUGS_OPEN` item 8.
+    validation_error = re.sub(r"^scopes\.\d+\.", "", validation_error, flags=re.M)
     field_names = {
         "semantic_query",
         "shopper_guidance",
@@ -654,9 +673,10 @@ def _native_validation_fields(content: str) -> set[str]:
 def _is_native_validation_failure(content: str) -> bool:
     """Return whether ToolNode rejected arguments before tool execution."""
 
-    if not content.startswith(SEARCH_VALIDATION_ERROR_PREFIX):
+    body = _validation_error_body(content)
+    if not body:
         return False
-    feedback = content.removeprefix(SEARCH_VALIDATION_ERROR_PREFIX).lstrip()
+    feedback = body.removeprefix(SEARCH_VALIDATION_ERROR_PREFIX).lstrip()
     return feedback.startswith("{")
 
 

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -1170,6 +1170,61 @@ def _search_catalog_tool_input_model(
     )
 
 
+def _scope_content_errors_only(errors: Sequence[Any]) -> bool:
+    """Whether every error is about what is *inside* a scope.
+
+    A location of ``("scopes", 0, "required_constraints", ...)`` is one role's
+    content: the model chose a value this catalog does not advertise. Anything
+    shorter is structural -- too many scopes, a scope that is not an object, a
+    malformed ``not_covered`` -- and remains a hard failure at the boundary.
+    """
+
+    for error in errors:
+        location = tuple(error.get("loc") or ())
+        if len(location) < 3:
+            return False
+        if location[0] != "scopes" or not isinstance(location[1], int):
+            return False
+    return True
+
+
+def _admit_scopes_for_adjudication(cls: Any, data: Any, handler: Any) -> Any:
+    """Let the search body judge scope content, one role at a time.
+
+    The tool schema is how the catalog's shape reaches the model: every
+    advertised value is in it, and it must stay exact. But a schema bound as
+    ``args_schema`` also *adjudicates*, and it can only do so for the whole
+    call. One unadvertised colour on a third scope therefore cancelled two
+    valid searches, and the shopper was told the assistant could not search at
+    all -- observed live, `BUGS_OPEN` item 7.
+
+    `search_catalog` already validates each scope against this same model and
+    already reports rejections per role. It was built that way. Nothing reached
+    it, because the boundary answered first.
+
+    So the schema keeps advertising and stops adjudicating scope content: when
+    every complaint is about what is inside a scope, the raw scopes are admitted
+    and the body decides them one at a time -- rejecting the role that is wrong
+    and running the roles that are right. Structural complaints still fail here,
+    where they are the boundary's own business.
+    """
+
+    try:
+        return handler(data)
+    except ValidationError as exc:
+        if not isinstance(data, dict):
+            raise
+        if not _scope_content_errors_only(exc.errors()):
+            raise
+        scopes = data.get("scopes")
+        if not isinstance(scopes, list) or not scopes:
+            raise
+        return cls.model_construct(
+            scopes=list(scopes),
+            not_covered=data.get("not_covered"),
+        )
+
+
 def _search_catalog_scopes_input_model(
     capabilities: CatalogCapabilities,
     *,
@@ -1228,6 +1283,11 @@ def _search_catalog_scopes_input_model(
                 ),
             ),
         ),
+        __validators__={
+            "_admit_scopes_for_adjudication": model_validator(mode="wrap")(
+                classmethod(_admit_scopes_for_adjudication)
+            ),
+        },
     )
 
 

--- a/tests/unit/chain_server/test_catalog_search_rejections.py
+++ b/tests/unit/chain_server/test_catalog_search_rejections.py
@@ -565,3 +565,48 @@ def test_an_advertised_type_rejected_on_its_taxonomy_is_not_called_uncarried() -
     text, artifact = result if isinstance(result, tuple) else (result, None)
     assert NOT_CARRIED_KEY not in (artifact or {})
     assert "NOT_CARRIED" not in text
+
+
+def test_one_rejected_scope_does_not_cancel_the_scopes_beside_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shopper asked for a look and got nothing, over one word.
+
+    The model composed three roles and wrote an unadvertised colour on the
+    third. The whole call was refused at the tool boundary, so the two sound
+    roles never reached this function -- which had been built all along to judge
+    each role on its own and run the ones that stand up.
+    """
+
+    searched: list[str] = []
+
+    def _record(plan: Any, *_args: Any, **_kwargs: Any) -> Any:
+        searched.extend(plan.semantic_queries)
+        return SimpleNamespace(
+            result=SearchCatalogResult(ok=True, products=[]),
+            fallback_attempted=False,
+            fallback_used=False,
+        )
+
+    monkeypatch.setattr(catalog_search_mod, "execute_catalog_search", _record)
+
+    ctx = _context("a black dress and a tan tote bag")
+    result = search_catalog(
+        ctx,
+        [
+            _scope(
+                semantic_query="black dresses",
+                requested_product_type="dresses",
+                taxonomy={"category": ["apparel"], "subcategory": ["dresses"]},
+                required_constraints={"color": ["black"]},
+            ),
+            _scope(
+                semantic_query="tan tote bags",
+                required_constraints={"color": ["tan"]},
+            ),
+        ],
+    )
+
+    # The sound role ran; the unsound one did not.
+    assert searched == ["black dresses"]
+    assert SearchRejection.CAPABILITIES_SCHEMA_MISMATCH in _rejection_codes(result)

--- a/tests/unit/chain_server/test_search_boundary_adjudication.py
+++ b/tests/unit/chain_server/test_search_boundary_adjudication.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The tool schema advertises the catalog; the search body adjudicates it.
+
+A shopper uploaded a video and asked for something similar. The model composed
+three scopes -- a sweater, jeans, and brown heels -- and wrote `tan` for the
+heels, a colour this catalog does not advertise. Every scope died with it and
+the shopper was told "I couldn't complete a valid catalog search", having been
+shown neither the sweaters nor anything else.
+
+`search_catalog` already validates each scope and already reports rejections one
+role at a time. Nothing reached it, because `args_schema` answered first and can
+only answer for the whole call.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from chain_server.src.turn_support import _search_catalog_scopes_input_model
+from shared.commerce_contracts import (
+    CatalogCapabilities,
+    CatalogFilterCapability,
+    CatalogTaxonomyCapabilities,
+    CatalogTaxonomyCategory,
+    CatalogTaxonomySubcategory,
+)
+
+
+def _capabilities() -> CatalogCapabilities:
+    return CatalogCapabilities(
+        catalog_id="fashion",
+        retrieval_modes=["text"],
+        filters={
+            "category": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["category"],
+                values=["apparel", "footwear"],
+            ),
+            "subcategory": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["subcategory"],
+                values=["sweaters", "heels"],
+            ),
+            "primary_color": CatalogFilterCapability(
+                type="enum",
+                operators=["in"],
+                source_fields=["primary_color"],
+                values=["beige", "brown"],
+            ),
+        },
+        taxonomy=CatalogTaxonomyCapabilities(
+            category_field="category",
+            subcategory_field="subcategory",
+            categories={
+                "apparel": CatalogTaxonomyCategory(
+                    product_count=2,
+                    subcategories={
+                        "sweaters": CatalogTaxonomySubcategory(product_count=2)
+                    },
+                ),
+                "footwear": CatalogTaxonomyCategory(
+                    product_count=2,
+                    subcategories={
+                        "heels": CatalogTaxonomySubcategory(product_count=2)
+                    },
+                ),
+            },
+        ),
+    )
+
+
+def _scope(
+    product_type: str,
+    category: str,
+    subcategory: list[str],
+    colors: list[str] | None = None,
+) -> dict:
+    scope: dict = {
+        "semantic_query": f"a {product_type}",
+        "shopper_guidance": f"Looking for a {product_type}.",
+        "requested_product_type": product_type,
+        "taxonomy": {"category": [category], "subcategory": subcategory},
+        "required_constraints": {},
+        "scope_complete": True,
+        "search_mode": "text",
+    }
+    if colors is not None:
+        scope["required_constraints"] = {"primary_color": colors}
+    return scope
+
+
+def _model():
+    return _search_catalog_scopes_input_model(_capabilities(), max_scopes=4)
+
+
+def test_an_unadvertised_value_in_one_scope_does_not_cancel_the_others() -> None:
+    """The live failure: `tan` on the heels killed the sweaters as well."""
+
+    validated = _model().model_validate(
+        {
+            "scopes": [
+                _scope("sweater", "apparel", ["sweaters"]),
+                _scope("heels", "footwear", ["heels"], ["brown", "tan"]),
+            ],
+            "not_covered": None,
+        }
+    )
+
+    assert len(validated.scopes) == 2
+    # Admitted whole and unaltered, so the body judges each role on its merits
+    # and the offending value is still there to be named in the rejection.
+    sweater, heels = validated.scopes
+    assert sweater["requested_product_type"] == "sweater"
+    assert heels["required_constraints"]["primary_color"] == ["brown", "tan"]
+
+
+def test_a_call_the_catalog_fully_advertises_is_validated_as_before() -> None:
+    """Nothing changes for a well-formed call: it still arrives typed."""
+
+    validated = _model().model_validate(
+        {"scopes": [_scope("sweater", "apparel", ["sweaters"], ["beige"])]}
+    )
+
+    scope = validated.scopes[0]
+    assert not isinstance(scope, dict)
+    assert scope.requested_product_type == "sweater"
+
+
+def test_the_schema_still_advertises_every_value_it_no_longer_enforces() -> None:
+    """The schema is how the catalog's shape reaches the model.
+
+    Relaxing what it *rejects* must not relax what it *publishes*, or the model
+    loses the only list of advertised values it is given.
+    """
+
+    schema = json.dumps(_model().model_json_schema())
+
+    for advertised in ("apparel", "footwear", "sweaters", "heels", "beige", "brown"):
+        assert f'"{advertised}"' in schema
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"scopes": []}, id="no scopes at all"),
+        pytest.param({"scopes": ["not an object"]}, id="a scope that is not an object"),
+        pytest.param(
+            {"scopes": [_scope("sweater", "apparel", ["sweaters"])] * 5},
+            id="more scopes than the call allows",
+        ),
+        pytest.param(
+            {
+                "scopes": [_scope("sweater", "apparel", ["sweaters"])],
+                "not_covered": [1, 2],
+            },
+            id="a malformed not_covered",
+        ),
+    ],
+)
+def test_a_structurally_malformed_call_is_still_refused_at_the_boundary(
+    payload: dict,
+) -> None:
+    """Only scope *content* is delegated. The call's shape stays the boundary's."""
+
+    with pytest.raises(ValidationError):
+        _model().model_validate(payload)
+
+
+def test_a_verdict_that_follows_another_notice_is_still_found() -> None:
+    """The body says what is not carried first, then why the scope was refused.
+
+    Read with `startswith`, that verdict was invisible: no repair was queued and
+    the bounded-repair accounting never ran.
+    """
+
+    from chain_server.src.tool_loop_control import (
+        SEARCH_VALIDATION_ERROR_PREFIX,
+        _validation_error_body,
+    )
+
+    content = (
+        "NOT_CARRIED: this catalog advertises nothing of these kinds: jeans\n\n"
+        + SEARCH_VALIDATION_ERROR_PREFIX
+        + "The catalog search request does not match current capabilities: []"
+    )
+
+    assert _validation_error_body(content).startswith(SEARCH_VALIDATION_ERROR_PREFIX)
+    assert _validation_error_body("a search that simply found nothing") == ""
+
+
+def test_the_repair_feedback_carries_the_verdict_rather_than_its_existence() -> None:
+    """What the model was told when it wrote `tan`, and what it is told now.
+
+    Pydantic named the scope, the field, the offending value and every value
+    that would have been right. The model received
+    "Tool arguments failed schema validation." and repeated the mistake.
+    """
+
+    from chain_server.src.tool_loop_control import (
+        SEARCH_VALIDATION_ERROR_PREFIX,
+        _sanitize_repair_feedback,
+    )
+
+    content = (
+        "NOT_CARRIED: nothing of these kinds: jeans\n\n"
+        + SEARCH_VALIDATION_ERROR_PREFIX
+        + "The catalog search request does not match current capabilities: "
+        "[{'loc': ['required_constraints', 'primary_color'], "
+        "'msg': \"Input should be 'beige' or 'brown'\"}]"
+    )
+
+    feedback = _sanitize_repair_feedback(content)
+
+    assert "primary_color" in feedback
+    assert "'beige' or 'brown'" in feedback
+    assert feedback != "Tool arguments failed schema validation."
+
+
+def test_a_scoped_error_location_names_the_field_inside_the_scope() -> None:
+    """Every scoped location reads `scopes.<n>.<field>`.
+
+    Matching the first segment against the field names therefore matched
+    "scopes" every time and nothing else, so the extractor returned an empty
+    set on every scoped failure and the caller read that as "nothing to say".
+    """
+
+    from chain_server.src.tool_loop_control import (
+        SEARCH_VALIDATION_ERROR_PREFIX,
+        _native_validation_fields,
+    )
+
+    content = (
+        SEARCH_VALIDATION_ERROR_PREFIX
+        + "{'scopes': []} with error:\n"
+        + "scopes.2.required_constraints.primary_color\n"
+        + "  Input should be 'beige' or 'brown'\n"
+        + "scopes.0.taxonomy.subcategory\n"
+        + "  Input should be 'sweaters' or 'heels'\n"
+    )
+
+    assert _native_validation_fields(content) == {
+        "required_constraints",
+        "taxonomy",
+    }


### PR DESCRIPTION
A shopper uploaded a video and asked for something similar. Perception was right — cream sweater, dark jeans, brown heeled shoes. The reply was *"I couldn't complete a valid catalog search for that request."*

The model composed three scopes and wrote `tan` for the shoes, a colour this catalog does not advertise. `tan` was the only thing wrong with the call.

- **One word cancelled two sound searches.** The sweater and jeans scopes were valid on their own and died with the third.
- **The body was already built for this.** `search_catalog` validates each scope and rejects one role at a time. Nothing reached it: `args_schema` answers first, and it can only answer for the whole call.
- **The model was told nothing it could act on.** Pydantic named the scope, the field, the value and the sixteen alternatives. The repair message was `Tool arguments failed schema validation.` It retried and kept `tan`.

**What changed**

- Scope *content* errors are admitted at the boundary and decided by the body, which rejects the wrong role and runs the right ones.
- Structural errors — scope count, a scope that is not an object, a malformed `not_covered` — still fail at the boundary.
- The schema is unchanged and still publishes every advertised value; a test fails if one stops reaching the model.
- A verdict that *follows* another notice is found again. The body prefixes `NOT_CARRIED:` when a scope names a kind the catalog lacks, so a `startswith` test missed the verdict behind it and no repair was ever queued.
- A scoped error location now names the field inside the scope. Every location reads `scopes.<n>.<field>`, so matching the first segment matched `scopes` every time and the extractor returned an empty set on every scoped failure.

**Before / after** — same video, same request, against the running stack:

| | result |
|---|---|
| before | 0 products, "I couldn't complete a valid catalog search" |
| after | 4 sweaters, priced and described |

Capabilities remain the only published shape, and a value outside them is still refused — now by the role that used it, not the call that contained it.
