### PR TITLE
A finished search closes the search, not the turn

### DIFF
--- a/chain_server/src/tool_loop_control.py
+++ b/chain_server/src/tool_loop_control.py
@@ -144,18 +144,31 @@ class ToolLoopControlMiddleware(AgentMiddleware):
                         _SYNTHESIS_PROMPT,
                     ),
                 )
-            if self._search_budget_exhausted or self._search_scope_closed:
+            if self._search_scope_closed and not self._search_budget_exhausted:
+                # The model said it needs no more searching. Its field
+                # description lists four things that should have made it say
+                # otherwise: another product role, a detail check, an
+                # availability check, a cart action. Three of those need a tool
+                # that is not search -- and the fourth needs search itself. So
+                # taking any tool away on a prediction drops one of the four
+                # silently, and the model is predicting, not reporting.
+                #
+                # Nothing is removed here. What bounds the loop is deterministic
+                # and already in place: the per-turn search budget below, the
+                # duplicate-scope guards, and the graph's own recursion limit. A
+                # model with nothing left to do simply stops calling tools.
+                return request.override(
+                    system_message=_append_system_text(
+                        request.system_message,
+                        _SEARCH_CLOSED_PROMPT,
+                    ),
+                )
+            if self._search_budget_exhausted:
                 tools = [
                     tool
                     for tool in request.tools
                     if _tool_name(tool) != SEARCH_TOOL_NAME
                 ]
-                system_message = request.system_message
-                if self._search_scope_closed:
-                    system_message = _append_system_text(
-                        system_message,
-                        _SEARCH_CLOSED_PROMPT,
-                    )
                 return request.override(
                     tools=tools,
                     tool_choice=(
@@ -167,7 +180,6 @@ class ToolLoopControlMiddleware(AgentMiddleware):
                             else request.tool_choice
                         )
                     ),
-                    system_message=system_message,
                 )
             if not self._repair_pending:
                 return request

--- a/chain_server/src/tool_loop_control.py
+++ b/chain_server/src/tool_loop_control.py
@@ -40,6 +40,13 @@ is insufficient, say what the catalog could not establish and offer one next
 step. When the outcome says no faithful advertised taxonomy matches, do not
 claim a search ran and do not name alternative product types; ask permission
 before searching a different advertised type."""
+_SEARCH_CLOSED_PROMPT = """## Search Complete
+
+The catalog search for this turn is finished. Do not search again. If the
+shopper asked for something still to be done -- an item added to their cart, a
+detail confirmed, availability checked -- do that now with the tools you still
+have, then answer. If nothing remains, answer from the evidence already in this
+turn."""
 _REPAIR_PROMPT = """## Catalog Search Repair
 
 Correct one invalid catalog search. Either return exactly one
@@ -90,6 +97,10 @@ class ToolLoopControlMiddleware(AgentMiddleware):
         self._repair_feedback = ""
         self._synthesis_required = False
         self._search_budget_exhausted = False
+        #: The search is finished. That is a statement about searching, not
+        #: about the turn: a shopper who asked for something to be added is
+        #: still owed the add.
+        self._search_scope_closed = False
         self._observed_tool_results: set[str] = set()
         self._lock = Lock()
 
@@ -133,12 +144,18 @@ class ToolLoopControlMiddleware(AgentMiddleware):
                         _SYNTHESIS_PROMPT,
                     ),
                 )
-            if self._search_budget_exhausted:
+            if self._search_budget_exhausted or self._search_scope_closed:
                 tools = [
                     tool
                     for tool in request.tools
                     if _tool_name(tool) != SEARCH_TOOL_NAME
                 ]
+                system_message = request.system_message
+                if self._search_scope_closed:
+                    system_message = _append_system_text(
+                        system_message,
+                        _SEARCH_CLOSED_PROMPT,
+                    )
                 return request.override(
                     tools=tools,
                     tool_choice=(
@@ -150,6 +167,7 @@ class ToolLoopControlMiddleware(AgentMiddleware):
                             else request.tool_choice
                         )
                     ),
+                    system_message=system_message,
                 )
             if not self._repair_pending:
                 return request
