### PR TITLE
An environment profile that serves the app LLM locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,17 @@ export COMPOSE_DISABLE_ENV_FILE=1
 # Secrets
 # ---------------------------------------------------------------------------
 
-# Hosted NVIDIA endpoints and NGC-hosted local NIM images use NVIDIA keys.
-# Leave API keys empty for no-auth local OpenAI-compatible endpoints.
+# Hosted NVIDIA endpoints use an inference key. Leave API keys empty for
+# no-auth local OpenAI-compatible endpoints.
 export NVIDIA_API_KEY="${NVIDIA_API_KEY:-}"
-export NGC_API_KEY="${NGC_API_KEY:-$NVIDIA_API_KEY}"
+
+# Pulling NIM images from the NGC catalog uses a *different* credential with a
+# different scope: an inference key cannot pull from NGC. There is deliberately
+# no fallback between them, because falling back turns "the NGC key is missing"
+# into an opaque authentication error partway through a weight download.
+#
+# Only needed to run a NIM locally. Leave it empty otherwise.
+export NGC_API_KEY="${NGC_API_KEY:-}"
 export LLM_API_KEY="${LLM_API_KEY:-$NVIDIA_API_KEY}"
 export EMBED_API_KEY="${EMBED_API_KEY:-$NVIDIA_API_KEY}"
 export RAIL_API_KEY="${RAIL_API_KEY:-$NVIDIA_API_KEY}"

