### PR TITLE
Removing a cart line has never worked

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1752,7 +1752,11 @@ class DeepAgentsRuntime:
 
             return normalize_tool_result(_add_cart_items_impl(items))
 
-        @tool(return_direct=False)
+        # Not a tool. `remove_cart_item_tool` calls this directly, and a
+        # decorated function is a StructuredTool, which is not callable -- so
+        # every removal raised `'StructuredTool' object is not callable` and
+        # the turn died. Its sibling `_add_cart_items_impl` is undecorated for
+        # the same reason.
         def _remove_cart_item_impl(cart_line_id: str, quantity: int = 1):
             """Remove a cart line. Use ONLY on explicit shopper intent to remove
             an item. Requires CART_LINE_ID from get_cart_tool — do not guess.

--- a/tests/unit/chain_server/test_main.py
+++ b/tests/unit/chain_server/test_main.py
@@ -9463,3 +9463,32 @@ class TestAudienceAwareSearch:
         assert "send every value that suits them as a hard filter" in normalized
         assert "Otherwise send no audience filter at all" in normalized
         assert "never ask the shopper their gender" in normalized
+
+
+def test_every_cart_impl_helper_is_callable_by_the_tool_that_wraps_it() -> None:
+    """`remove_cart_item_tool` calls its impl directly, and could not.
+
+    The impl carried a `@tool` decorator, which makes it a StructuredTool --
+    not callable. Every removal raised `'StructuredTool' object is not
+    callable' and the turn died with an agent error, so a shopper could not
+    take anything out of their cart, and a size change left both lines behind.
+
+    A source check rather than a call, because these helpers are closures
+    inside `_create_agent` and cannot be reached from here. What is checked is
+    exactly the property that broke: a helper the tool invokes directly must
+    not itself be a tool.
+    """
+
+    import inspect
+    import re
+
+    from chain_server.src import deepagents_runtime
+
+    source = inspect.getsource(deepagents_runtime).splitlines()
+    decorated: list[str] = []
+    for index, line in enumerate(source):
+        match = re.match(r"\s*def (_\w+_impl)\(", line)
+        if match and index and source[index - 1].strip().startswith("@tool"):
+            decorated.append(match.group(1))
+
+    assert decorated == []


### PR DESCRIPTION
```
TypeError: 'StructuredTool' object is not callable
```

`remove_cart_item_tool` calls `_remove_cart_item_impl` directly, and the impl carried a `@tool` decorator. A decorated function is a `StructuredTool`, which is not callable — so **every removal raised, and the turn ended in `agent_error`.**

- A shopper could not take anything out of their cart.
- A size change is add-the-new-line-then-remove-the-old, by design, so a swap left **both** lines behind and reported an error mid-way.

Found live: *"actually can you replace that one with a size 6"* resolved correctly, added size 6, then died on the remove — leaving sizes 2, 4 and 6 in the cart.

Its sibling `_add_cart_items_impl` is undecorated, which is why adds have always worked and this went unseen.

**The guard.** These helpers are closures inside `_create_agent` and cannot be called from a test, so the test checks exactly the property that broke: no `_*_impl` helper is itself decorated as a tool. Putting the decorator back turns it red.

**Before / after**, live, same four turns:

| | cart after "replace that one with a size 6" |
|---|---|
| before | Vivienne (2), Black Satin (4), Black Satin (6) — plus "something went wrong" |
| after | Vivienne (2), Black Satin (6) — "Swapped it to Black Satin Lace-Up Dress (size 6)" |