### PR TITLE
Add the catalog-indexer service that Compose was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,22 +477,33 @@ The exact published response is documented in
 
    Model routing lives in `shared/configs/models.yaml`.
 
-6. **Index the product catalog**:
+6. **Confirm the product catalog is indexed**:
    ```bash
-   docker compose exec catalog-retriever python -m app.index_catalog
    curl -s http://localhost:8010/ready
    ```
 
-   Required once after a first deployment, and again whenever the catalog data,
-   schema, or embedding model changes. Serving containers do not index
-   themselves: rebuilding an index begins by dropping the collection, which is
-   safe when one process does it and destructive when two do, so it is an
-   explicit step rather than something that happens on start.
+   Compose indexes for you: the `catalog-indexer` service runs once, builds the
+   index and exits, and `catalog-retriever` waits for it to succeed before it
+   starts. Bringing the stack up again re-runs it, so a change to the catalog
+   data, schema, or embedding model is picked up by `docker compose up -d`.
 
-   Skipping it is visible rather than silent. `/ready` returns 503 until the
-   index matches, and searches would otherwise return no products -- a shopper
-   would be told the catalog is empty. The command is safe to repeat: it checks
-   the catalog fingerprint first and does nothing when the index is current.
+   Serving containers do not index themselves: rebuilding an index begins by
+   dropping the collection, which is safe when one process does it and
+   destructive when two do, so it is a separate one-shot service rather than
+   something that happens on start.
+
+   To rebuild without cycling Compose, run it directly. Safe to repeat: it
+   checks the catalog fingerprint first and does nothing when the index is
+   already current.
+
+   ```bash
+   docker compose exec catalog-retriever python -m app.index_catalog
+   ```
+
+   Check `/ready` here, not `/health`. A catalog container with no matching
+   index is alive but deliberately serving no traffic, so `/health` returns 200
+   while `/ready` returns 503. Searches in that state return no products rather
+   than an error, and a shopper is told the catalog is empty.
 
 7. **Access the application**: Open your browser to `http://localhost:3000`
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,52 @@ services:
     networks:
       - shopping-network
 
+  # Catalog Indexer - builds the vector index, then exits.
+  #
+  # Indexing is deliberately not done by the serving container: rebuilding
+  # starts by dropping the collection, so exactly one process may do it at a
+  # time. This one-shot service is the Compose equivalent of the
+  # `parallelism: 1` Job that docs/DEPLOYMENT.md prescribes for Kubernetes, and
+  # it is what makes `docker compose up` sufficient on its own.
+  #
+  # Two things keep it to a single run, which is the whole contract:
+  #
+  #  - `container_name` pins it to one container. Compose refuses to scale a
+  #    service that has one, so `--scale catalog-indexer=N` cannot start a
+  #    second indexer; it warns and leaves the single container alone.
+  #  - The fingerprint check makes repeat runs free. Bringing the stack up
+  #    again re-runs this service, which compares the catalog fingerprint and
+  #    exits without touching Milvus when the index is already current.
+  #
+  # Neither of those is a distributed lock, and this process cannot provide one
+  # -- a lock across replicas needs somewhere to live. Scaling out horizontally
+  # means Kubernetes, where the indexing Job's `parallelism: 1` is the
+  # guarantee and the serving replicas stay unready until it succeeds.
+  catalog-indexer:
+    build:
+      context: ./catalog_retriever
+    container_name: catalog-indexer
+    command: ["python", "-m", "app.index_catalog"]
+    restart: "no"
+    environment:
+      - EMBED_API_KEY=${EMBED_API_KEY:-}
+      - TEXT_EMBED_BASE_URL=${TEXT_EMBED_BASE_URL:-}
+      - TEXT_EMBED_MODEL=${TEXT_EMBED_MODEL:-}
+      - IMAGE_EMBED_BASE_URL=${IMAGE_EMBED_BASE_URL:-}
+      - IMAGE_EMBED_MODEL=${IMAGE_EMBED_MODEL:-}
+      - CATALOG_DATA_SOURCE=${CATALOG_DATA_SOURCE:-}
+      - CATALOG_SCHEMA_SOURCE=${CATALOG_SCHEMA_SOURCE:-}
+      - CATALOG_IMAGE_EMBEDDING_ENABLED=${CATALOG_IMAGE_EMBEDDING_ENABLED:-true}
+      - MILVUS_HOST=milvus
+      - MILVUS_PORT=19530
+    volumes:
+      - ./shared:/app/shared
+    depends_on:
+      milvus:
+        condition: service_healthy
+    networks:
+      - shopping-network
+
   # Catalog Retriever
   catalog-retriever:
     build:
