### PR TITLE
The rule that says which skills are alternatives reads the registry

### DIFF
--- a/chain_server/skills/shopper/budget-shopping/SKILL.md
+++ b/chain_server/skills/shopper/budget-shopping/SKILL.md
@@ -15,6 +15,11 @@ Handle firm-budget requests. Do not expose skill names or tool names in response
 - Treat a stated price ceiling as a hard constraint. Pass it as `required_constraints.price.max` in catalog search.
 - Do not recommend over-budget items framed as "just a bit more" or "worth considering."
 - When recommending multiple products, compare only confirmed prices. Actual cart totals belong to `cart-management`.
+- A budget below what the shop charges is a fact about the shop, not a search
+  that came back empty. When the primary procedure is answering a question about
+  the catalog itself, the published price range settles it and no search is
+  needed: say where prices start. An empty result proves only that one query
+  found nothing, and cannot support "there is nothing in that range."
 
 ## When the Budget Is Tight
 

--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -1220,9 +1220,7 @@ class DeepAgentsRuntime:
         if skills_backend is None:
             raise RuntimeError("Shopper skill backend is unavailable.")
         skill_registry = _shopper_skill_registry(skills_root)
-        skill_activation_input = _skill_activation_input_model(
-            tuple(skill_registry)
-        )
+        skill_activation_input = _skill_activation_input_model(skill_registry)
         scope = TurnScope()
         state.retrieved = scope.retrieved
         wearer_audience_field = str(
@@ -2357,20 +2355,24 @@ class DeepAgentsRuntime:
             """Select and load shopper behavior skills for this turn. This is
             the required first step before answering or calling shopping tools.
             Select the smallest set whose registered descriptions cover the
-            complete current intent. Use outfit-styling for outfit building,
-            completion, refinement, or mid-browse styling questions; style-led
-            single-piece selection, including a statement or balancing piece,
-            also uses outfit-styling. Use product-discovery for search and browse
-            without styling intent. These are alternative primary procedures,
-            never a pair. Adding a product the shopper names that no search in
-            this conversation has shown is a discovery request as well as a cart
-            one: select product-discovery with cart-management, because the cart
-            skill cannot search and the product must be found and shown before
-            it can be added. Add budget-shopping only as a modifier when the
-            shopper states a budget. Keep outfit-styling as the primary skill throughout
-            an active outfit-building thread, including its single-piece follow-up
-            searches.
+            complete current intent.
 
+            Which primary to pick is answered by the registered descriptions
+            themselves, and by the allowed values on `skill_names`. This
+            docstring used to answer it again in its own words, naming two of
+            the primaries; a third was registered and the list here did not
+            know, so the one skill that could answer a question about the shop
+            was never offered as an option. Read the descriptions.
+
+            What they cannot tell you, because it spans two of them: adding a
+            product the shopper names that no search in this conversation has
+            shown is a discovery request as well as a cart one. Select
+            `product-discovery` and `cart-management` together -- the cart skill
+            cannot search, and a product must be found and shown before it can
+            be added. Both names are literal here on purpose. This is one
+            composition rule about two specific skills, not a list of the
+            members of a group, so it does not go stale when a skill is
+            registered; a test asserts both are still registered.
             """
 
             selected_names = list(dict.fromkeys(skill_names))
@@ -2870,16 +2872,14 @@ Rules:
   about which size, became a fresh dress search instead of the add the shopper
   was waiting for. Search only when the shopper is asking to see something
   they have not been shown.
-- Outfit styling and product discovery are alternative primary procedures;
-  never activate both. Budget shopping may accompany either only as a modifier
-  when the shopper states a budget.
-- Style-led fashion selection belongs to outfit styling even when the shopper
-  asks for one statement or balancing piece. Product discovery is for browse
-  and filter intent without styling judgment.
-- Keep the primary skill aligned with the active conversation task. An outfit-
-  building or styling thread continues to use outfit styling for piece-by-piece
-  searches until the shopper changes tasks; do not reclassify a follow-up as
-  product discovery merely because it asks for one product type.
+- Which skills exist, what each is for, and which may be combined are stated in
+  the activation step's own registered descriptions and allowed values. Do not
+  work from memory of a fixed pair: three of these bullets used to name two
+  primary procedures, and were still naming two after a third was registered.
+- Keep the primary skill aligned with the active conversation task. A styling
+  thread continues with the styling procedure for its piece-by-piece searches
+  until the shopper changes tasks; do not reclassify a follow-up merely because
+  it asks for one product type.
 - Use at most {self.config.max_catalog_searches_per_turn} product roles across
   all catalog searches in one user turn, and carry them in as few calls as
   possible: roles in one call retrieve together and cost one round trip.

--- a/chain_server/src/skill_activation.py
+++ b/chain_server/src/skill_activation.py
@@ -96,15 +96,15 @@ registered skills that fully covers the shopper's current intent. Use the
 registered descriptions below and the full conversation context; this is
 semantic selection, not keyword matching. Do not attempt another tool in the
 same response. The runtime will load the complete selected instructions before
-the next model step. Outfit styling and product discovery are alternative
-primary procedures, so never select both; budget shopping may accompany either
-only when the shopper states a budget. Keep the primary procedure aligned with
-the active conversation task: an outfit-building or styling thread continues
-to use outfit styling for piece-by-piece searches until the shopper changes
-tasks. Do not switch to product discovery merely because the current turn asks
-for one product type; a terse item-only follow-up does not by itself end an
-active outfit task. Do not mention this activation step or skill names to the
-shopper."""
+the next model step. Read every registered description before choosing: the
+right primary is the one whose description names what this turn is actually
+asking for, not the one you reached for last time. Keep the primary procedure
+aligned with the active conversation task -- an outfit-building or styling
+thread continues with the styling procedure for piece-by-piece searches until
+the shopper changes tasks. Do not switch procedures merely because the current
+turn asks for one product type; a terse item-only follow-up does not by itself
+end an active outfit task. Do not mention this activation step or skill names
+to the shopper."""
 
 _ACTIVATION_FAILED_PROMPT = """## Shopper Skill Activation Failed
 
@@ -236,7 +236,7 @@ class ShopperSkillActivationMiddleware(AgentMiddleware):
         """Return bounded model feedback for an invalid skill selection."""
 
         issue = _activation_validation_issue(error)
-        feedback = _activation_validation_feedback(issue)
+        feedback = _activation_validation_feedback(error, issue)
         with self._lock:
             if self._status != "pending":
                 return f"{SKILL_ACTIVATION_INVALID} {feedback}"
@@ -510,17 +510,26 @@ def _activation_validation_issue(error: Any) -> str:
     return "invalid_selection"
 
 
-def _activation_validation_feedback(issue: str) -> str:
-    if issue == SKILL_ACTIVATION_MODIFIER_REQUIRES_PRIMARY:
-        return (
-            "budget-shopping is a modifier and requires exactly one primary "
-            "procedure: outfit-styling or product-discovery."
-        )
-    if issue == SKILL_ACTIVATION_MULTIPLE_PRIMARY:
-        return (
-            "Select exactly one primary procedure: outfit-styling or "
-            "product-discovery, never both."
-        )
+def _activation_validation_feedback(error: Any, issue: str) -> str:
+    """Relay the validator's own message rather than restating the rule.
+
+    This used to hold its own copy, naming outfit-styling and product-discovery
+    in both branches. The copy went stale when a third primary was registered,
+    so a model that selected `catalog-questions` beside a budget was told to
+    swap in one of two skills that were not the right answer. The validator
+    already names the skills it actually rejected; there is no second version
+    of the rule to keep in step.
+    """
+
+    errors = error.errors() if callable(getattr(error, "errors", None)) else []
+    for detail in errors:
+        if str(_value(detail, "type") or "") != issue:
+            continue
+        message = str(_value(detail, "msg") or "").strip()
+        if message:
+            message = message.removeprefix("Value error, ").strip()
+        if message:
+            return message if message.endswith(".") else f"{message}."
     return "The selected shopper-skill combination is invalid."
 
 

--- a/chain_server/src/turn_support.py
+++ b/chain_server/src/turn_support.py
@@ -29,7 +29,7 @@ import logging
 import os
 from pathlib import Path
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from difflib import SequenceMatcher
 from types import SimpleNamespace
 from typing import Any, Literal
@@ -1662,7 +1662,12 @@ def _a_list_written_as_json_text(value: Any) -> Any:
 
 
 class _ShopperSkillActivationInput(BaseModel):
-    """Shared composition rules for dynamic shopper-skill activation."""
+    """Shared composition rules for dynamic shopper-skill activation.
+
+    The composition rule itself lives on the subclass `create_model` builds,
+    because it depends on which skills are registered and what roles they
+    declare. This base carries only what every registry shares.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -1674,52 +1679,132 @@ class _ShopperSkillActivationInput(BaseModel):
         "skill_names", mode="before", check_fields=False
     )(_a_list_written_as_json_text)
 