@@ -248,7 +266,13 @@ class ToolLoopControlMiddleware(AgentMiddleware):
                     self._synthesis_required = True
                 continue
             if SEARCH_SCOPE_COMPLETE_PREFIX in content:
-                self._synthesis_required = True
+                # Not synthesis. `scope_complete` is the model predicting it
+                # needs no further *search*, and its own description says to
+                # set it false when a cart action still has to run. Taking it
+                # as the end of the turn made a wrong prediction final and
+                # silent: measured 4/4, an add asked for in plain words was
+                # never attempted, because every tool had been taken away.
+                self._search_scope_closed = True
             elif _validation_error_body(content) or content.startswith(
                 CONSTRAINT_REVIEW_PREFIX
             ):

--- a/tests/unit/chain_server/test_tool_loop_control.py
+++ b/tests/unit/chain_server/test_tool_loop_control.py
@@ -161,10 +161,11 @@ def test_completed_search_scope_runs_one_tool_closed_synthesis() -> None:
     # says to set it false when a cart action still has to run. Read as the end
     # of the turn, a wrong prediction was final and silent: measured 4/4, an add
     # asked for in plain words was never attempted because every tool had gone.
-    assert _tool_names(captured[0].tools) == [
-        "activate_shopper_skills_tool",
-        "get_cart_tool",
-    ]
+    # Nothing is removed. Three of the four things that should have made the
+    # model say "not complete" need a tool that is not search, and the fourth
+    # needs search itself -- so taking any tool away on a prediction drops one
+    # of the four silently. The per-turn search budget still bounds the loop.
+    assert captured[0].tools == TOOLS
     assert captured[0].tool_choice != "none"
     assert "## Search Complete" in captured[0].system_prompt
     assert "## Tool Loop Closed" not in captured[0].system_prompt
@@ -226,10 +227,7 @@ def test_completed_search_after_non_search_tool_keeps_model_synthesis() -> None:
 
     response = middleware.wrap_model_call(_model_request(messages), handler)
 
-    assert _tool_names(captured[0].tools) == [
-        "activate_shopper_skills_tool",
-        "get_cart_tool",
-    ]
+    assert captured[0].tools == TOOLS
     assert response.result[0].content == "answer"
 
 
@@ -245,10 +243,7 @@ def test_completed_scoped_no_match_removes_tools_from_next_model_step() -> None:
         _messages_with_result(result),
     )
 
-    assert _tool_names(prepared.tools) == [
-        "activate_shopper_skills_tool",
-        "get_cart_tool",
-    ]
+    assert prepared.tools == TOOLS
     assert "## Search Complete" in prepared.system_prompt
 
 
@@ -456,9 +451,7 @@ def test_one_search_schema_repair_is_exposed_then_tools_are_removed() -> None:
     assert invalid_call not in repair_request.messages
     assert error not in repair_request.messages
     # The repair searched and completed. Searching is over; acting is not.
-    assert _tool_names(
-        _capture_model_request(middleware, completed_messages).tools
-    ) == ["activate_shopper_skills_tool", "get_cart_tool"]
+    assert _capture_model_request(middleware, completed_messages).tools == TOOLS
 
 
 def test_incomplete_successful_repair_allows_one_repair_for_next_scope() -> None:
@@ -1949,10 +1942,11 @@ async def test_async_completed_search_runs_one_tool_closed_synthesis() -> None:
     # says to set it false when a cart action still has to run. Read as the end
     # of the turn, a wrong prediction was final and silent: measured 4/4, an add
     # asked for in plain words was never attempted because every tool had gone.
-    assert _tool_names(captured[0].tools) == [
-        "activate_shopper_skills_tool",
-        "get_cart_tool",
-    ]
+    # Nothing is removed. Three of the four things that should have made the
+    # model say "not complete" need a tool that is not search, and the fourth
+    # needs search itself -- so taking any tool away on a prediction drops one
+    # of the four silently. The per-turn search budget still bounds the loop.
+    assert captured[0].tools == TOOLS
     assert captured[0].tool_choice != "none"
     assert "## Search Complete" in captured[0].system_prompt
     assert "## Tool Loop Closed" not in captured[0].system_prompt
