### PR TITLE
A choice the record made outlives the turn that made it

### DIFF
--- a/chain_server/src/agenttypes.py
+++ b/chain_server/src/agenttypes.py
@@ -125,6 +125,10 @@ class State(BaseModel):
         default_factory=list,
         description="Typed prior turns; authoritative for shopper intent context"
     )
+    #: Products the record itself picked this turn, by ref. Written where the
+    #: resolutions land and read at finalization, so the choice can be recorded
+    #: durably instead of expiring with the message that made it.
+    system_identified_products: List[str] = Field(default_factory=list)
     historical_product_sets: List[Dict[str, Any]] = Field(
         default_factory=list,
         description=(

--- a/chain_server/src/conversation_products.py
+++ b/chain_server/src/conversation_products.py
@@ -280,6 +280,18 @@ class ProductEvidence:
 
         return (product_ref or "").strip() in self._system_identified
 
+    def system_identified(self) -> tuple[str, ...]:
+        """Every product the record picked this turn, in a stable order.
+
+        Read at finalization so the choice can be recorded. A shopper who says
+        "add the first pairing" has chosen, by a coordinate the system itself
+        wrote down -- and that choice used to be forgotten the moment the turn
+        ended, leaving them to say it again, and again, until they typed the
+        catalog's own names.
+        """
+
+        return tuple(sorted(self._system_identified))
+
     def get(self, product_ref: str) -> ProductSummary | None:
         return self._products.get((product_ref or "").strip())
 

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -56,6 +56,7 @@ from .turn_support import (
     _append_product_results,
     _detail_fields_already_held,
     _search_catalog_scopes_input_model,
+    _system_identification_events,
     _turn_audience_events,
     AddCartItemsToolItemInput,
     RequestIdentity,
@@ -64,6 +65,7 @@ from .turn_support import (
     _cart_line_size,
     _cart_quantity_provenance_issue,
     _cart_product_provenance_issue,
+    _identified_in_the_current_showing,
     _most_recently_shown,
     _images_in_product_order,
     _in_presentation_order,
@@ -1438,6 +1440,9 @@ class DeepAgentsRuntime:
                     "the shopper means; do not guess or search for a substitute."
                 )
             scope.product_evidence.add_resolutions(result.results, references)
+            state.system_identified_products = list(
+                scope.product_evidence.system_identified()
+            )
             for resolution in result.results:
                 if resolution.status != "resolved":
                     continue
@@ -1527,6 +1532,9 @@ class DeepAgentsRuntime:
                 except (ConversationProductsError, ValidationError):
                     return None
                 scope.product_evidence.add_resolutions(result.results, descriptors)
+                state.system_identified_products = list(
+                    scope.product_evidence.system_identified()
+                )
                 return scope.product_evidence.get(product_ref)
 
             resolved: list[tuple[str, ProductSummary, int]] = []
@@ -1637,6 +1645,7 @@ class DeepAgentsRuntime:
                     _shopper_words_this_conversation(state),
                     scope.product_evidence,
                     _most_recently_shown(state),
+                    _identified_in_the_current_showing(state),
                 )
                 if product_issue:
                     blocked.append(
@@ -3124,13 +3133,16 @@ Rules:
                 assistant_text=state.response,
                 status=final_status,
                 termination_reason=reason,
-                events=_turn_audience_events(
-                    state,
-                    identity,
-                    field_name=getattr(
-                        self.config, "wearer_audience_field", ""
+                events=[
+                    *_turn_audience_events(
+                        state,
+                        identity,
+                        field_name=getattr(
+                            self.config, "wearer_audience_field", ""
+                        ),
                     ),
-                ),
+                    *_system_identification_events(state, identity),
+                ],
                 output=output,
             )
             finalized = True

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -2367,6 +2367,42 @@ def _audience_assumption_events(
     ]
 
 
+def _system_identification_events(
+    state: Any,
+    identity: Any,
+) -> list[ConversationEvent]:
+    """Record which products the record itself picked this turn.
+
+    Establishment was scoped to the message that produced it. A shopper chose
+    "the first pairing" in one turn and, three turns later -- having only
+    answered the assistant's own questions -- was still being told the products
+    were not established, because answering a question names nothing. The same
+    add was refused three times and accepted on the fourth, when they finally
+    typed both catalog names. The request never changed.
+
+    The choice itself is durable: it was made against a set of products the
+    record wrote down. So it is recorded here, and the memory service files it
+    against the set it was made from -- which is what makes it lapse when a new
+    set is shown, and nothing else does.
+    """
+
+    refs = [
+        str(ref)
+        for ref in (getattr(state, "system_identified_products", None) or [])
+        if ref
+    ]
+    if not refs:
+        return []
+    return [
+        ConversationEvent(
+            event_key=f"system-identified:{identity.request_id}",
+            event_type="historical_reference_resolved",
+            source_kind="runtime",
+            payload={"product_refs": refs[:16]},
+        )
+    ]
+
+
 def _turn_audience_events(
     state: Any,
     identity: Any,
@@ -4104,6 +4140,29 @@ def _most_recently_shown(state: Any) -> list[dict]:
     return [item for item in newest["products"] if isinstance(item, dict)]
 
 
+def _identified_in_the_current_showing(state: Any) -> set[str]:
+    """Products the record picked from the set now in front of the shopper.
+
+    An identification is filed against the showing it was made from, so this is
+    simply the newest showing's own list. When a newer set is presented it
+    becomes the newest, carrying its own choices and none of the older set's --
+    which is the lapse, expressed as a consequence of where the fact is kept
+    rather than as a rule that has to be remembered.
+    """
+
+    sets = [
+        entry
+        for entry in (getattr(state, "historical_product_sets", None) or [])
+        if isinstance(entry, dict) and isinstance(entry.get("products"), list)
+    ]
+    if not sets:
+        return set()
+    newest = max(sets, key=lambda entry: entry.get("turn_seq") or 0)
+    return {
+        str(ref) for ref in (newest.get("system_identified") or []) if ref
+    }
+
+
 def _reference_candidates(
     evidence: ProductEvidence,
     recently_shown: Sequence[Any] = (),
@@ -4127,6 +4186,7 @@ def _cart_product_provenance_issue(
     shopper_text: str,
     evidence: ProductEvidence,
     recently_shown: Sequence[Any] = (),
+    already_identified: Sequence[str] = (),
 ) -> str:
     """Say why this product cannot be trusted as the one meant, or "" if it can.
 
@@ -4176,6 +4236,14 @@ def _cart_product_provenance_issue(
         ):
             return ""
     if evidence.identified_by_the_system(product.product_id):
+        return ""
+    # The same fact, established earlier in this conversation and still true.
+    # A shopper who chose "the first pairing" was asked to choose again on
+    # every turn that followed, because answering the assistant's own questions
+    # names no product -- five turns to add two items it had itself proposed.
+    # Nothing about a later turn makes that choice untrue; a newer showing
+    # does, and that is what retires it.
+    if str(product.product_id) in {str(ref) for ref in (already_identified or ())}:
         return ""
     return (
         f"PRODUCT NOT ESTABLISHED: the shopper did not name "

--- a/memory_retriever/src/product_references.py
+++ b/memory_retriever/src/product_references.py
@@ -150,6 +150,41 @@ def append_presented_products_event(
     return event
 
 
+def _system_identifications_by_turn(db, conversation_id: str) -> list[tuple[int, list[str]]]:
+    """Which products the record itself picked, and on which turn.
+
+    A shopper who says "the first pairing" has chosen by a coordinate this
+    service wrote down. The choice is durable for the same reason the showing
+    is.
+    """
+
+    rows = (
+        db.query(ConversationEvent, ConversationTurn)
+        .join(ConversationTurn, ConversationTurn.turn_id == ConversationEvent.turn_id)
+        .filter(
+            ConversationTurn.conversation_id == conversation_id,
+            ConversationEvent.event_type == "historical_reference_resolved",
+            ConversationEvent.source_kind == "runtime",
+        )
+        .order_by(ConversationTurn.sequence, ConversationEvent.logical_order)
+        .all()
+    )
+    identifications: list[tuple[int, list[str]]] = []
+    for event, turn in rows:
+        try:
+            payload = json.loads(event.payload_json or "{}")
+        except (TypeError, ValueError):
+            continue
+        refs = [
+            str(ref)
+            for ref in (payload.get("product_refs") or [])
+            if isinstance(ref, (str, int))
+        ]
+        if refs:
+            identifications.append((turn.sequence, refs))
+    return identifications
+
+
 def rebuild_product_reference_index(
     db,
     projection: ConversationProjection,
@@ -157,6 +192,7 @@ def rebuild_product_reference_index(
     """Rebuild the compact index from durable presented-product events."""
 
     rows = _recent_presented_event_rows(db, projection.conversation_id)
+    identifications = _system_identifications_by_turn(db, projection.conversation_id)
     reference_sets = []
     for event, turn in rows:
         products = _compact_products(event.payload_json)
@@ -167,6 +203,21 @@ def rebuild_product_reference_index(
             "turn_seq": turn.sequence,
             "products": products,
         }
+        # A choice belongs to the set it was made from, so it is filed against
+        # the newest showing at or before the turn that made it. That is also
+        # what retires it: once a newer set is shown, this set is no longer the
+        # one in front of the shopper and its choices no longer answer for what
+        # is.
+        shown = {str(item.get("ref")) for item in products if isinstance(item, dict)}
+        picked = [
+            ref
+            for sequence, refs in identifications
+            if sequence >= turn.sequence
+            for ref in refs
+            if ref in shown
+        ]
+        if picked:
+            reference_set["system_identified"] = sorted(dict.fromkeys(picked))
         if turn.catalog_revision:
             reference_set["catalog_revision"] = turn.catalog_revision
         reference_sets.append(reference_set)

--- a/tests/unit/chain_server/test_choice_outlives_its_turn.py
+++ b/tests/unit/chain_server/test_choice_outlives_its_turn.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A choice the record made is a fact about the conversation, not the message.
+
+Live, `conversation-e01a4fee`: the shopper said "add the first pairing to cart",
+was asked for a shoe size, gave it -- and was then refused three turns running,
+each time being asked to confirm products they had already chosen. The fourth
+attempt succeeded only because they typed both catalog names in full.
+
+The tool call was byte-identical in all four turns. Only the words in the
+shopper's message differed, and the gate could see nothing else.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from chain_server.src.conversation_products import ProductEvidence
+from chain_server.src.turn_support import (
+    _cart_product_provenance_issue,
+    _identified_in_the_current_showing,
+    _system_identification_events,
+)
+
+
+def _product(ref: str, name: str) -> SimpleNamespace:
+    return SimpleNamespace(product_id=ref, display_name=name)
+
+
+DRESS = _product("generated:dress", "Ocean Blue Chiffon Maxi Dress")
+SHOES = _product("generated:shoes", "Elegant Embroidered Espadrilles")
+OTHER = _product("generated:other", "Coral Silk Maxi Dress")
+
+
+def _showing(turn_seq: int, *, identified: list[str] | None = None) -> dict:
+    entry: dict = {
+        "candidate_set_id": f"set-{turn_seq}",
+        "turn_seq": turn_seq,
+        "products": [
+            {"ref": DRESS.product_id, "name": DRESS.display_name},
+            {"ref": SHOES.product_id, "name": SHOES.display_name},
+            {"ref": OTHER.product_id, "name": OTHER.display_name},
+        ],
+    }
+    if identified is not None:
+        entry["system_identified"] = identified
+    return entry
+
+
+def test_a_product_chosen_in_an_earlier_turn_is_still_established() -> None:
+    """Turn 3 chose the pairing. Turn 4 only answered a question about size."""
+
+    state = SimpleNamespace(
+        historical_product_sets=[
+            _showing(2, identified=[DRESS.product_id, SHOES.product_id])
+        ]
+    )
+
+    issue = _cart_product_provenance_issue(
+        DRESS,
+        "I need size 6 for the shoes",
+        ProductEvidence(),
+        state.historical_product_sets[0]["products"],
+        _identified_in_the_current_showing(state),
+    )
+
+    assert issue == ""
+
+
+def test_a_product_nobody_chose_is_still_refused() -> None:
+    """The gate's whole purpose, and it must survive the change."""
+
+    state = SimpleNamespace(
+        historical_product_sets=[_showing(2, identified=[DRESS.product_id])]
+    )
+
+    issue = _cart_product_provenance_issue(
+        OTHER,
+        "I need size 6 for the shoes",
+        ProductEvidence(),
+        state.historical_product_sets[0]["products"],
+        _identified_in_the_current_showing(state),
+    )
+
+    assert "PRODUCT NOT ESTABLISHED" in issue
+    assert OTHER.display_name in issue
+
+
+def test_a_newer_showing_retires_the_earlier_choice() -> None:
+    """A new set of products is a new choice to make.
+
+    Without this the gate would be permanently satisfied by something the
+    shopper picked once, twenty turns ago, and "add it" would mean whatever the
+    model decided it meant.
+    """
+
+    state = SimpleNamespace(
+        historical_product_sets=[
+            _showing(2, identified=[DRESS.product_id, SHOES.product_id]),
+            _showing(5),
+        ]
+    )
+
+    assert _identified_in_the_current_showing(state) == set()
+
+    issue = _cart_product_provenance_issue(
+        DRESS,
+        "add it",
+        ProductEvidence(),
+        state.historical_product_sets[1]["products"],
+        _identified_in_the_current_showing(state),
+    )
+
+    assert "PRODUCT NOT ESTABLISHED" in issue
+
+
+def test_the_newest_showing_carries_its_own_choices() -> None:
+    """The lapse is not amnesia: a choice made against the new set still holds."""
+
+    state = SimpleNamespace(
+        historical_product_sets=[
+            _showing(2, identified=[OTHER.product_id]),
+            _showing(5, identified=[DRESS.product_id]),
+        ]
+    )
+
+    assert _identified_in_the_current_showing(state) == {DRESS.product_id}
+
+
+def test_the_turn_records_what_the_record_picked() -> None:
+    """Nothing is durable unless the turn writes it down."""
+
+    events = _system_identification_events(
+        SimpleNamespace(
+            system_identified_products=[DRESS.product_id, SHOES.product_id]
+        ),
+        SimpleNamespace(request_id="request-1"),
+    )
+
+    assert len(events) == 1
+    assert events[0].event_type == "historical_reference_resolved"
+    assert events[0].payload["product_refs"] == [
+        DRESS.product_id,
+        SHOES.product_id,
+    ]
+
+
+def test_a_turn_that_picked_nothing_records_nothing() -> None:
+    """An empty event would retire the previous choice for no reason."""
+
+    assert (
+        _system_identification_events(
+            SimpleNamespace(system_identified_products=[]),
+            SimpleNamespace(request_id="request-1"),
+        )
+        == []
+    )

--- a/tests/unit/memory_retriever/test_conversations.py
+++ b/tests/unit/memory_retriever/test_conversations.py
@@ -2064,3 +2064,80 @@ def test_one_key_reused_with_a_different_size_is_not_a_replay(
         assert second.json()["cart_line"].get("size") != "6"
     else:
         assert second.status_code == 409
+
+
+def test_a_choice_is_filed_against_the_showing_it_was_made_from(
+    conversation_db: TestClient,
+) -> None:
+    """And is retired by the next showing, because that is where it lives.
+
+    Live, a shopper chose "the first pairing" and was asked to choose again on
+    every turn that followed: establishment was scoped to the message that made
+    it. Filing the choice against the set it was made from is what lets a later
+    turn honour it -- and what stops it honouring a set nobody is looking at
+    any more.
+    """
+
+    conversation = "conversation-durable-choice"
+    products = [
+        {"product_id": "bag-1", "display_name": "Structured Tote"},
+        {"product_id": "bag-2", "display_name": "Cobalt Crossbody"},
+    ]
+
+    shown = _start_turn(conversation_db, conversation, request_id="request-shown")
+    assert shown.status_code == 200
+    shown = shown.json()
+    _finalize_turn(
+        conversation_db,
+        conversation,
+        shown["turn_id"],
+        request_id="request-shown",
+        attempt_id=shown["attempt_id"],
+        output={"product_results": products, "retrieved": {}, "agent_diagnostics": {}},
+    )
+
+    chose = _start_turn(conversation_db, conversation, request_id="request-chose").json()
+    _finalize_turn(
+        conversation_db,
+        conversation,
+        chose["turn_id"],
+        request_id="request-chose",
+        attempt_id=chose["attempt_id"],
+        events=[
+            {
+                "event_key": "system-identified:request-chose",
+                "event_type": "historical_reference_resolved",
+                "source_kind": "runtime",
+                "payload": {"product_refs": ["bag-1"]},
+            }
+        ],
+    )
+
+    after = _start_turn(conversation_db, conversation, request_id="request-after")
+    index = after.json()["projection"]["product_reference_index"]
+    assert [entry.get("system_identified") for entry in index] == [["bag-1"]]
+    after = after.json()
+    _finalize_turn(
+        conversation_db,
+        conversation,
+        after["turn_id"],
+        request_id="request-after",
+        attempt_id=after["attempt_id"],
+    )
+
+    # A new showing is a new choice to make.
+    again = _start_turn(conversation_db, conversation, request_id="request-again")
+    again = again.json()
+    _finalize_turn(
+        conversation_db,
+        conversation,
+        again["turn_id"],
+        request_id="request-again",
+        attempt_id=again["attempt_id"],
+        output={"product_results": products, "retrieved": {}, "agent_diagnostics": {}},
+    )
+
+    latest = _start_turn(conversation_db, conversation, request_id="request-latest")
+    index = latest.json()["projection"]["product_reference_index"]
+    newest = max(index, key=lambda entry: entry["turn_seq"])
+    assert "system_identified" not in newest


### PR DESCRIPTION
A shopper said *"Can you add the first pairing to cart"*, was asked for a shoe size, gave it — and was refused three turns running, each time asked to confirm products they had already chosen. The fourth attempt succeeded only because they typed both catalog names in full.

```
3  "Can you add the first pairing t ocart"   → "what shoe size?"          empty
4  "I need size 6 for the shoes"             → "please confirm"           empty
5  "Confirm, please add"                     → "explicitly confirm"       empty
6  "Yes—add these two:"                      → "didn't go through"        empty
7  "Yes—add these two: 1) Ocean Blue Chiffon Maxi Dress (size 2) ..."     added
```

- **The tool call was byte-identical in turns 4, 5, 6 and 7.** Same refs, same sizes, same names. Three refused, one accepted. Nothing about the request changed — only the words typed in that one message.
- **Establishment was scoped to the message that produced it.** The cart gate accepts a product if the shopper's *current* message names it, or the record identified it *this turn*. `ProductEvidence` says so in its own docstring: "products authorized for deterministic tools in the current turn".
- **So the clearest choice a shopper can make expired fastest.** "The first pairing" is an ordinal over a set the system itself wrote down — the one selector the gate trusts above a model's assertion. It was correct, it was resolved, and it was forgotten. Turns 4–6 were the shopper answering the assistant's own questions, and answering a question names no product.

The gate was not wrong about any single turn. It had no way to know the conversation had already settled this.

**What changed**

- A system identification is recorded durably, on the existing finalize events and an event type both services already declared. No new contract field, no schema migration.
- The memory service files it against the newest showing at or before the turn that made it, so the choice lives with the set it was made from.
- The cart gate honours a choice made against the showing now in front of the shopper.
- **A new showing retires it.** A new set of products is a new choice to make — and the lapse falls out of where the fact is kept rather than being a rule anyone has to remember.

**Before / after**, same four turns, live:

| | turns to add two items |
|---|---|
| before | 7 — the add refused three times, accepted only on full catalog names |
| after | 4 — added on the turn the shopper gave the size |

**What is not loosened**

- A `product_ref` still establishes nothing. Refs are printed into the prompt, so choosing one is the model choosing and then quoting itself. This extends the lifetime of a system selector; it does not add one.
- A product nobody chose is still refused, and there is a test for it in both directions — the add succeeding, and the same choice refused once a newer set has been shown. Both are mutation-verified.
- The size gate is untouched. Turn 3 asking for a shoe size was correct and still happens.
- The add stays atomic.