--- a/.env.local-llm.example
+++ b/.env.local-llm.example
@@ -1,0 +1,291 @@
+# Retail Shopping Assistant -- the app LLM served locally as a NIM.
+#
+# A copy of .env.example with one role moved. Everything else stays on the
+# hosted endpoints: embeddings, the VLM, guardrails, the judge and the
+# challenger. Only the model serving the shopper changes, so a run against this
+# profile and a run against .env.example differ by that and nothing else, which
+# is what makes the two comparable.
+#
+# Copy it, fill in the keys, and source it:
+#
+#   cp .env.local-llm.example .env.local-llm
+#   $EDITOR .env.local-llm        # NVIDIA_API_KEY, LOCAL_NIM_CACHE
+#   source .env.local-llm
+#
+#   mkdir -p "$LOCAL_NIM_CACHE" && chmod a+w "$LOCAL_NIM_CACHE"
+#   docker compose -f docker-compose-nim-local.yaml up -d nemotron
+#   curl -s http://localhost:8000/v1/models     # ready when this answers
+#   docker compose up -d
+#
+# The first start pulls roughly 120GB into LOCAL_NIM_CACHE and takes a long
+# while. The NIM needs two GPUs; docker-compose-nim-local.yaml reserves
+# device_ids '0' and '1'.
+#
+# This file contains no secrets and is committed. The copy you fill in is
+# ignored by .gitignore, like every other .env.*.
+
+# Retail Shopping Assistant environment template.
+#
+# This file is intentionally complete and contains no real secrets. Copy or
+# source it, then override only the values that differ for your deployment.
+#
+# Usage:
+#   cp .env.example .env
+#   $EDITOR .env
+#   source .env
+#   python scripts/model_config.py show --validate
+#   python scripts/model_config.py deploy --build
+
+export RETAIL_REPO_ROOT="${RETAIL_REPO_ROOT:-${PWD:-.}}"
+
+# Keep Docker Compose from auto-parsing repo-root .env as dotenv. This is
+# intentionally forced because these env profiles are sourceable shell files.
+export COMPOSE_DISABLE_ENV_FILE=1
+
+# ---------------------------------------------------------------------------
+# Secrets
+# ---------------------------------------------------------------------------
+
+# Hosted NVIDIA endpoints and NGC-hosted local NIM images use NVIDIA keys.
+# Leave API keys empty for no-auth local OpenAI-compatible endpoints.
+export NVIDIA_API_KEY="${NVIDIA_API_KEY:-}"
+export NGC_API_KEY="${NGC_API_KEY:-$NVIDIA_API_KEY}"
+export LLM_API_KEY="${LLM_API_KEY:-$NVIDIA_API_KEY}"
+export EMBED_API_KEY="${EMBED_API_KEY:-$NVIDIA_API_KEY}"
+export RAIL_API_KEY="${RAIL_API_KEY:-$NVIDIA_API_KEY}"
+
+# ---------------------------------------------------------------------------
+# App LLM
+# ---------------------------------------------------------------------------
+
+export LLM_BASE_URL="${LLM_BASE_URL:-}"
+export LLM_MODEL="${LLM_MODEL:-}"
+
+# ---------------------------------------------------------------------------
+# Optional VLM media perception
+# ---------------------------------------------------------------------------
+
+export VLM_API_KEY="${VLM_API_KEY:-$NVIDIA_API_KEY}"
+export VLM_BASE_URL="${VLM_BASE_URL:-}"
+export VLM_MODEL="${VLM_MODEL:-}"
+
+# ---------------------------------------------------------------------------
+# Text embedding
+#
+# Left empty, the model comes from shared/configs/models.yaml, which is
+# nvidia/nemotron-3-embed-1b. Set these only to point somewhere else.
+#
+# Changing the embedding model changes the vector dimension, so the Milvus
+# collection must be rebuilt. The catalog fingerprint includes the model name,
+# so the rebuild is automatic on the next start -- but it is not free, and a
+# collection built by another model rejects every query until it happens.
+# ---------------------------------------------------------------------------
+
+export TEXT_EMBED_BASE_URL="${TEXT_EMBED_BASE_URL:-}"
+export TEXT_EMBED_MODEL="${TEXT_EMBED_MODEL:-}"
+
+# ---------------------------------------------------------------------------
+# Image embedding
+# ---------------------------------------------------------------------------
+
+# `shared/configs/models.yaml` enables hosted nvclip by default for developers
+# with NVIDIA Build endpoint access. Override these only when pointing image
+# search at another hosted endpoint or a remote NIM host.
+export IMAGE_EMBED_BASE_URL="${IMAGE_EMBED_BASE_URL:-}"
+export IMAGE_EMBED_MODEL="${IMAGE_EMBED_MODEL:-}"
+
+# ---------------------------------------------------------------------------
+# Guardrails models
+# ---------------------------------------------------------------------------
+
+export RAILS_BASE_URL="${RAILS_BASE_URL:-}"
+export RAILS_CONTENT_BASE_URL="${RAILS_CONTENT_BASE_URL:-$RAILS_BASE_URL}"
+export RAILS_TOPIC_BASE_URL="${RAILS_TOPIC_BASE_URL:-$RAILS_BASE_URL}"
+
+# ---------------------------------------------------------------------------
+# Local NIM support
+# ---------------------------------------------------------------------------
+
+# Required when any model role in shared/configs/models.yaml uses source: local_nim.
+export LOCAL_NIM_CACHE="${LOCAL_NIM_CACHE:-$HOME/.cache/nim}"
+
+# Useful examples for a single remote NIM host. Uncomment and adjust the host
+# when pointing model roles at a remote NIM host.
+# export LLM_BASE_URL="http://HOST:8000/v1"
+# export TEXT_EMBED_BASE_URL="http://HOST:8001/v1"
+# export IMAGE_EMBED_BASE_URL="http://HOST:8002/v1"
+# export VLM_BASE_URL="http://HOST:8005/v1"
+# export RAILS_CONTENT_BASE_URL="http://HOST:8003/v1"
+# export RAILS_TOPIC_BASE_URL="http://HOST:8004/v1"
+
+# ---------------------------------------------------------------------------
+# Service wiring
+# ---------------------------------------------------------------------------
+
+# Compose supplies container-internal defaults. Override these for local process
+# development or nonstandard service placement.
+export CATALOG_RETRIEVER_URL="${CATALOG_RETRIEVER_URL:-http://catalog-retriever:8010}"
+export MEMORY_RETRIEVER_URL="${MEMORY_RETRIEVER_URL:-http://memory-retriever:8011}"
+export RAILS_URL="${RAILS_URL:-http://rails:8012}"
+# Opt-in: set to true to turn guardrails on for this deployment.
+export GUARDRAILS_ENABLED="${GUARDRAILS_ENABLED:-false}"
+
+# Durable raw conversation turns and cart state use one SQLite-backed memory
+# service replica. Compose supplies sqlite:////data/context.db on the
+# memory-data named volume. Leave the URL empty for that Compose default, or set
+# a SQLite URL when running the memory service directly. Finalized product
+# cards support typed same-conversation historical-product resolution.
+export MEMORY_DATABASE_URL="${MEMORY_DATABASE_URL:-}"
+export MEMORY_SQLITE_BUSY_TIMEOUT_MS="${MEMORY_SQLITE_BUSY_TIMEOUT_MS:-5000}"
+export MEMORY_TURN_ABANDON_SECONDS="${MEMORY_TURN_ABANDON_SECONDS:-300}"
+export MEMORY_RECENT_TURNS="${MEMORY_RECENT_TURNS:-8}"
+
+# ---------------------------------------------------------------------------
+# Deep Agents graph checkpointing
+# ---------------------------------------------------------------------------
+
+# In-process MemorySaver is still the only supported graph checkpoint store.
+# Its request-scoped threads are deleted after successful durable finalization,
+# are lost on chain-server restart, and are not shared across replicas. This is
+# separate from durable turns in the memory-service SQLite database. An
+# explicitly empty value fails fast.
+export CHECKPOINT_STORE="${CHECKPOINT_STORE-memory}"
+
+# Bound one live Deep Agents graph-plus-grounding model stage below the client
+# request timeout. This is separate from stale durable-turn recovery.
+export DEEPAGENTS_EXECUTION_TIMEOUT_SECONDS="${DEEPAGENTS_EXECUTION_TIMEOUT_SECONDS:-45}"
+
+# Detailed agent/tool traces can contain shopper-derived arguments and internal
+# product references. Keep them out of public query responses unless a trusted
+# operator or evaluation deployment explicitly enables them.
+export EXPOSE_AGENT_DIAGNOSTICS="${EXPOSE_AGENT_DIAGNOSTICS:-false}"
+
+# ---------------------------------------------------------------------------
+# Dormant weather tool
+# ---------------------------------------------------------------------------
+
+# Slice 3 keeps weather disabled and unregistered with the shopping agent.
+# Enabling it permits explicit direct tool construction only; it does not make
+# weather model-visible. Keep the provider key in an ignored local .env,
+# process environment, or deployment secret store.
+export WEATHER_ENABLED="${WEATHER_ENABLED:-false}"
+export WEATHER_API_KEY="${WEATHER_API_KEY:-}"
+
+export MILVUS_HOST="${MILVUS_HOST:-milvus}"
+export MILVUS_PORT="${MILVUS_PORT:-19530}"
+export CATALOG_DB_PORT="${CATALOG_DB_PORT:-}"
+export CATALOG_DATA_SOURCE="${CATALOG_DATA_SOURCE:-}"
+export CATALOG_SCHEMA_SOURCE="${CATALOG_SCHEMA_SOURCE:-}"
+export CATALOG_IMAGE_EMBEDDING_ENABLED="${CATALOG_IMAGE_EMBEDDING_ENABLED:-true}"
+
+export SHARED_ROOT="${SHARED_ROOT:-$RETAIL_REPO_ROOT/shared}"
+export SHARED_CONFIG_ROOT="${SHARED_CONFIG_ROOT:-$SHARED_ROOT/configs}"
+
+# ---------------------------------------------------------------------------
+# Local UI/process development
+# ---------------------------------------------------------------------------
+
+export REACT_APP_API_BASE_URL="${REACT_APP_API_BASE_URL:-/api}"
+export BROWSER="${BROWSER:-none}"
+export PORT="${PORT:-3000}"
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+export TEST_PATH="${TEST_PATH:-shopping}"
+export RESULT_DIRECTORY="${RESULT_DIRECTORY:-results}"
+export RETAIL_TEST_PYTHON="${RETAIL_TEST_PYTHON:-}"
+
+# ---------------------------------------------------------------------------
+# Evaluation Challenger/Judge
+# ---------------------------------------------------------------------------
+
+export CHALLENGER_MODEL_BASE_URL="${CHALLENGER_MODEL_BASE_URL:-}"
+export CHALLENGER_MODEL_NAME="${CHALLENGER_MODEL_NAME:-}"
+export CHALLENGER_MODEL_API_KEY="${CHALLENGER_MODEL_API_KEY:-}"
+
+export JUDGE_MODEL_BASE_URL="${JUDGE_MODEL_BASE_URL:-}"
+export JUDGE_MODEL_NAME="${JUDGE_MODEL_NAME:-}"
+export JUDGE_MODEL_API_KEY="${JUDGE_MODEL_API_KEY:-}"
+
+# ---------------------------------------------------------------------------
+# Tracing
+# ---------------------------------------------------------------------------
+# The collector address. An exporter is installed only when this is set, so a
+# deployment without a collector pays nothing and cannot fail on startup. The
+# collector ships in docker-compose.yaml and forwards to Phoenix on :6006.
+#
+#   docker compose up -d otel-collector phoenix
+#   open http://localhost:6006
+export OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4318}"
+
+# The service name on every span.
+export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-chain-server}"
+
+# NeMo Relay: agent-level tracing, off and absent by default.
+#
+# The two lines above give you which tools ran, in what order, and how long
+# each took. Relay adds what was in them -- tool arguments, tool results, and
+# the exact prompt the model saw. That is the difference between "the search
+# found nothing" and "the search was asked for the wrong thing".
+#
+# It is off by default because it reads prompts, completions and cart contents.
+# That is shopper data leaving the process, and it belongs in a backend you
+# control. Turn it on to study a specific problem, then turn it off; it produces
+# one detailed trace per turn, not metrics.
+#
+# Both are needed. INSTALL_RELAY puts the library in the image and takes effect
+# at `docker compose build`; RELAY_ENABLED switches it on at `docker compose
+# up`. Setting only the second logs one warning and serves shoppers untouched.
+#
+# See docs/OBSERVABILITY.md.
+export INSTALL_RELAY="${INSTALL_RELAY:-false}"
+export RELAY_ENABLED="${RELAY_ENABLED:-false}"
+
+# ---------------------------------------------------------------------------
+# App LLM -- local NIM instead of a hosted endpoint
+# ---------------------------------------------------------------------------
+# These override the values above. The environment is read before
+# shared/configs/models.yaml is consulted, so running locally needs no change
+# to tracked configuration.
+#
+# `nemotron` is the compose service name and resolves on the shopping network.
+# From the host the same NIM is at localhost:8000.
+export LLM_BASE_URL="http://nemotron:8000/v1"
+export LLM_MODEL="nvidia/nemotron-3-super-120b-a12b"
+
+# A NIM on the compose network needs no authentication, and the OpenAI client
+# sends a key regardless -- so this is set to a value rather than left empty.
+export LLM_API_KEY="local"
+
+# Pulling the image from NGC, and where the weights are cached between runs.
+# The directory must exist and be writable by the container's user, which is
+# ${UID}: a first start that cannot write re-downloads on every restart.
+export NGC_API_KEY="${NGC_API_KEY:-${NVIDIA_API_KEY:-}}"
+export LOCAL_NIM_CACHE="${LOCAL_NIM_CACHE:-$HOME/.cache/nim}"
+export UID="${UID:-$(id -u)}"
+
+# vLLM arguments reach the NIM through NIM_PASSTHROUGH_ARGS in
+# docker-compose-nim-local.yaml, which is where --max-num-seqs and the
+# tool-call parser are set. Raise --max-num-seqs there to admit more concurrent
+# sequences when driving load.
+export NIM_LOG_LEVEL="${NIM_LOG_LEVEL:-INFO}"
+
+
+# ---------------------------------------------------------------------------
+# What the local NIM lets you see
+# ---------------------------------------------------------------------------
+# It serves vLLM's Prometheus metrics on its own port, with nothing to enable:
+#
+#   curl -s http://localhost:8000/metrics | grep -E '^vllm:'
+#
+# These are the numbers a hosted endpoint cannot give you -- tokens in and out,
+# time to first token, queue depth, KV-cache utilisation, running and waiting
+# sequences. Under load `vllm:num_requests_waiting` is the one that answers
+# whether the model is the bottleneck, which scripts/journey_load.py currently
+# has to infer.
+#
+# Nothing scrapes them yet: the collector in docker-compose.yaml carries a
+# traces pipeline only and there is no Prometheus in the stack. They are
+# available to curl and to nothing else.