@@ -2072,3 +2066,43 @@ def test_absent_or_malformed_artifact_falls_back_to_text() -> None:
     )
 
     assert captured.tool_choice == "none"
+
+
+def test_a_completed_scope_still_allows_a_second_role_to_be_searched() -> None:
+    """The fourth thing the model should have weighed needs search itself.
+
+    `scope_complete`'s description says to set it false when another explicitly
+    requested product role still has to run. A shopper asking for a dress and
+    shoes whose first search covered only the dress has a role outstanding --
+    and removing the search tool on the model's own prediction is what made
+    that unrecoverable.
+
+    The search budget is what bounds the loop, and it is deterministic.
+    """
+
+    middleware = ToolLoopControlMiddleware()
+    result = _tool_result(
+        "SEARCH_RESULT_GROUNDING_NOTE: grounded candidates\n\n"
+        "SEARCH_SCOPE_COMPLETE: This search covers every requested role."
+    )
+
+    prepared = _capture_model_request(middleware, _messages_with_result(result))
+
+    assert SEARCH_TOOL_NAME in _tool_names(prepared.tools)
+    assert "## Search Complete" in prepared.system_prompt
+
+
+def test_an_exhausted_budget_still_removes_only_the_search_tool() -> None:
+    """The deterministic bound, which a prediction must not be allowed to replace."""
+
+    middleware = ToolLoopControlMiddleware()
+    result = _tool_result(
+        "SEARCH_RESULT_GROUNDING_NOTE: grounded candidates\n\n"
+        f"{SEARCH_BUDGET_EXHAUSTED_PREFIX} no searches remain\n\n"
+        "SEARCH_SCOPE_COMPLETE: complete"
+    )
+
+    prepared = _capture_model_request(middleware, _messages_with_result(result))
+
+    assert SEARCH_TOOL_NAME not in _tool_names(prepared.tools)
+    assert "get_cart_tool" in _tool_names(prepared.tools)

--- a/tests/unit/chain_server/test_tool_loop_control.py
+++ b/tests/unit/chain_server/test_tool_loop_control.py
@@ -56,6 +56,10 @@ def get_cart_tool() -> str:
 TOOLS = [activate_shopper_skills_tool, search_catalog_tool, get_cart_tool]
 
 
+def _tool_names(tools: list[Any]) -> list[str]:
+    return [getattr(t, "name", getattr(t, "__name__", str(t))) for t in tools]
+
+
 def _model_request(messages: list[Any] | None = None) -> ModelRequest:
     messages = messages or [HumanMessage(content="shopper request")]
     return ModelRequest(
@@ -152,9 +156,18 @@ def test_completed_search_scope_runs_one_tool_closed_synthesis() -> None:
     )
 
     assert len(captured) == 1
-    assert captured[0].tools == []
-    assert captured[0].tool_choice == "none"
-    assert "## Tool Loop Closed" in captured[0].system_prompt
+    # A finished search closes the search, not the turn. `scope_complete` is
+    # the model predicting it needs no further *search* -- its own description
+    # says to set it false when a cart action still has to run. Read as the end
+    # of the turn, a wrong prediction was final and silent: measured 4/4, an add
+    # asked for in plain words was never attempted because every tool had gone.
+    assert _tool_names(captured[0].tools) == [
+        "activate_shopper_skills_tool",
+        "get_cart_tool",
+    ]
+    assert captured[0].tool_choice != "none"
+    assert "## Search Complete" in captured[0].system_prompt
+    assert "## Tool Loop Closed" not in captured[0].system_prompt
     assert response.result[0].content == "shopper answer"
 
 
@@ -213,7 +226,10 @@ def test_completed_search_after_non_search_tool_keeps_model_synthesis() -> None:
 
     response = middleware.wrap_model_call(_model_request(messages), handler)
 
-    assert captured[0].tools == []
+    assert _tool_names(captured[0].tools) == [
+        "activate_shopper_skills_tool",
+        "get_cart_tool",
+    ]
     assert response.result[0].content == "answer"
 
 
