### PR TITLE
One cart line per product and size, kept by the database

### DIFF
--- a/memory_retriever/src/migrations.py
+++ b/memory_retriever/src/migrations.py
@@ -211,6 +211,35 @@ def _cart_size(connection: Connection) -> None:
     ensure_cart_size_column(connection)
 
 
+def _cart_line_uniqueness(connection: Connection) -> None:
+    """Make one cart line per (user, product, size) a rule the database keeps.
+
+    Written to run on a database that already has rows. It builds the indexes
+    directly rather than through `create_all`, so it applies to tables created
+    before the model declared them.
+
+    It does not deduplicate first. Checked on the live volume on 2026-08-27:
+    2,061 cart rows and zero duplicate groups, so the indexes build cleanly. A
+    week earlier it was 249 rows -- the count grows with use, and a database
+    that has drifted will need a merge step before this runs. Failing loudly
+    here is right: silently dropping a shopper's second line to make an index
+    build is worse than a migration that stops and asks.
+
+    Two indexes because `size` is nullable and NULLs do not collide in a unique
+    index. `IF NOT EXISTS` so a re-run is a no-op, matching the rest of this
+    file.
+    """
+
+    connection.exec_driver_sql(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_cart_line_sized "
+        "ON cart_items (user_id, product_id, size) WHERE size IS NOT NULL"
+    )
+    connection.exec_driver_sql(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_cart_line_unsized "
+        "ON cart_items (user_id, product_id) WHERE size IS NULL"
+    )
+
+
 _MIGRATIONS = (
     (1, _legacy_schema),
     (2, _conversation_schema),
@@ -219,6 +248,7 @@ _MIGRATIONS = (
     (5, _shopper_profiles_schema),
     (6, _conversation_shopper_profile),
     (7, _cart_size),
+    (8, _cart_line_uniqueness),
 )
 
 

--- a/memory_retriever/src/models.py
+++ b/memory_retriever/src/models.py
@@ -38,7 +38,51 @@ class User(Base):
 
 
 class CartItem(Base):
+    """One line of the cart: a product, a chosen size, and a quantity.
+
+    The line is unique on `(user_id, product_id, size)`, and that is enforced
+    here rather than left to the add path. The add reads then writes, and today
+    two concurrent adds of the same product and size cannot interleave -- not
+    because anything prevents it, but because every endpoint is `async def`
+    doing blocking work, so the event loop serialises the whole service. That
+    is an accident, and the two steps that make this service scale both remove
+    it: Postgres replaces database-wide write serialisation with MVCC, and
+    making the endpoints threadpool-bound removes the loop lock. After either,
+    the read-then-write is a lost update or a duplicate line.
+
+    So the invariant moves into the schema first, while it is still cheap. The
+    durable-turn tables already work this way -- `uq_turn_event_key`,
+    `uq_turn_event_order`, and a partial unique index on in-flight turns. The
+    cart was the outlier.
+
+    Two indexes rather than one, because `size` is nullable and NULLs are
+    distinct in a unique index on both SQLite and Postgres. A single
+    three-column index would leave every one-size product -- bags, sunglasses,
+    jewellery, 38 of the 215 in this catalog -- entirely unconstrained, which
+    is the half of the cart most likely to be added twice.
+    """
+
     __tablename__ = "cart_items"
+    __table_args__ = (
+        Index(
+            "uq_cart_line_sized",
+            "user_id",
+            "product_id",
+            "size",
+            unique=True,
+            sqlite_where=text("size IS NOT NULL"),
+            postgresql_where=text("size IS NOT NULL"),
+        ),
+        Index(
+            "uq_cart_line_unsized",
+            "user_id",
+            "product_id",
+            unique=True,
+            sqlite_where=text("size IS NULL"),
+            postgresql_where=text("size IS NULL"),
+        ),
+    )
+
     id = Column(Integer, primary_key=True, index=True)
     cart_line_id = Column(
         String,

--- a/tests/unit/memory_retriever/test_conversations.py
+++ b/tests/unit/memory_retriever/test_conversations.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from memory_retriever.src import main as memory_main
+from memory_retriever.src.migrations import _MIGRATIONS
 from memory_retriever.src import product_references
 
 
@@ -1619,7 +1620,7 @@ def test_versioned_migrations_upgrade_legacy_schema_once_without_data_loss(
             ).scalars()
         )
 
-    assert versions == [1, 2, 3, 4, 5, 6, 7]
+    assert versions == [1, 2, 3, 4, 5, 6, 7, 8]
     assert row[0] == "Legacy Bag"
     assert len(row[1]) == 32
     assert row[2:] == (None, None)
@@ -1694,7 +1695,7 @@ def test_file_database_reopens_with_sqlite_safety_settings(
             connection.execute(
                 text("SELECT COUNT(*) FROM schema_migrations")
             ).scalar_one()
-            == 7
+            == len(_MIGRATIONS)
         )
     reopened_engine.dispose()
 

--- a/tests/unit/memory_retriever/test_one_cart_line_per_product_and_size.py
+++ b/tests/unit/memory_retriever/test_one_cart_line_per_product_and_size.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One cart line per (user, product, size), kept by the database.
+
+The add reads then writes. It is correct today only because the service
+serialises every request -- 13 `async def` endpoints doing blocking database
+work make the event loop a lock over the whole process. Both changes that let
+this scale remove that lock: Postgres swaps database-wide write serialisation
+for MVCC, and threadpool-bound endpoints free the loop. After either, two
+concurrent adds of the same product and size are a lost update or a duplicate
+line.
+
+So the invariant lives in the schema, and these tests are about the schema
+keeping it rather than about the add path being careful.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from memory_retriever.src.migrations import run_schema_migrations
+from memory_retriever.src.models import CartItem
+
+
+@pytest.fixture
+def session() -> Iterator[object]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    # Through the migrations, not `create_all`: the index has to reach a
+    # database whose tables already existed, which is every deployed one.
+    run_schema_migrations(engine)
+    maker = sessionmaker(bind=engine)
+    db = maker()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def _line(db, user_id=1, product_id="p1", size=None, amount=1):
+    item = CartItem(
+        user_id=user_id,
+        product_id=product_id,
+        item="A Dress",
+        amount=amount,
+        price=10.0,
+        size=size,
+    )
+    db.add(item)
+    db.flush()
+    return item
+
+
+def test_a_sized_line_cannot_be_inserted_twice(session) -> None:
+    _line(session, size="8")
+    with pytest.raises(IntegrityError):
+        _line(session, size="8")
+
+
+def test_a_one_size_line_cannot_be_inserted_twice(session) -> None:
+    """The case a single three-column index would miss.
+
+    `size` is nullable and NULLs are distinct in a unique index on both SQLite
+    and Postgres, so `(user_id, product_id, NULL)` twice would not collide.
+    That is bags, sunglasses and jewellery -- 38 of the 215 products here, and
+    the ones most likely to be added twice, since nothing asks the shopper a
+    size question for them.
+    """
+
+    _line(session, size=None)
+    with pytest.raises(IntegrityError):
+        _line(session, size=None)
+
+
+def test_two_sizes_of_one_product_are_still_two_lines(session) -> None:
+    """The invariant must not become "one line per product".
+
+    A 6 and an 8 of one dress are two things the shopper owns.
+    """
+
+    _line(session, size="6")
+    _line(session, size="8")
+    assert session.query(CartItem).count() == 2
+
+
+def test_the_same_product_for_two_shoppers_is_two_lines(session) -> None:
+    _line(session, user_id=1, size="8")
+    _line(session, user_id=2, size="8")
+    assert session.query(CartItem).count() == 2
+
+
+def test_the_migration_adds_the_index_to_a_database_that_predates_it() -> None:
+    """The case that matters, and the one `create_all` hides.
+
+    Every deployed database has `cart_items` already. Building the schema from
+    today's model creates the indexes as a side effect, so a test that does
+    that proves nothing about the migration -- removing migration 8 entirely
+    left the other tests in this file green.
+
+    So this one builds the table the way an older version left it, with no
+    unique index, and asserts the migration puts one there.
+    """
+
+    from sqlalchemy import inspect, text
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            "CREATE TABLE cart_items ("
+            " id INTEGER PRIMARY KEY,"
+            " cart_line_id VARCHAR,"
+            " user_id INTEGER,"
+            " product_id VARCHAR,"
+            " item VARCHAR,"
+            " size VARCHAR,"
+            " amount INTEGER,"
+            " price FLOAT)"
+        )
+        # A database in use, not an empty one.
+        connection.exec_driver_sql(
+            "INSERT INTO cart_items (user_id, product_id, item, size, amount)"
+            " VALUES (1, 'p1', 'A Dress', '8', 1)"
+        )
+
+    before = {i["name"] for i in inspect(engine).get_indexes("cart_items")}
+    assert "uq_cart_line_sized" not in before
+
+    from memory_retriever.src.migrations import _cart_line_uniqueness
+
+    with engine.begin() as connection:
+        _cart_line_uniqueness(connection)
+
+    after = {i["name"] for i in inspect(engine).get_indexes("cart_items")}
+    assert {"uq_cart_line_sized", "uq_cart_line_unsized"} <= after
+
+    # And it is enforced, on the row that was already there.
+    with pytest.raises(IntegrityError):
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO cart_items (user_id, product_id, item, size,"
+                    " amount) VALUES (1, 'p1', 'A Dress', '8', 1)"
+                )
+            )
+    engine.dispose()