--- a/.env.local-llm.example
+++ b/.env.local-llm.example
@@ -46,10 +46,17 @@ export COMPOSE_DISABLE_ENV_FILE=1
 # Secrets
 # ---------------------------------------------------------------------------
 
-# Hosted NVIDIA endpoints and NGC-hosted local NIM images use NVIDIA keys.
-# Leave API keys empty for no-auth local OpenAI-compatible endpoints.
+# Hosted NVIDIA endpoints use an inference key. Leave API keys empty for
+# no-auth local OpenAI-compatible endpoints.
 export NVIDIA_API_KEY="${NVIDIA_API_KEY:-}"
-export NGC_API_KEY="${NGC_API_KEY:-$NVIDIA_API_KEY}"
+
+# Pulling NIM images from the NGC catalog uses a *different* credential with a
+# different scope: an inference key cannot pull from NGC. There is deliberately
+# no fallback between them, because falling back turns "the NGC key is missing"
+# into an opaque authentication error partway through a weight download.
+#
+# Only needed to run a NIM locally. Leave it empty otherwise.
+export NGC_API_KEY="${NGC_API_KEY:-}"
 export LLM_API_KEY="${LLM_API_KEY:-$NVIDIA_API_KEY}"
 export EMBED_API_KEY="${EMBED_API_KEY:-$NVIDIA_API_KEY}"
 export RAIL_API_KEY="${RAIL_API_KEY:-$NVIDIA_API_KEY}"