@@ -229,8 +245,11 @@ def test_completed_scoped_no_match_removes_tools_from_next_model_step() -> None:
         _messages_with_result(result),
     )
 
-    assert prepared.tools == []
-    assert "## Tool Loop Closed" in prepared.system_prompt
+    assert _tool_names(prepared.tools) == [
+        "activate_shopper_skills_tool",
+        "get_cart_tool",
+    ]
+    assert "## Search Complete" in prepared.system_prompt
 
 
 def test_partial_search_scope_keeps_tools_available() -> None:
@@ -436,7 +455,10 @@ def test_one_search_schema_repair_is_exposed_then_tools_are_removed() -> None:
     )
     assert invalid_call not in repair_request.messages
     assert error not in repair_request.messages
-    assert _capture_model_request(middleware, completed_messages).tools == []
+    # The repair searched and completed. Searching is over; acting is not.
+    assert _tool_names(
+        _capture_model_request(middleware, completed_messages).tools
+    ) == ["activate_shopper_skills_tool", "get_cart_tool"]
 
 
 def test_incomplete_successful_repair_allows_one_repair_for_next_scope() -> None:
@@ -1922,9 +1944,18 @@ async def test_async_completed_search_runs_one_tool_closed_synthesis() -> None:
     )
 
     assert len(captured) == 1
-    assert captured[0].tools == []
-    assert captured[0].tool_choice == "none"
-    assert "## Tool Loop Closed" in captured[0].system_prompt
+    # A finished search closes the search, not the turn. `scope_complete` is
+    # the model predicting it needs no further *search* -- its own description
+    # says to set it false when a cart action still has to run. Read as the end
+    # of the turn, a wrong prediction was final and silent: measured 4/4, an add
+    # asked for in plain words was never attempted because every tool had gone.
+    assert _tool_names(captured[0].tools) == [
+        "activate_shopper_skills_tool",
+        "get_cart_tool",
+    ]
+    assert captured[0].tool_choice != "none"
+    assert "## Search Complete" in captured[0].system_prompt
+    assert "## Tool Loop Closed" not in captured[0].system_prompt
     assert response.result[0].content == "shopper answer"
 
 


### PR DESCRIPTION
A shopper said *"add the Southwest Bracelet"*. The assistant searched for it, described it, and stopped. No gate refused anything — **the add was never attempted.**

`scope_complete` is the model **predicting** it needs no further search. Its own field description says:

> *"Set **false** when an explicitly requested product role, product-detail verification, availability check, or **cart action** still must run after this search."*

The middleware read that prediction as the end of the **turn** and stripped every tool — `tools=[]`, `tool_choice="none"`. A wrong prediction was final, unrecoverable, and silent.

**Measured**, `nemotron-3-ultra`, two turns:

| `scope_complete` | `add_cart_items_tool` called |
|---|---|
| `True` | **never** (2/2) |
| `False` | yes (2/2) |

**What changed**

A completed scope now removes **no tool at all**. It appends guidance saying the search is finished and to complete what the shopper asked for.

Removing *only* the search tool was the obvious half-fix and it is not enough: three of the four things that should have made the model say "not complete" need a tool that is not search, and **the fourth needs search itself**. Taking any tool away on a prediction drops one of the four silently.

What bounds the loop is deterministic and already in place — the per-turn search budget, the duplicate-scope guards, and the graph's recursion limit. A model with nothing left to do stops calling tools.

The six genuine turn-enders — unsupported taxonomy, unsupported constraint, an exhausted repair — still close the loop completely, and an exhausted budget still removes the search tool.

**Verified live**, ultra:

- cart action after a completed search: **3/3 add**, every one with `scope_complete: True`
- two roles in one turn: both still searched
- unit: 1231 pass; three mutations — reverting to turn-ending, making the branch inert, and disabling the budget filter — each turn the tests red

**This reverses a deliberate decision.** Five tests asserted `tools == []` on a completed scope; they now assert the corrected contract.

**Not model-specific.** `gpt-5.2` sets the flag `False` more often, so it hits this less. Same latent bug; the suite has been passing on luck.

Found while diagnosing 24 failures in a full val run on ultra — most of them the same shape: *"add X"* answered with a description.