--- a/tests/unit/memory_retriever/test_shopper_profiles.py
+++ b/tests/unit/memory_retriever/test_shopper_profiles.py
@@ -112,7 +112,7 @@ def test_startup_migrates_bootstraps_and_lists_exact_profiles(
     with memory_main.engine.connect() as connection:
         assert connection.exec_driver_sql(
             "SELECT version FROM schema_migrations ORDER BY version"
-        ).scalars().all() == [1, 2, 3, 4, 5, 6, 7]
+        ).scalars().all() == [1, 2, 3, 4, 5, 6, 7, 8]
 
 
 def test_get_profile_is_typed_and_unknown_or_malformed_ids_fail(


### PR DESCRIPTION
Step 1 of `PLAN_2026-08-27-ready-for-prod.md`, and the prerequisite for the rest of it.

`cart_items` had no unique constraint on `(user_id, product_id, size)` — only `cart_line_id`, which is generated per row and so constrains nothing about what a line means. The add reads then writes.

That is correct today, and only by accident. Thirteen `async def` endpoints do blocking database work, making the event loop a lock over the whole service, so two adds cannot interleave. **Both changes that let this scale remove that lock** — Postgres swaps database-wide write serialisation for MVCC, and threadpool-bound endpoints free the loop — and then the same read-then-write is a lost update or a duplicate line.

So the invariant moves into the schema while the service is still serialised, which is the only moment it is free. The durable-turn tables already work this way; the cart was the outlier.

- **Two indexes, not one.** `size` is nullable and NULLs are distinct in a unique index on both SQLite and Postgres. A single three-column index would leave every one-size product unconstrained — bags, sunglasses and jewellery, 38 of the 215 here, and the ones most likely to be added twice because nothing asks the shopper a size question for them.
- **Migration 8 uses raw DDL**, not `create_all`, because every deployed database already has the table. Both indexes carry `sqlite_where` and `postgresql_where` so step 2 needs no rework here.
- **It does not deduplicate first.** A database that has drifted should fail loudly rather than have a shopper's second line silently merged away to make an index build.
- The migration-count assertion now derives from `_MIGRATIONS` instead of hardcoding 7.

**Not included:** making the add *merge* when it loses the race. That needs a SAVEPOINT — without one a failed flush raises `PendingRollbackError` and poisons the session — and the savepoint left a row behind in a transaction that rolled back, which an existing test caught. That is a transaction-semantics change I do not yet understand, and the cart is the wrong place to ship one on a hunch. The index is what prevents the duplicate; merging is about what the shopper sees when they lose, and today they cannot lose. **It has to land before the endpoints stop blocking, not before this does.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)