-    @model_validator(mode="after")
-    def primary_procedures_are_exclusive(self) -> "_ShopperSkillActivationInput":
-        selected = set(self.skill_names)
-        primary = selected.intersection(
-            {"outfit-styling", "product-discovery"}
-        )
-        if len(primary) > 1:
+
+def primary_skills_by_group(
+    skills: Mapping[str, Any],
+) -> dict[str, tuple[str, ...]]:
+    """Group the registry's primary skills by the group they are exclusive in.
+
+    Read off `role` and `exclusive_group` in the frontmatter, which
+    `_shopper_skill_from_metadata` already requires to agree: a skill is
+    primary if and only if it names a group.
+    """
+
+    groups: dict[str, list[str]] = {}
+    for name, skill in skills.items():
+        if getattr(skill, "role", "") != "primary":
+            continue
+        group = getattr(skill, "exclusive_group", None)
+        if group:
+            groups.setdefault(str(group), []).append(name)
+    return {group: tuple(sorted(names)) for group, names in groups.items()}
+
+
+def _one_primary_per_group(self: Any) -> Any:
+    """Reject two primaries from one exclusive group, or a stranded modifier.
+
+    This used to intersect against the literal set
+    ``{"outfit-styling", "product-discovery"}``. `catalog-questions` shipped on
+    2026-08-25 declaring ``role: primary`` and ``exclusive_group:
+    product_procedure`` -- the same group as the other two -- and the check
+    could not see it. Measured on the shipped registry: selecting it beside
+    product-discovery was *accepted*, two primaries from one group, while
+    selecting it beside budget-shopping was *rejected* as a modifier with no
+    primary, which is the shape of "do you have anything for $5 to $10".
+
+    `ShopperSkill.exclusive_group` was parsed, validated and stored the whole
+    time, and nothing ever read it. So read it.
+    """
+
+    cls = type(self)
+    groups: Mapping[str, tuple[str, ...]] = cls._primary_skills_by_group
+    selected = set(self.skill_names)
+    primaries: list[str] = []
+    for group, names in sorted(groups.items()):
+        chosen = sorted(selected.intersection(names))
+        if len(chosen) > 1:
             raise PydanticCustomError(
                 SKILL_ACTIVATION_MULTIPLE_PRIMARY,
-                "select exactly one primary procedure: outfit-styling or "
-                "product-discovery, never both",
+                "select exactly one primary procedure: {options}, never more "
+                "than one",
+                {"options": " or ".join(chosen)},
             )