@@ -259,12 +266,29 @@ export LLM_MODEL="nvidia/nemotron-3-super-120b-a12b"
 # sends a key regardless -- so this is set to a value rather than left empty.
 export LLM_API_KEY="local"
 
-# Pulling the image from NGC, and where the weights are cached between runs.
-# The directory must exist and be writable by the container's user, which is
-# ${UID}: a first start that cannot write re-downloads on every restart.
-export NGC_API_KEY="${NGC_API_KEY:-${NVIDIA_API_KEY:-}}"
+# Pulling the image from NGC. This is a different credential from
+# NVIDIA_API_KEY with a different scope -- an inference key cannot pull from the
+# NGC catalog -- so there is deliberately no fallback between them. Falling back
+# turns "the NGC key is missing" into an opaque authentication error partway
+# through a weight download, which is a much worse place to learn it.
+#
+# Get one from ngc.nvidia.com; `docker login nvcr.io` uses the same key with
+# $oauthtoken as the username.
+export NGC_API_KEY="${NGC_API_KEY:?set NGC_API_KEY to an NGC catalog key; NVIDIA_API_KEY will not work}"
+
+# Where the weights are cached between runs. It must exist and be writable by
+# the user the container runs as, or a first start that cannot write
+# re-downloads on every restart.
 export LOCAL_NIM_CACHE="${LOCAL_NIM_CACHE:-$HOME/.cache/nim}"