@@ -62,6 +108,12 @@ services:
     depends_on:
       milvus:
         condition: service_healthy
+      # Waiting for a successful exit is what keeps this container from serving
+      # empty searches against a missing index. It also means the server binds
+      # its Milvus collections after they exist, rather than holding a handle
+      # from before the indexer created them.
+      catalog-indexer:
+        condition: service_completed_successfully
     networks:
       - shopping-network
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -189,14 +189,21 @@ Serving containers do not index themselves. Rebuilding an index begins by
 dropping the collection, so it must happen exactly once, and a container cannot
 know whether it is the only one doing it.
 
+Under Compose this is already handled: the `catalog-indexer` service runs
+`python -m app.index_catalog` once and exits, and `catalog-retriever` depends on
+its successful completion, so it cannot start against a missing index. `up`
+re-runs it, which covers any change to the catalog data, schema, or embedding
+model.
+
+To index out of band -- forcing a rebuild without cycling Compose, or after
+editing catalog files in place -- run it directly:
+
 ```bash
 docker compose exec catalog-retriever python -m app.index_catalog
 ```
 
-Required after a first deployment and after any change to the catalog data,
-schema, or embedding model. Safe to repeat and safe to leave unconditionally in
-a pipeline: it checks the catalog fingerprint first and does nothing when the
-index is already current.
+Safe to repeat and safe to leave unconditionally in a pipeline: it checks the
+catalog fingerprint first and does nothing when the index is already current.
 
 ### Step 6: Verify Deployment
 

--- a/docs/EMBEDDING_MANAGEMENT.md
+++ b/docs/EMBEDDING_MANAGEMENT.md
@@ -99,10 +99,17 @@ hybrid modes then disappear from `/capabilities`.
    export CATALOG_SCHEMA_SOURCE="$PWD/shared/data/my_products.schema.yaml"
    ```
 
-4. Restart the catalog service, then index. **Restarting no longer indexes**:
+4. Rebuild and bring the catalog service back up. **A serving container never
+   indexes itself**, but Compose runs the `catalog-indexer` service for you and
+   `catalog-retriever` waits for it to finish, so this is one command:
 
    ```bash
    docker compose up -d --build catalog-retriever
+   ```
+
+   To index without cycling the service, run it directly instead:
+
+   ```bash
    docker compose exec catalog-retriever python -m app.index_catalog
    ```
 


### PR DESCRIPTION
## Problem

`docker compose up` never indexed the catalog. Milvus came up empty,
`catalog-retriever` returned zero products, and the assistant told shoppers the
catalog was empty. Nothing errored: `/health` stayed 200 throughout, so the
failure looked like a working deployment.

Indexing existed only as a manual command in the docs. `index_catalog.py`
already documented a `catalog-indexer` service as running it on `up`; that
service did not exist.

## Fix

- Add `catalog-indexer`: runs `python -m app.index_catalog` once, then exits.
- `catalog-retriever` waits on it via `service_completed_successfully`, so it
  cannot start against a missing index.
- Idempotent. The existing fingerprint check makes repeat runs no-ops, so `up`
  stays cheap and a catalog or embedding-model change is picked up automatically.

Indexing stays a separate one-shot service rather than something the serving
container does, because a rebuild starts by dropping the collection.

## Docs

Three places called indexing a required manual step and no longer should:
`README.md` step 6, `docs/DEPLOYMENT.md` step 5, and
`docs/EMBEDDING_MANAGEMENT.md`. All keep the manual command, which is still how
you rebuild without cycling Compose and still what the Kubernetes `Job` runs.

README step 6 now checks `/ready` instead of `/health`, since only `/ready`
reports a missing index.

## Testing

On a stack with an empty collection: `up` indexed 215 products, `/ready`
reported ready, and catalog search returned real products for queries that
previously returned none. A second `up` re-ran the indexer, which logged
`index is current` and exited without touching the collection.