-        if "budget-shopping" in selected and len(primary) != 1:
-            raise PydanticCustomError(
-                SKILL_ACTIVATION_MODIFIER_REQUIRES_PRIMARY,
-                "budget-shopping requires exactly one primary procedure: "
-                "outfit-styling or product-discovery",
-            )
-        return self
+        primaries.extend(chosen)
+
+    modifiers: tuple[str, ...] = cls._modifier_skills
+    stranded = sorted(selected.intersection(modifiers))
+    if stranded and not primaries:
+        raise PydanticCustomError(
+            SKILL_ACTIVATION_MODIFIER_REQUIRES_PRIMARY,
+            "{modifier} is a modifier and requires exactly one primary "
+            "procedure: {options}",
+            {
+                "modifier": stranded[0],
+                "options": " or ".join(
+                    name for names in sorted(groups.values()) for name in names
+                ),
+            },
+        )
+    return self
 
 
 def _skill_activation_input_model(
-    skill_names: tuple[str, ...],
+    skills: Mapping[str, Any],
 ) -> type[BaseModel]:
     """Create the semantic skill-selection schema from the active registry."""
 
-    skill_name_type = Literal.__getitem__(skill_names)
-    return create_model(
+    skill_names = tuple(skills)
+    groups = primary_skills_by_group(skills)
+    modifiers = tuple(
+        sorted(
+            name
+            for name, skill in skills.items()
+            if getattr(skill, "role", "") == "modifier"
+        )
+    )
+    # Named here rather than in a literal, so a skill added to the registry is
+    # described to the model without anyone remembering to edit this string.
+    every_primary = [name for names in sorted(groups.values()) for name in names]
+    choose_one = (
+        " Select exactly one primary procedure -- "
+        + ", ".join(every_primary)
+        + " -- and never two."
+        if every_primary
+        else ""
+    )
+    modifier_rule = (
+        " " + ", ".join(modifiers) + " may only accompany a primary, never "
+        "stand alone."
+        if modifiers
+        else ""
+    )
+    model = create_model(
         "ShopperSkillActivationInput",
         __base__=_ShopperSkillActivationInput,
+        __validators__={
+            "_one_primary_per_group": model_validator(mode="after")(
+                _one_primary_per_group
+            ),
+        },
         skill_names=(
-            list[skill_name_type],
+            list[Literal.__getitem__(skill_names)],
             Field(
                 ...,
                 min_length=1,
                 max_length=len(skill_names),
                 description=(
                     "Smallest set of registered shopper skills whose descriptions "
-                    "cover the current turn's complete intent. For product search "
-                    "or styling, select exactly one primary procedure: outfit-"
-                    "styling or product-discovery, never both. Cart and policy "
-                    "intents may select their standalone skill without a primary."
+                    "cover the current turn's complete intent." + choose_one
+                    + modifier_rule
+                    + " Standalone skills may be selected with or without a "
+                    "primary."
                 ),
             ),
         ),
     )
+    model._primary_skills_by_group = groups
+    model._modifier_skills = modifiers
+    return model
 
 
 def _taxonomy_hard_constraints(

--- a/tests/unit/chain_server/test_a_list_written_as_json_text.py
+++ b/tests/unit/chain_server/test_a_list_written_as_json_text.py
@@ -20,13 +20,25 @@ exactly as before.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from pydantic import ValidationError
 
 from chain_server.src.deepagents_runtime import AddCartItemsToolInput
 from chain_server.src.turn_support import _skill_activation_input_model
 
-_REGISTERED = ("outfit-styling", "product-discovery", "cart-management")
+# The builder reads `role` and `exclusive_group` off each registered skill, so
+# a bare tuple of names no longer describes a registry.
+_REGISTERED = {
+    "outfit-styling": SimpleNamespace(
+        role="primary", exclusive_group="product_procedure"
+    ),
+    "product-discovery": SimpleNamespace(
+        role="primary", exclusive_group="product_procedure"
+    ),
+    "cart-management": SimpleNamespace(role="standalone", exclusive_group=None),
+}
 
 
 def _activation_model() -> type:

--- a/tests/unit/chain_server/test_skill_activation.py
+++ b/tests/unit/chain_server/test_skill_activation.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -221,10 +223,23 @@ def _middleware(
     )
 
 
+def _skill(role: str, group: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(role=role, exclusive_group=group)
+
+
+#: Three primaries in one group, which is what the shipped registry has.
+_THREE_PRIMARIES = {
+    "outfit-styling": _skill("primary", "product_procedure"),
+    "product-discovery": _skill("primary", "product_procedure"),
+    "catalog-questions": _skill("primary", "product_procedure"),
+    "budget-shopping": _skill("modifier"),
+    "cart-management": _skill("standalone"),
+    "store-policy-answers": _skill("standalone"),
+}
+
+
 def test_activation_schema_rejects_two_primary_procedures() -> None:
-    activation_input = _skill_activation_input_model(
-        ("budget-shopping", "outfit-styling", "product-discovery")
-    )
+    activation_input = _skill_activation_input_model(_THREE_PRIMARIES)
 
     with pytest.raises(ValueError, match="select exactly one primary procedure"):
         activation_input(
@@ -237,29 +252,112 @@ def test_activation_schema_rejects_two_primary_procedures() -> None:
     assert selected.skill_names == ["outfit-styling", "budget-shopping"]
 
 
+def test_every_primary_in_a_group_is_exclusive_with_every_other() -> None:
+    """The pair that used to be hardcoded was two of three.
+
+    `catalog-questions` declares the same `exclusive_group` as the other two.
+    Measured on the shipped registry before this changed: selecting it beside
+    product-discovery was accepted, because the check intersected against a
+    literal set that did not contain it.
+    """
+
+    activation_input = _skill_activation_input_model(_THREE_PRIMARIES)
+    primaries = ["outfit-styling", "product-discovery", "catalog-questions"]
+
+    for first in primaries:
+        for second in primaries:
+            if first == second:
+                continue
+            with pytest.raises(
+                ValueError, match="select exactly one primary procedure"
+            ):
+                activation_input(skill_names=[first, second])
+
+
 def test_activation_schema_requires_primary_for_budget_only() -> None:
-    activation_input = _skill_activation_input_model(
-        ("budget-shopping", "outfit-styling", "product-discovery")
-    )
+    activation_input = _skill_activation_input_model(_THREE_PRIMARIES)
 
     with pytest.raises(
         ValueError,
-        match="budget-shopping requires exactly one primary procedure",
+        match="budget-shopping is a modifier and requires exactly one primary",
     ):
         activation_input(
             skill_names=["budget-shopping"],
         )
 
 
-def test_activation_schema_allows_standalone_cart_and_policy_skills() -> None:
-    activation_input = _skill_activation_input_model(
-        (
-            "cart-management",
-            "outfit-styling",
-            "product-discovery",
-            "store-policy-answers",
-        )
+def test_a_modifier_may_accompany_any_primary_in_the_group() -> None:
+    """"Do you have anything for $5 to $10" is a budget and a shop question.
+
+    It was rejected as a stranded modifier, and the shopper got "What product
+    or outfit would you like to find within your budget?" instead of an answer
+    -- because catalog-questions did not count as a primary.
+    """
+
+    activation_input = _skill_activation_input_model(_THREE_PRIMARIES)
+
+    for primary in ("outfit-styling", "product-discovery", "catalog-questions"):
+        selected = activation_input(skill_names=[primary, "budget-shopping"])
+        assert set(selected.skill_names) == {primary, "budget-shopping"}
+
+
+def test_the_schema_names_every_primary_to_the_model() -> None:
+    """The allowed-values description is the channel that binds the choice.
+
+    It named two primaries while three were registered, so the one skill that
+    could answer a question about the shop was never offered as an option.
+    """
+
+    activation_input = _skill_activation_input_model(_THREE_PRIMARIES)
+    description = activation_input.model_fields["skill_names"].description
+
+    for primary in ("outfit-styling", "product-discovery", "catalog-questions"):
+        assert primary in description
+    assert "budget-shopping" in description
+
+
+def test_enforcement_matches_the_shipped_frontmatter() -> None:
+    """Read the real registry, not a fixture.
+
+    Nothing asserted that the enforcement agreed with the frontmatter, which is
+    exactly how a third primary shipped with `exclusive_group:
+    product_procedure` and went unseen for a day.
+    """
+
+    from chain_server.src.tool_policy import load_shopper_skill_registry
+    from chain_server.src.turn_support import primary_skills_by_group
+
+    registry = load_shopper_skill_registry(
+        Path(__file__).resolve().parents[3] / "chain_server" / "skills"
     )
+    groups = primary_skills_by_group(registry)
+
+    declared = {
+        name
+        for name, skill in registry.items()
+        if skill.role == "primary"
+    }
+    grouped = {name for names in groups.values() for name in names}
+    assert declared == grouped, "a primary skill is missing from its group"
+
+    activation_input = _skill_activation_input_model(registry)
+    description = activation_input.model_fields["skill_names"].description
+    for name in declared:
+        assert name in description, f"{name} is invisible to the model"
+
+    for group, names in groups.items():
+        for first in names:
+            for second in names:
+                if first == second:
+                    continue
+                with pytest.raises(
+                    ValueError, match="select exactly one primary procedure"
+                ):
+                    activation_input(skill_names=[first, second])
+
+
+def test_activation_schema_allows_standalone_cart_and_policy_skills() -> None:
+    activation_input = _skill_activation_input_model(_THREE_PRIMARIES)
 
     assert activation_input(
         skill_names=["cart-management"],
@@ -394,11 +492,15 @@ def test_pending_phase_forces_only_the_activation_tool() -> None:
     assert "Required Shopper Skill Selection" in prepared.system_prompt
     assert "outfit-styling: Use for outfit completion" in prepared.system_prompt
     assert "product-discovery: Use for browsing" in prepared.system_prompt
-    assert "never select both" in prepared.system_prompt
-    assert "budget shopping may accompany either" in prepared.system_prompt
+    # The composition rule is not restated here. It is generated from the
+    # registry onto the `skill_names` allowed values, which is the channel that
+    # binds the choice; a second copy in prose is what went stale when a third
+    # primary was registered.
+    assert "never select both" not in prepared.system_prompt
+    assert "Read every registered description" in prepared.system_prompt
     assert (
-        "Do not switch to product discovery merely because the current turn asks"
-        in prepared.system_prompt
+        "does not by itself\nend an active outfit task" in prepared.system_prompt
+        or "end an active outfit task" in prepared.system_prompt
     )
 
 
@@ -1427,3 +1529,39 @@ def test_a_turn_cannot_reselect_for_ever() -> None:
         _tool_request("add_cart_items_tool", _activated_messages()), lambda r: r
     )
     assert str(refused.content).startswith(SKILL_TOOL_NOT_GRANTED)
+
+
+def test_skills_named_in_the_activation_tool_are_registered() -> None:
+    """The one place a skill name is still written literally.
+
+    The exclusivity rule was an enumeration of a group's members, so it went
+    stale when a third member was registered and is now generated. This is a
+    different thing: one composition rule about two specific skills, where
+    naming them is what makes it actionable. Measured -- softening it to "the
+    discovery procedure alongside cart management" produced a turn that
+    activated twice, searched three times, said "Now I'll add it to your cart"
+    and added nothing.
+
+    So the names stay, and this asserts they still exist.
+    """
+
+    import re
+
+    from chain_server.src.tool_policy import load_shopper_skill_registry
+
+    runtime_source = (
+        Path(__file__).resolve().parents[3]
+        / "chain_server"
+        / "src"
+        / "deepagents_runtime.py"
+    ).read_text()
+    start = runtime_source.index("def activate_shopper_skills_tool(")
+    docstring = runtime_source[start : runtime_source.index('"""', start + 400)]
+
+    registry = load_shopper_skill_registry(
+        Path(__file__).resolve().parents[3] / "chain_server" / "skills"
+    )
+    named = set(re.findall(r"`([a-z][a-z-]+)`", docstring))
+    assert named, "the composition rule names no skill at all"
+    unknown = named - set(registry)
+    assert not unknown, f"activation tool names unregistered skills: {unknown}"


### PR DESCRIPTION
`ShopperSkill.exclusive_group` was parsed, validated and stored, and nothing ever read it. The composition check intersected the selection against the literal set `{outfit-styling, product-discovery}`, and five other places wrote the same pair out in prose.

`catalog-questions` registered on 2026-08-25 declaring the same exclusive group as the other two. Measured on the shipped registry: selecting it beside `product-discovery` was **accepted** — two primaries from one group, with nothing objecting — while selecting it beside `budget-shopping` was **rejected** as a modifier with no primary, which is the shape of "do you have anything for $5 to $10".

- Derive the exclusive groups from `role` and `exclusive_group` in the skill frontmatter.
- Generate the allowed-values description on `skill_names` from the registry, so a newly registered skill is described to the model without anyone remembering to edit a string.
- Relay the validator's own message as repair feedback instead of keeping a second copy of the rule that can go stale.
- Remove the pair from the activation prompt, the activation tool's docstring and the system prompt. Which primary to pick is answered by the registered descriptions; three bullets answering it again in their own words is what went out of date.
- Keep the two skill names literal in the one composition rule that spans them — a product the shopper names that no search has shown needs discovery and cart together. Softening that to "the discovery procedure alongside cart management" produced a turn that activated twice, searched three times, said "Now I'll add it to your cart" and added nothing. A check asserts both names are still registered.
- Tell `budget-shopping` that a budget under the shop's floor is a fact about the shop, not a search that came back empty.

What this does **not** do is repair a visible shopper failure. The turn that motivated it already reached the right answer most of the time by a longer route: the published price range is in the capabilities block, so the reply named the correct floor whether or not it searched first. This fixes a routing contract that did not know how many primaries existed, and a rejection that would bite as soon as the new skill started being selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)