### PR TITLE
The editor can see what the shopper's media showed

### DIFF
--- a/chain_server/src/deepagents_runtime.py
+++ b/chain_server/src/deepagents_runtime.py
@@ -396,6 +396,15 @@ Rules:
   and filter scope returned no products. It does not prove that a different,
   unsearched, or unadvertised product type is absent, and it never supports a
   catalog-wide availability claim.
+- WHAT THE SHOPPER'S MEDIA SHOWED is your sight of what they attached. It
+  supports saying what the media contained, and nothing else: it is not a
+  catalog fact, it never proves a product exists or what it is made of, and a
+  garment seen there is not a garment this shop sells. On a turn that carries
+  media, say what was seen before answering from it -- a shopper who sends a
+  photo is owed the assistant naming what it looked at, and where the shop
+  cannot serve that look, saying so is the answer rather than a list of the
+  nearest things. Never tell them you could not view their media when this lane
+  is present.
 - Use CONVERSATION to resolve direct references such as "that" and "those," and
   to honour what the shopper has already told you. It carries intent only: it
   can never establish a product fact, a price, availability, whether a search
@@ -2593,6 +2602,13 @@ class DeepAgentsRuntime:
             f"{format_cart_change(state.cart_at_turn_start, state.cart)}\n\n"
             "CONVERSATION (shopper intent only — never a product fact):\n"
             f"{state.dialogue_context or '(none)'}\n\n"
+            # The editor had seven lanes and none of them was the shopper's own
+            # media, so a draft naming what the photo showed -- "tan blazer,
+            # cable-knit sweater, salmon trousers" -- had no lane supporting it,
+            # and this editor cuts what no lane supports. It was not merely
+            # failing to require the description; it had reason to remove one.
+            "WHAT THE SHOPPER'S MEDIA SHOWED (sight, never a catalog fact):\n"
+            f"{state.media_analysis or '(none)'}\n\n"
             f"AVAILABLE IMAGES:\n{_format_retrieved_images(state.retrieved)}\n\n"
             f"DRAFT RESPONSE:\n{draft_response}"
         )


### PR DESCRIPTION
Asked "my husband wants something like this" with a photo of menswear, one run opened by naming what it saw — tan blazer, cable-knit sweater, salmon trousers — and said the shop carries women's apparel. Another, on identical code, opened "I assumed you were looking for women's pieces" and listed blouses without mentioning the photo.

The rule asking for the first behaviour exists in the media turn rules, and it was not simply being skipped. The grounding editor had seven lanes — tool evidence, products shown earlier, the cart, what the turn did to it, conversation, images, the draft — and none was the shopper's own media. It cuts what no lane supports, so a draft naming what the photo contained had nothing behind it. **The editor was not failing to require a description; it had reason to remove one.**

- The media analysis becomes a lane, labelled for what it can support: sight, never a catalog fact. Same shape as `PRODUCTS SHOWN EARLIER` being identity only and `CONVERSATION` being intent only.
- Roughly 350 characters on a 9,003-character prompt.

J20 replayed four times: all four name what was seen and say the shop's range is women's. J02 and J19 reference the seen garments — "the sweater and booties from the look", "the mermaid silhouette and corset-inspired details".

J02 also now says "I didn't find any jeans that match the dark blue denim" rather than presenting the skirts it searched as though they answered. **The search still maps jeans onto skirts** — that substitution is not fixed here; the composer has stopped misreporting it.

Not measured: turns with no media, where the lane reads `(none)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)