-export UID="${UID:-$(id -u)}"
+
+# The uid the NIM container runs as, so the cache it writes is owned by you.
+#
+# Not named UID: bash marks that read-only, so `export UID=...` fails, the
+# variable never reaches compose, and compose silently uses its own default of
+# 1000. That is correct only on a machine where you happen to be 1000, and
+# wrong everywhere else -- with the failure showing up as a cache nobody can
+# write rather than as an error.
+export NIM_UID="${NIM_UID:-$(id -u)}"
 
 # vLLM arguments reach the NIM through NIM_PASSTHROUGH_ARGS in
 # docker-compose-nim-local.yaml, which is where --max-num-seqs and the

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ tests/evaluation/results/*
 .env
 .env.*
 !.env.example
+!.env.local-llm.example
 
 # Next.js build output (the UI is CRA; this appears from stray tooling runs)
 ui/.next/

--- a/README.md
+++ b/README.md
@@ -430,7 +430,23 @@ The exact published response is documented in
    source .env
    ```
 
-   Set `NVIDIA_API_KEY` in the file. The env file is a sourceable shell file;
+   Set `NVIDIA_API_KEY` in the file.
+
+   Two templates are provided, and they differ by one role:
+
+   | template | app LLM | everything else |
+   |---|---|---|
+   | `.env.example` | hosted endpoint | hosted |
+   | `.env.local-llm.example` | **local NIM**, on your GPUs | hosted |
+
+   Use the second when you need what a hosted endpoint cannot give you: no rate
+   limit, and the model's own metrics. Only the LLM moves, so a run against one
+   and a run against the other differ by the model serving the shopper and
+   nothing else — which is what makes them comparable. See
+   [Running the LLM locally](#running-the-llm-locally) below.
+
+   Copy a template rather than editing it. Every `.env.*` is ignored except the
+   two templates, so your filled-in copy stays out of git along with its keys. The env file is a sourceable shell file;
    sourcing it also sets `COMPOSE_DISABLE_ENV_FILE=1` so Docker Compose uses
    the exported shell environment instead of auto-parsing repo-root `.env`.
    `CHECKPOINT_STORE=memory` is the only supported graph-checkpoint
@@ -506,6 +522,58 @@ The exact published response is documented in
    than an error, and a shopper is told the catalog is empty.
 
 7. **Access the application**: Open your browser to `http://localhost:3000`
+
+### Running the LLM locally
+
+The app LLM can be served from your own GPUs as a NIM instead of a hosted
+endpoint. Nothing else moves: embeddings, the VLM, guardrails, the judge and
+the challenger stay where they were.
+
+```bash
+cp .env.local-llm.example .env.local-llm
+$EDITOR .env.local-llm            # NVIDIA_API_KEY, and LOCAL_NIM_CACHE if not $HOME/.cache/nim
+source .env.local-llm
+
+mkdir -p "$LOCAL_NIM_CACHE" && chmod a+w "$LOCAL_NIM_CACHE"
+docker compose -f docker-compose-nim-local.yaml up -d nemotron
+
+curl -s http://localhost:8000/v1/models     # ready when this answers
+
+docker compose up -d
+docker compose exec catalog-retriever python -m app.index_catalog
+```
+
+The first start pulls roughly 120GB into `LOCAL_NIM_CACHE` and takes a long
+while; later starts read the cache. The NIM reserves two GPUs, `device_ids`
+`'0'` and `'1'` in `docker-compose-nim-local.yaml`. Make the cache writable
+before the first start — the container runs as `${UID}`, and a first start that
+cannot write re-downloads on every restart.
+
+No tracked configuration changes. The environment is read before
+`shared/configs/models.yaml`, so `LLM_BASE_URL` and `LLM_MODEL` are enough and
+`models.yaml` is left alone.
+
+**What this gets you.** The NIM serves vLLM's Prometheus metrics on its own
+port, with nothing to enable:
+
+```bash
+curl -s http://localhost:8000/metrics | grep -E '^vllm:'
+```
+
+Tokens in and out, time to first token, queue depth, KV-cache utilisation, and
+running and waiting sequences. `vllm:num_requests_waiting` is the one that says
+whether the model is the bottleneck rather than the application — a question a
+hosted endpoint cannot answer at all, and one the load tooling otherwise has to
+infer. Nothing scrapes these yet; the collector carries a traces pipeline only.
+
+**Going back to the hosted endpoint** is sourcing the other profile and
+restarting the chain server:
+
+```bash
+source .env
+docker compose up -d --force-recreate chain-server
+docker compose -f docker-compose-nim-local.yaml stop nemotron
+```
 
 8. **Stop the containers**:
 

--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -12,7 +12,7 @@ services:
       - NIM_PASSTHROUGH_ARGS=--enable-auto-tool-choice --tool-call-parser pythonic --max-num-seqs 256
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
-    user: "${UID:-1000}"
+    user: "${NIM_UID:-1000}"
     shm_size: "16gb"
     deploy:
       resources:
@@ -58,7 +58,7 @@ services:
       - NGC_API_KEY=${NGC_API_KEY}
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
-    user: "${UID:-1000}"
+    user: "${NIM_UID:-1000}"
     shm_size: "32gb"
     deploy:
       resources:
@@ -82,7 +82,7 @@ services:
       - NGC_API_KEY=${NGC_API_KEY}
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
-    user: "${UID:-1000}"
+    user: "${NIM_UID:-1000}"
     deploy:
       resources:
         reservations:
@@ -102,7 +102,7 @@ services:
       - NIM_KVCACHE_PERCENT=.4
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
-    user: "${UID:-1000}"
+    user: "${NIM_UID:-1000}"
     deploy:
       resources:
         reservations:
@@ -123,7 +123,7 @@ services:
       - NIM_KVCACHE_PERCENT=.4
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
-    user: "${UID:-1000}"
+    user: "${NIM_UID:-1000}"
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Adds `.env.local-llm.example`, a template for serving the app LLM from local GPUs as a NIM.

- **One role moves, nothing else.** Embeddings, the VLM, guardrails, the judge and the challenger stay on their hosted endpoints. A run against this profile and a run against `.env.example` differ by the model serving the shopper and nothing else, which is what makes them comparable.
- **No tracked configuration changes.** The environment is read before `shared/configs/models.yaml`, so `LLM_BASE_URL` and `LLM_MODEL` are sufficient; `models.yaml` keeps `source: endpoint` and nobody has to edit a shared file to run locally.
- **No secrets.** Every key is the same `${VAR:-}` placeholder `.env.example` uses. The only literals are the NIM's address on the compose network, its model name, and `LLM_API_KEY="local"` — a NIM there needs no authentication and the client sends a key regardless. The filled-in copy stays ignored like every other `.env.*`; the `.gitignore` negation admits this template alone.
- **README covers both profiles** — which to use when, and the local path end to end, including that the first start pulls roughly 120GB, that the cache must be writable before it, and that the catalog still needs indexing afterwards. Returning to the hosted endpoint is two commands, written down.
- **What a local NIM gives you.** vLLM serves Prometheus metrics on its own port with nothing to enable — tokens in and out, time to first token, queue depth, KV-cache utilisation, waiting sequences. `vllm:num_requests_waiting` answers whether the model or the application is the bottleneck, which a hosted endpoint cannot answer at all.
- **Not yet scraped.** The collector carries a traces pipeline only and there is no Prometheus in the stack, so those metrics are available to `curl` and nothing else. Said in the file rather than left to be discovered.
- **Unverified against a running NIM.** No NVIDIA driver on the machine this was written on; what is checked is that the variables resolve and the file carries no keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)