### PR TITLE
Performance measurement: tooling and a step-by-step guide

### DIFF
--- a/.env.local-llm.example
+++ b/.env.local-llm.example
@@ -313,7 +313,7 @@ export NIM_LOG_LEVEL="${NIM_LOG_LEVEL:-INFO}"
 # These are the numbers a hosted endpoint cannot give you -- tokens in and out,
 # time to first token, queue depth, KV-cache utilisation, running and waiting
 # sequences. Under load `vllm:num_requests_waiting` is the one that answers
-# whether the model is the bottleneck, which scripts/journey_load.py currently
+# whether the model is the bottleneck, which benchmarks/journey_load.py currently
 # has to infer.
 #
 # Nothing scrapes them yet: the collector in docker-compose.yaml carries a

--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ The Brev deployment guide walks you through the entire process from creating a L
 - **[Deep Agents Migration Plan](docs/DEEP_AGENTS_MIGRATION_PLAN.md)**: SDK migration, session isolation, tools, skills, and scaling notes
 - **[Deep Agents Cart Tool Goal](docs/DEEP_AGENTS_CART_TOOL_GOAL.md)**: Minimal cart-tool smoke gate and constraints
 - **[Deployment Guide](docs/DEPLOYMENT.md)**: Installation and setup instructions
+- **[Performance](docs/PERFORMANCE.md)**: Measure where a turn spends its time, sweep the local LLM to saturation, and size concurrent shoppers on given hardware
 - **[Testing and Evaluation](tests/README.md)**: Unit, integration, and
   Challenger/Judge workflows; multi-turn judging uses the actual generated
   conversation plus bounded current-turn catalog evidence from successful

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,6 +22,28 @@ Start the monitoring stack first, or the resource columns come back blank:
 cd ../monitoring && ./dashboard.sh up
 ```
 
+**The two sweep steps need tooling the rest does not.** `bench.sh sweep` drives
+load with vLLM's own benchmark, so it needs the `vllm` CLI and a tokenizer on
+disk. Neither is a dependency of this repo and neither is a small download, so
+install them before you start rather than meeting them four steps in:
+
+```bash
+# The CLI. A throwaway venv keeps it out of the application's environment.
+python3 -m venv ~/vllm-bench && ~/vllm-bench/bin/pip install vllm==0.17.1
+
+# A tokenizer. The benchmark counts tokens locally, so it needs the tokenizer
+# files -- a few MB -- but not the weights.
+hf download <your-model-repo> \
+  --include 'tokenizer*' 'config.json' --local-dir ~/model-tokenizer
+
+VLLM_BIN=~/vllm-bench/bin TOKENIZER=~/model-tokenizer ./bench.sh sweep
+```
+
+`bench.sh` looks for both on `PATH` and in the usual locations, and prints these
+commands if it cannot find them. Everything else here runs without them,
+including `shopper_study.py`, which is the one that answers the capacity
+question.
+
 ## The tools, by what they drive
 
 Grouped by which layer of the system they exercise, which is also the order you

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,107 @@
+# Benchmarks
+
+Tools that put load through this application and measure what happens.
+
+The Prometheus + Grafana stack that collects the results is next door in
+[`monitoring/`](../monitoring/README.md). The split is deliberate: standing up a
+scraper and driving traffic are different jobs, and conflating them made it easy
+to benchmark a deployment nobody had verified.
+
+**Read [`docs/PERFORMANCE.md`](../docs/PERFORMANCE.md) before using any of
+this.** It walks through the six measurements in the order that makes each one
+interpretable. This file is only a map of what is here.
+
+## Prerequisites
+
+The app LLM must be a **local NIM** (`docker-compose-nim-local.yaml`). A hosted
+endpoint publishes no metrics and rate-limits sustained load.
+
+Start the monitoring stack first, or the resource columns come back blank:
+
+```bash
+cd ../monitoring && ./dashboard.sh up
+```
+
+## The tools, by what they drive
+
+Grouped by which layer of the system they exercise, which is also the order you
+should use them in.
+
+### The LLM directly
+
+| Tool | Question it answers |
+|---|---|
+| `bench.sh load [c] [n]` | Are the instruments working? Does anything move? |
+| `bench.sh sweep [levels]` | Where does the engine saturate, and *why* — queueing, preemption, memory or compute? |
+| `bench.sh top` | What is happening right now, without a browser? |
+
+These bypass the application entirely, so they measure the engine's ceiling
+rather than anything a shopper would experience.
+
+### One turn through the whole application
+
+| Tool | Question it answers |
+|---|---|
+| `turn_profile.py` | Where does one turn's time actually go, and what is the token shape? |
+
+Run this **second, and before any sweep.** It produces the per-call input and
+output token counts that `sweep` needs; without them the sweep runs at a generic
+1:1 benchmark shape, and this application reads far more than it writes, so the
+answer can be off by a multiple.
+
+Needs `EXPOSE_AGENT_DIAGNOSTICS=true` or the tool-call breakdown — most of the
+value — comes back empty. The script warns when it does.
+
+### Whole journeys under concurrency
+
+| Tool | Question it answers |
+|---|---|
+| `shopper_study.py` | How many concurrent shoppers, at a stated latency target? |
+| `journey_load.py` | What breaks first, holding each level for a fixed duration? |
+| `concurrent_shoppers.py` | Do concurrent shoppers queue behind each other end to end? |
+
+`shopper_study.py` is the one that answers the capacity question. It fixes the
+*work* per level rather than the time — N shoppers each play one complete
+journey, and the level ends when the last finishes — so every level does the
+same amount of work and the levels are comparable. `journey_load.py` holds each
+level for a fixed duration instead, which is quicker but makes levels finish
+different amounts of work.
+
+Both report **time to first token** as the headline latency, because that is
+what a shopper waits for on a streaming interface.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `bench.sh` | Entry point for `load`, `sweep` and `top` |
+| `loadgen.py` | Concurrent load; discovers the served model from `/v1/models` |
+| `saturate.py` | Wraps `vllm bench serve`, samples gauges, detects saturation and names the cause |
+| `metrics_top.py` | Terminal metrics view |
+| `turn_profile.py` | Per-turn latency budget, reconciling app timings, engine counters and Phoenix spans |
+| `shopper_study.py` | Capacity harness: fixed work per level, TTFT headline, liveness checks |
+| `journey_load.py` | Journeys at rising concurrency, fixed duration per level |
+| `concurrent_shoppers.py` | End-to-end serialisation check |
+
+`loadgen.py` and `saturate.py` both resolve the served model name from
+`/v1/models` at run time instead of hardcoding it, because the name differs
+between a NIM and a hand-built vLLM server, and a stale name fails as an opaque
+HTTP 404.
+
+## The one thing you must not skip
+
+**A dead model looks like a fast one.** When a model call fails, the application
+returns canned text — "I could not complete that shopping request." That text
+streams like any other reply: it has a first-token time and raises no exception.
+A harness measuring latency and counting exceptions cannot tell it from a real
+answer, and will report a full sweep of completed turns with zero errors against
+a model that answered none of them.
+
+`shopper_study.py` therefore applies three independent checks per level — probes
+the model server directly before and after, confirms `vllm:prompt_tokens_total`
+advanced, and matches the application's failure strings in the replies — and
+aborts rather than climbing into levels that would produce the same confident
+nonsense. Levels it distrusts are marked `<-- DISCARD` and excluded from the
+summary.
+
+If you write your own harness against this stack, it needs the equivalent.

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Load generation and measurement against the locally deployed LLM NIM.
+#
+# Only meaningful when the app LLM is a local NIM (docker-compose-nim-local.yaml).
+# A hosted endpoint publishes no metrics and rate-limits sustained load, so there
+# is nothing to measure and no way to measure it.
+#
+# This script covers the subcommands that need environment plumbing -- resolving
+# the served model name, locating the vllm CLI, finding a tokenizer on disk. The
+# whole-application harnesses in this directory take their own arguments and are
+# run directly with python3; see ./bench.sh with no arguments for the list.
+#
+# For the monitoring stack that collects what these produce, see
+# ../monitoring/dashboard.sh.
+#
+# Usage: ./bench.sh {load|sweep|top}
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The NIM as seen from this host. The load tools run here rather than in a
+# container, so they reach it over the published port.
+VLLM_HOST="${VLLM_HOST:-127.0.0.1}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+# Only needs the standard library. The sweep additionally needs vLLM's benchmark
+# CLI; see stage_sweep.
+PY="${PYTHON:-python3}"
+
+RED=$'\033[31m'; GRN=$'\033[32m'; BLU=$'\033[34m'; RST=$'\033[0m'
+log() { printf '%s[%s]%s %s\n' "$BLU" "$(date +%H:%M:%S)" "$RST" "$*"; }
+ok()  { printf '%s  ok%s %s\n' "$GRN" "$RST" "$*"; }
+die() { printf '%sfail%s %s\n' "$RED" "$RST" "$*" >&2; exit 1; }
+
+require_nim() {
+  curl -sf --max-time 5 "http://$VLLM_HOST:$VLLM_PORT/health" >/dev/null \
+    || die "the NIM is not responding on $VLLM_HOST:$VLLM_PORT - start it first"
+}
+
+# Terminal view straight off /metrics. No Prometheus, no Grafana, no browser --
+# useful over a bare SSH session or when docker is unavailable.
+stage_top() {
+  VLLM_BASE="http://$VLLM_HOST:$VLLM_PORT" "$PY" "$HERE/metrics_top.py" "$@"
+}
+
+# Drives concurrent traffic so the panels have something to show. An idle
+# dashboard looks identical to a broken one.
+stage_load() {
+  local conc="${1:-8}" reqs="${2:-32}"
+  require_nim
+  log "Generating load: $reqs requests at concurrency $conc"
+  VLLM_BASE="http://$VLLM_HOST:$VLLM_PORT" \
+    "$PY" "$HERE/loadgen.py" "$conc" "$reqs"
+}
+
+# Concurrency sweep to find where the server stops keeping up. Load comes from
+# vLLM's own benchmark; this adds the metric peaks the benchmark cannot see.
+stage_sweep() {
+  require_nim
+
+  # The sweep drives load with vLLM's own benchmark rather than a homegrown
+  # client, so the throughput and latency figures are the ones vLLM's
+  # maintainers publish. That means the vllm CLI has to be importable here --
+  # it is not needed for anything else in this directory.
+  local vllm_bin="${VLLM_BIN:-}"
+  if [[ -z "$vllm_bin" ]]; then
+    if command -v vllm >/dev/null 2>&1; then
+      vllm_bin="$(dirname "$(command -v vllm)")"
+    else
+      die "the 'vllm' CLI is not on PATH, and the sweep needs it for 'vllm bench serve'.
+
+  Install it into a virtualenv (it is a large download):
+    python3 -m venv ~/vllm-bench && ~/vllm-bench/bin/pip install vllm==0.17.1
+    VLLM_BIN=~/vllm-bench/bin $0 sweep ${1:-}
+
+  For a quick check without it, './bench.sh load' needs nothing extra."
+    fi
+  fi
+  log "vllm CLI: $vllm_bin"
+
+  local tok="${TOKENIZER:-}"
+  if [[ -z "$tok" ]]; then
+    # bench serve counts tokens locally, so it needs tokenizer files on disk.
+    # The served name is tried first, but a NIM reports a catalog name rather
+    # than a path, and resolving that name against HuggingFace fails without
+    # credentials -- so fall back to any local checkpoint that has a tokenizer.
+    tok=$(curl -sf "http://$VLLM_HOST:$VLLM_PORT/v1/models" \
+          | "$PY" -c 'import json,sys
+d=json.load(sys.stdin)["data"]
+print(d[0].get("root") or d[0]["id"] if d else "")' 2>/dev/null || true)
+    if [[ ! -f "$tok/tokenizer_config.json" ]]; then
+      # Search the NIM cache and any local checkpoint directory. The NIM unpacks
+      # tokenizer files somewhere under its cache, so this looks a few levels in.
+      #
+      # Only existing directories are passed to find, and the result is guarded
+      # with `|| true`. Without both, one absent path makes find exit non-zero,
+      # and `set -o pipefail` then kills the script here -- silently, after it
+      # has already found a usable tokenizer, which is a memorably annoying way
+      # to spend an afternoon.
+      local search=()
+      for d in "${LOCAL_NIM_CACHE:-$HOME/.cache/nim}" /data/models "$HOME/nemotron-tokenizer"; do
+        [[ -d "$d" ]] && search+=("$d")
+      done
+      if (( ${#search[@]} )); then
+        # Snapshot directories before tmp ones: the NIM leaves tokenizer files in
+        # both, but its tmp copies are not guaranteed to outlive a restart.
+        tok=$(find "${search[@]}" -maxdepth 5 -name tokenizer_config.json \
+                -printf '%h\n' 2>/dev/null | grep -v '/tmp/' | head -1 || true)
+        [[ -z "$tok" ]] && tok=$(find "${search[@]}" -maxdepth 5 \
+                -name tokenizer_config.json -printf '%h\n' 2>/dev/null | head -1 || true)
+      fi
+    fi
+  fi
+  if [[ -z "$tok" ]]; then
+    die "no tokenizer found, and 'bench serve' counts tokens locally so it needs one.
+
+  Fetch just the tokenizer files (a few MB, not the weights):
+    pip install huggingface_hub
+    hf download nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8 \\
+      --include 'tokenizer*' 'config.json' --local-dir ~/nemotron-tokenizer
+
+  Then re-run with:
+    TOKENIZER=~/nemotron-tokenizer $0 sweep ${1:-}"
+  fi
+  log "tokenizer: $tok"
+
+  # Sweeping at the default shape measures a workload this application does not
+  # run. SWEEP_INPUT_LEN / SWEEP_OUTPUT_LEN / SWEEP_PREFIX_LEN come from
+  # turn_profile.py; without them the answer can be off by a multiple.
+  if [[ -z "${SWEEP_INPUT_LEN:-}" ]]; then
+    printf '%s warn%s no SWEEP_INPUT_LEN set, sweeping at the generic benchmark shape.\n' \
+      $'\033[33m' "$RST"
+    printf '       This application reads far more than it writes, so that answers a\n'
+    printf '       different question. Take the real shape from turn_profile.py first.\n'
+  fi
+
+  VLLM_BASE="http://$VLLM_HOST:$VLLM_PORT" VENV_BIN="$vllm_bin" TOKENIZER="$tok" \
+    "$PY" "$HERE/saturate.py" "${1:-}"
+}
+
+case "${1:-}" in
+  load)   shift || true; stage_load "$@" ;;
+  sweep)  shift || true; stage_sweep "$@" ;;
+  top)    shift || true; stage_top "$@" ;;
+  up|down|status|urls|logs)
+    die "'$1' belongs to the monitoring stack
+
+  This script generates load and takes measurements. The Prometheus + Grafana
+  stack lives next door:
+    ../monitoring/dashboard.sh $1" ;;
+  *)      die "usage: $0 {load|sweep|top}
+
+  load [c] [n]   generate concurrent traffic straight at the NIM,
+                 so the dashboard panels have something to show
+  sweep [levels] concurrency sweep to find the saturation point,
+                 e.g. 'sweep 1,8,32,128'   (default 1,4,8,16,32,64,128)
+                 set SWEEP_INPUT_LEN / SWEEP_OUTPUT_LEN / SWEEP_PREFIX_LEN
+                 from turn_profile.py, or it measures the wrong workload
+  top [secs]     live terminal metrics view, no browser needed
+
+  The whole-application harnesses take their own arguments -- run them directly:
+
+    python3 benchmarks/turn_profile.py --out /tmp/profile.json
+        where one turn's time goes, and the token shape the sweep needs
+
+    python3 benchmarks/shopper_study.py --levels 1,2,4,8,16,32 --think 0
+        how many concurrent shoppers, at a stated latency target
+
+    python3 benchmarks/journey_load.py
+        journeys at rising concurrency for a fixed duration per level
+
+    python3 benchmarks/concurrent_shoppers.py --shoppers N
+        do concurrent shoppers queue behind each other end to end
+
+  Step-by-step: docs/PERFORMANCE.md" ;;
+esac

--- a/benchmarks/concurrent_shoppers.py
+++ b/benchmarks/concurrent_shoppers.py
@@ -11,7 +11,7 @@ waiting properly, N shoppers at once should finish in about the time of one. If
 instead the wall clock grows with N, something on the turn path is holding the
 event loop and every shopper is paying for every other shopper.
 
-    python scripts/concurrent_shoppers.py --shoppers 3
+    python3 benchmarks/concurrent_shoppers.py --shoppers 3
 
 Each shopper gets its own user, session and cart, so nothing is shared and any
 queueing observed is the service's, not the scenario's.

--- a/benchmarks/journey_load.py
+++ b/benchmarks/journey_load.py
@@ -21,9 +21,9 @@ search, resolve references, call tools and write carts. A synthetic single-turn
 benchmark stresses the wrong thing and flatters the result -- most of a real
 turn is the agent loop, not one model call.
 
-    python scripts/journey_load.py                          # ramp 1,2,4,8
-    python scripts/journey_load.py --levels 1,4,8,16
-    python scripts/journey_load.py --only J12,J17 --minutes 3
+    python3 benchmarks/journey_load.py                      # ramp 1,2,4,8
+    python3 benchmarks/journey_load.py --levels 1,4,8,16
+    python3 benchmarks/journey_load.py --only J12,J17 --minutes 3
 
 Nothing is judged and nothing is asserted. Checking answers costs further model
 calls, which is the resource under test. Correctness is `replay.py`'s job.

--- a/benchmarks/loadgen.py
+++ b/benchmarks/loadgen.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Concurrent load generator, so the dashboard panels have data to show.
+
+An idle dashboard looks exactly like a broken one, so this exists mainly to
+prove the metrics pipeline works end to end.
+
+    ./bench.sh load                # 8 concurrent, 32 requests
+    ./bench.sh load 16 64          # 16 concurrent, 64 requests
+"""
+
+import json
+import os
+import random
+import sys
+import threading
+import time
+import urllib.request
+
+BASE = os.environ.get("VLLM_BASE", "http://127.0.0.1:8000")
+
+
+def resolve_model():
+    """Ask the server what it serves rather than assuming a name.
+
+    A hardcoded default silently turns every request into a 404 the moment the
+    endpoint is replaced -- which is exactly what happened when the hand-rolled
+    vLLM server ('nemotron-3-super') gave way to the NIM
+    ('nvidia/nemotron-3-super-120b-a12b'). SERVED_NAME still overrides for the
+    case of several models behind one endpoint.
+    """
+    override = os.environ.get("SERVED_NAME")
+    if override:
+        return override
+    with urllib.request.urlopen(f"{BASE}/v1/models", timeout=10) as r:
+        data = json.loads(r.read())["data"]
+    if not data:
+        sys.exit(f"{BASE} reports no served models")
+    return data[0]["id"]
+
+
+MODEL = resolve_model()
+
+# Mixed shapes so the latency histograms and the prompt/generation length
+# heatmaps get a spread of values rather than one spike.
+PROMPTS = [
+    ("Explain in two sentences what expert parallelism means.", 200),
+    ("List five uses for a state-space model.", 400),
+    ("Write a haiku about tensor cores.", 120),
+    ("Summarise the tradeoff between FP8 and FP4 inference.", 500),
+    ("What is 17 * 23? Show your working.", 300),
+    ("Name three advantages of Mixture-of-Experts architectures.", 400),
+    ("Describe KV cache paging in one paragraph.", 600),
+    ("Give a one-line definition of speculative decoding.", 150),
+]
+
+lock = threading.Lock()
+stats = {"ok": 0, "fail": 0, "prompt_tokens": 0, "completion_tokens": 0,
+         "latencies": []}
+
+
+def worker(n_requests):
+    for _ in range(n_requests):
+        prompt, max_tokens = random.choice(PROMPTS)
+        payload = {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.7,
+        }
+        req = urllib.request.Request(
+            f"{BASE}/v1/chat/completions",
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        t0 = time.time()
+        try:
+            with urllib.request.urlopen(req, timeout=600) as r:
+                d = json.loads(r.read())
+            elapsed = time.time() - t0
+            with lock:
+                stats["ok"] += 1
+                stats["prompt_tokens"] += d["usage"]["prompt_tokens"]
+                stats["completion_tokens"] += d["usage"]["completion_tokens"]
+                stats["latencies"].append(elapsed)
+        except Exception as exc:
+            with lock:
+                stats["fail"] += 1
+            print(f"  request failed: {type(exc).__name__}: {exc}")
+
+
+def main():
+    concurrency = int(sys.argv[1]) if len(sys.argv) > 1 else 8
+    total = int(sys.argv[2]) if len(sys.argv) > 2 else 32
+
+    per_worker = max(1, total // concurrency)
+    actual = per_worker * concurrency
+    print(f"  {actual} requests, {concurrency} concurrent, "
+          f"{per_worker} per worker")
+
+    t0 = time.time()
+    threads = [threading.Thread(target=worker, args=(per_worker,))
+               for _ in range(concurrency)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    wall = time.time() - t0
+
+    lat = sorted(stats["latencies"])
+    print(f"\n  completed {stats['ok']} ok, {stats['fail']} failed "
+          f"in {wall:.1f}s")
+    if lat:
+        def pct(p):
+            return lat[min(len(lat) - 1, int(p * len(lat)))]
+        print(f"  e2e latency   mean {sum(lat) / len(lat):.2f}s   "
+              f"p50 {pct(0.5):.2f}s   p90 {pct(0.9):.2f}s   max {lat[-1]:.2f}s")
+    print(f"  tokens        {stats['prompt_tokens']:,} prompt, "
+          f"{stats['completion_tokens']:,} generated")
+    if wall > 0:
+        print(f"  throughput    {stats['completion_tokens'] / wall:.1f} "
+              f"generated tok/s aggregate, "
+              f"{stats['ok'] / wall:.2f} req/s")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/metrics_top.py
+++ b/benchmarks/metrics_top.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Live terminal metrics view for a vLLM server. No Prometheus, no browser.
+
+Reads the server's own /metrics endpoint and derives rates between samples the
+same way Prometheus would. Every metric shown below is one vLLM actually
+exposes -- verified against a live vLLM 0.17.1 /metrics scrape -- and the
+histogram averages are computed as documented, delta(_sum) / delta(_count).
+
+    ./bench.sh top              # refresh every 2s
+    ./bench.sh top 5            # every 5s
+"""
+
+import os
+import sys
+import time
+import urllib.request
+from collections import defaultdict
+
+BASE = os.environ.get("VLLM_BASE", "http://127.0.0.1:8000")
+
+BOLD, DIM, GRN, YLW, RED, CYA, RST = (
+    "\033[1m", "\033[2m", "\033[32m", "\033[33m", "\033[31m", "\033[36m", "\033[0m"
+)
+
+
+def scrape():
+    """Parse the Prometheus text exposition format into usable structures."""
+    with urllib.request.urlopen(f"{BASE}/metrics", timeout=10) as r:
+        text = r.read().decode()
+
+    plain = {}
+    buckets = defaultdict(dict)
+    labelled = defaultdict(float)
+
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        try:
+            key, val = line.rsplit(" ", 1)
+            val = float(val)
+        except ValueError:
+            continue
+
+        if "{" in key:
+            name, lbl = key.split("{", 1)
+            lbl = lbl.rstrip("}")
+        else:
+            name, lbl = key, ""
+
+        if name.endswith("_bucket"):
+            le = None
+            for part in lbl.split(","):
+                if part.strip().startswith("le="):
+                    le = part.split("=", 1)[1].strip('"')
+            if le is not None:
+                buckets[name[: -len("_bucket")]][float(le)] = val
+        else:
+            plain[name] = plain.get(name, 0.0) + val
+            if "finished_reason=" in lbl:
+                for part in lbl.split(","):
+                    if part.strip().startswith("finished_reason="):
+                        labelled[part.split("=", 1)[1].strip('"')] += val
+
+    return plain, buckets, labelled
+
+
+def rate(cur, prev, dt):
+    if prev is None or dt <= 0:
+        return 0.0
+    return max(0.0, (cur - prev)) / dt
+
+
+def hist_avg(name, plain, prev_plain):
+    """Interval mean of a histogram: delta(_sum) / delta(_count)."""
+    s, c = plain.get(f"{name}_sum", 0.0), plain.get(f"{name}_count", 0.0)
+    if prev_plain is None:
+        return None
+    ds = s - prev_plain.get(f"{name}_sum", 0.0)
+    dc = c - prev_plain.get(f"{name}_count", 0.0)
+    return (ds / dc) if dc > 0 else None
+
+
+def hist_quantile(name, q, buckets, prev_buckets):
+    """Quantile over the interval, interpolating within the matched bucket."""
+    cur = buckets.get(name, {})
+    if not cur:
+        return None
+    prev = (prev_buckets or {}).get(name, {})
+    deltas = sorted((le, cur[le] - prev.get(le, 0.0)) for le in cur)
+    if not deltas:
+        return None
+    total = deltas[-1][1]
+    if total <= 0:
+        return None
+    target = q * total
+    lower_le, lower_count = 0.0, 0.0
+    for le, count in deltas:
+        if count >= target:
+            if le == float("inf"):
+                return lower_le
+            if count == lower_count:
+                return le
+            frac = (target - lower_count) / (count - lower_count)
+            return lower_le + frac * (le - lower_le)
+        lower_le, lower_count = le, count
+    return deltas[-1][0]
+
+
+def fmt_s(v):
+    if v is None:
+        return f"{DIM}--{RST}"
+    if v < 1e-3:
+        return f"{v * 1e6:.0f}us"
+    if v < 1:
+        return f"{v * 1e3:.1f}ms"
+    return f"{v:.2f}s"
+
+
+def bar(frac, width=28):
+    frac = max(0.0, min(1.0, frac))
+    filled = int(frac * width)
+    color = GRN if frac < 0.7 else (YLW if frac < 0.9 else RED)
+    return f"{color}{'#' * filled}{DIM}{'.' * (width - filled)}{RST}"
+
+
+def row(label, value, note=""):
+    print(f"  {label:<26} {value:<22} {DIM}{note}{RST}")
+
+
+def main():
+    interval = float(sys.argv[1]) if len(sys.argv) > 1 else 2.0
+    prev_plain = prev_buckets = None
+    prev_t = None
+    print(f"{DIM}polling {BASE}/metrics every {interval}s - Ctrl-C to exit{RST}")
+
+    while True:
+        try:
+            plain, buckets, reasons = scrape()
+        except Exception as exc:
+            print(f"{RED}scrape failed:{RST} {exc}")
+            time.sleep(interval)
+            continue
+
+        now = time.time()
+        dt = (now - prev_t) if prev_t else 0.0
+
+        gen = rate(plain.get("vllm:generation_tokens_total", 0.0),
+                   (prev_plain or {}).get("vllm:generation_tokens_total"), dt)
+        pro = rate(plain.get("vllm:prompt_tokens_total", 0.0),
+                   (prev_plain or {}).get("vllm:prompt_tokens_total"), dt)
+        fin = rate(plain.get("vllm:request_success_total", 0.0),
+                   (prev_plain or {}).get("vllm:request_success_total"), dt)
+        pre = rate(plain.get("vllm:num_preemptions_total", 0.0),
+                   (prev_plain or {}).get("vllm:num_preemptions_total"), dt)
+
+        running = plain.get("vllm:num_requests_running", 0.0)
+        waiting = plain.get("vllm:num_requests_waiting", 0.0)
+        kv = plain.get("vllm:kv_cache_usage_perc", 0.0)
+
+        print("\033[2J\033[H", end="")
+        print(f"{BOLD}vLLM metrics{RST}  {DIM}{BASE}  "
+              f"{time.strftime('%H:%M:%S')}  window {dt:.1f}s{RST}\n")
+
+        print(f"{BOLD}{CYA}Throughput{RST}")
+        row("generation tokens/s", f"{gen:8.1f}", "vllm:generation_tokens_total")
+        row("prompt tokens/s", f"{pro:8.1f}", "vllm:prompt_tokens_total")
+        row("requests finished/s", f"{fin:8.2f}", "vllm:request_success_total")
+        it = hist_avg("vllm:iteration_tokens_total", plain, prev_plain)
+        row("tokens per engine step", f"{it:8.1f}" if it else f"{DIM}--{RST}",
+            "vllm:iteration_tokens_total")
+
+        print(f"\n{BOLD}{CYA}Concurrency{RST}")
+        row("requests running", f"{running:8.0f}", "vllm:num_requests_running")
+        row("requests waiting", f"{waiting:8.0f}", "vllm:num_requests_waiting")
+        row("preemptions/s", f"{pre:8.2f}", "vllm:num_preemptions_total")
+
+        print(f"\n{BOLD}{CYA}KV cache{RST}")
+        row("usage", f"{kv * 100:7.2f}%  {bar(kv)}", "vllm:kv_cache_usage_perc")
+        pq = plain.get("vllm:prefix_cache_queries_total", 0.0)
+        ph = plain.get("vllm:prefix_cache_hits_total", 0.0)
+        row("prefix cache hit rate",
+            f"{(ph / pq * 100):7.2f}%" if pq > 0 else f"{DIM}n/a (disabled){RST}",
+            "vllm:prefix_cache_hits_total / _queries_total")
+
+        print(f"\n{BOLD}{CYA}Latency{RST}  {DIM}interval mean, then p50 / p90 / p99{RST}")
+        for label, metric in (
+            ("end-to-end", "vllm:e2e_request_latency_seconds"),
+            ("time to first token", "vllm:time_to_first_token_seconds"),
+            ("inter-token", "vllm:inter_token_latency_seconds"),
+            ("time per output token", "vllm:request_time_per_output_token_seconds"),
+            ("queue wait", "vllm:request_queue_time_seconds"),
+            ("prefill phase", "vllm:request_prefill_time_seconds"),
+            ("decode phase", "vllm:request_decode_time_seconds"),
+        ):
+            avg = hist_avg(metric, plain, prev_plain)
+            qs = " / ".join(
+                fmt_s(hist_quantile(metric, q, buckets, prev_buckets))
+                for q in (0.5, 0.9, 0.99)
+            )
+            row(label, fmt_s(avg), qs)
+
+        if reasons:
+            print(f"\n{BOLD}{CYA}Finish reasons{RST} {DIM}(cumulative){RST}")
+            for reason, count in sorted(reasons.items(), key=lambda x: -x[1]):
+                row(reason, f"{count:8.0f}", "vllm:request_success_total")
+
+        if prev_plain is None:
+            print(f"\n{DIM}rates and quantiles appear after the second sample{RST}")
+
+        prev_plain, prev_buckets, prev_t = plain, buckets, now
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print()

--- a/benchmarks/saturate.py
+++ b/benchmarks/saturate.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+Find the saturation point of a vLLM deployment.
+
+Answers "can this system take more traffic?" by sweeping concurrency and
+watching for the signals that mean the server has stopped keeping up.
+
+Load is driven by vLLM's own benchmark (`vllm bench serve`) rather than a
+homegrown client, so the throughput and latency numbers are the ones vLLM's
+maintainers report. While each level runs, this script polls the server's
+/metrics endpoint to capture things the benchmark cannot see from outside:
+peak queue depth, peak KV cache usage, and whether the scheduler had to preempt.
+
+Saturation is called on four independent signals, in priority order:
+
+  1. PREEMPTION   vllm:num_preemptions_total increased. The scheduler evicted
+                  running requests to free KV cache. Hard over-capacity.
+  2. QUEUEING     vllm:num_requests_waiting went above zero. Requests are
+                  waiting for a slot rather than being served.
+  3. KV PRESSURE  vllm:kv_cache_usage_perc peaked above 90%. Cache-bound.
+  4. PLATEAU      output token throughput gained less than PLATEAU_PCT over the
+                  previous level. More concurrency is buying latency, not work.
+
+Usage:
+    ./bench.sh sweep                        # default ladder
+    ./bench.sh sweep 1,4,16,64,128          # explicit levels
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.request
+
+BASE = os.environ.get("VLLM_BASE", "http://127.0.0.1:8000")
+VENV = os.environ.get("VENV_BIN", os.path.dirname(sys.executable))
+TOKENIZER = os.environ.get("TOKENIZER", "")
+
+
+def resolve_served_name():
+    """The name the endpoint answers to, asked rather than assumed.
+
+    `bench serve` puts this in the request body, so a stale value returns 404
+    for every request and reports as a benchmark failure rather than a config
+    mistake. Set SERVED_NAME to pin it when one endpoint serves several models.
+    """
+    override = os.environ.get("SERVED_NAME")
+    if override:
+        return override
+    try:
+        with urllib.request.urlopen(f"{BASE}/v1/models", timeout=10) as r:
+            data = json.loads(r.read())["data"]
+        return data[0]["id"] if data else ""
+    except Exception:
+        return ""
+
+
+MODEL = resolve_served_name()
+
+INPUT_LEN = int(os.environ.get("SWEEP_INPUT_LEN", "1024"))
+OUTPUT_LEN = int(os.environ.get("SWEEP_OUTPUT_LEN", "256"))
+PLATEAU_PCT = float(os.environ.get("SWEEP_PLATEAU_PCT", "10"))
+
+# Tokens of identical prefix on the front of every request, on top of
+# INPUT_LEN. Zero -- the benchmark default -- makes every prompt independently
+# random, so no request can ever reuse another's prefill and the prefix cache
+# records queries with no hits at all.
+#
+# That is fine for a shape with nothing to share, and badly wrong for an agent,
+# where a system prompt, tool schemas and conversation history repeat on every
+# call. Measured against this application the shared part is around 44% of the
+# prompt, so a sweep without it does roughly twice the prefill the real system
+# does and understates throughput accordingly.
+#
+# Set it to the number of tokens that genuinely repeat:
+#   SWEEP_PREFIX_LEN=6176 SWEEP_INPUT_LEN=7990   # 14,166 total, 44% shared
+PREFIX_LEN = int(os.environ.get("SWEEP_PREFIX_LEN", "0"))
+
+BOLD, DIM, GRN, YLW, RED, CYA, RST = (
+    "\033[1m", "\033[2m", "\033[32m", "\033[33m", "\033[31m", "\033[36m", "\033[0m"
+)
+
+
+def get_metrics():
+    with urllib.request.urlopen(f"{BASE}/metrics", timeout=10) as r:
+        text = r.read().decode()
+    out = {}
+    for line in text.splitlines():
+        if line.startswith("#") or not line:
+            continue
+        try:
+            key, val = line.rsplit(" ", 1)
+            name = key.split("{", 1)[0]
+            out[name] = out.get(name, 0.0) + float(val)
+        except ValueError:
+            continue
+    return out
+
+
+class MetricSampler(threading.Thread):
+    """Polls /metrics during a benchmark run to capture peaks."""
+
+    def __init__(self, interval=0.5):
+        super().__init__(daemon=True)
+        self.interval = interval
+        self.stop_flag = threading.Event()
+        self.peak_running = 0.0
+        self.peak_waiting = 0.0
+        self.peak_kv = 0.0
+        self.start_preemptions = None
+        self.end_preemptions = None
+
+    def run(self):
+        while not self.stop_flag.is_set():
+            try:
+                m = get_metrics()
+            except Exception:
+                time.sleep(self.interval)
+                continue
+            self.peak_running = max(self.peak_running,
+                                    m.get("vllm:num_requests_running", 0.0))
+            self.peak_waiting = max(self.peak_waiting,
+                                    m.get("vllm:num_requests_waiting", 0.0))
+            self.peak_kv = max(self.peak_kv,
+                               m.get("vllm:kv_cache_usage_perc", 0.0))
+            p = m.get("vllm:num_preemptions_total", 0.0)
+            if self.start_preemptions is None:
+                self.start_preemptions = p
+            self.end_preemptions = p
+            time.sleep(self.interval)
+
+    @property
+    def preempted(self):
+        if self.start_preemptions is None or self.end_preemptions is None:
+            return 0.0
+        return max(0.0, self.end_preemptions - self.start_preemptions)
+
+
+def run_level(concurrency, num_prompts):
+    """Run one benchmark level, returning bench results plus metric peaks."""
+    out_json = tempfile.mktemp(suffix=".json")
+    cmd = [
+        os.path.join(VENV, "vllm"), "bench", "serve",
+        "--base-url", BASE,
+        "--model", MODEL,
+        "--dataset-name", "random",
+        "--random-input-len", str(INPUT_LEN),
+        "--random-output-len", str(OUTPUT_LEN),
+        "--num-prompts", str(num_prompts),
+        "--max-concurrency", str(concurrency),
+        # Fixed output length keeps levels comparable; without it the model
+        # stops at its own EOS and each level measures a different workload.
+        "--ignore-eos",
+        "--save-result", "--result-filename", out_json,
+    ]
+    if PREFIX_LEN:
+        cmd += ["--random-prefix-len", str(PREFIX_LEN)]
+    if TOKENIZER:
+        cmd += ["--tokenizer", TOKENIZER]
+
+    sampler = MetricSampler()
+    sampler.start()
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    sampler.stop_flag.set()
+    sampler.join(timeout=3)
+
+    if proc.returncode != 0:
+        return None, proc.stderr[-500:], sampler
+
+    try:
+        with open(out_json) as fh:
+            res = json.load(fh)
+        os.unlink(out_json)
+    except Exception as exc:
+        return None, f"could not read results: {exc}", sampler
+
+    return res, None, sampler
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1]:
+        levels = [int(x) for x in sys.argv[1].replace(" ", "").split(",") if x]
+    else:
+        levels = [1, 4, 8, 16, 32, 64, 128]
+
+    try:
+        urllib.request.urlopen(f"{BASE}/v1/models", timeout=5)
+    except Exception:
+        sys.exit(f"endpoint {BASE} is not responding")
+
+    print(f"{BOLD}Saturation sweep{RST}  {DIM}{BASE}{RST}")
+    print(f"{DIM}load driven by 'vllm bench serve'; "
+          f"{INPUT_LEN + PREFIX_LEN} in / {OUTPUT_LEN} out tokens per request, "
+          f"ignore-eos"
+          + (f"; {PREFIX_LEN} of the input is a prefix shared by every request "
+             f"({PREFIX_LEN / (INPUT_LEN + PREFIX_LEN) * 100:.0f}%), "
+             f"so the prefix cache has something to reuse"
+             if PREFIX_LEN else
+             "; every prompt independently random, so the prefix cache "
+             "cannot hit"))
+    print(f"levels: {', '.join(map(str, levels))}{RST}\n")
+
+    hdr = (f"{'conc':>5} {'reqs':>5} {'out tok/s':>10} {'tot tok/s':>10} "
+           f"{'req/s':>7} {'TTFT p99':>9} {'TPOT p99':>9} "
+           f"{'peak run':>9} {'peak wait':>10} {'peak KV':>8} {'preempt':>8}")
+    print(f"{BOLD}{hdr}{RST}")
+    print(DIM + "-" * len(hdr) + RST)
+
+    rows = []
+    for conc in levels:
+        num_prompts = min(max(3 * conc, 24), 384)
+        res, err, sampler = run_level(conc, num_prompts)
+        if res is None:
+            print(f"{conc:>5} {RED}failed: {err[:80]}{RST}")
+            continue
+
+        row = {
+            "concurrency": conc,
+            "num_prompts": num_prompts,
+            "completed": res.get("completed"),
+            "failed": res.get("failed"),
+            "output_throughput": res.get("output_throughput", 0.0),
+            "total_token_throughput": res.get("total_token_throughput", 0.0),
+            "request_throughput": res.get("request_throughput", 0.0),
+            "mean_ttft_ms": res.get("mean_ttft_ms", 0.0),
+            "p99_ttft_ms": res.get("p99_ttft_ms", 0.0),
+            "mean_tpot_ms": res.get("mean_tpot_ms", 0.0),
+            "p99_tpot_ms": res.get("p99_tpot_ms", 0.0),
+            "peak_running": sampler.peak_running,
+            "peak_waiting": sampler.peak_waiting,
+            "peak_kv": sampler.peak_kv,
+            "preempted": sampler.preempted,
+            "duration": res.get("duration", 0.0),
+        }
+        rows.append(row)
+
+        warn = ""
+        if row["preempted"] > 0:
+            warn = RED
+        elif row["peak_waiting"] > 0 or row["peak_kv"] > 0.9:
+            warn = YLW
+        print(f"{warn}{conc:>5} {row['completed']:>5} "
+              f"{row['output_throughput']:>10.1f} "
+              f"{row['total_token_throughput']:>10.1f} "
+              f"{row['request_throughput']:>7.2f} "
+              f"{row['p99_ttft_ms']:>8.0f}m {row['p99_tpot_ms']:>8.1f}m "
+              f"{row['peak_running']:>9.0f} {row['peak_waiting']:>10.0f} "
+              f"{row['peak_kv'] * 100:>7.1f}% {row['preempted']:>8.0f}{RST}")
+
+    # Written before the analysis gate, and to a per-run name by default. A sweep
+    # is minutes of load against a shared server, so a run that cannot be
+    # summarised -- a single level, or a ladder cut short -- must still leave its
+    # measurements behind rather than exiting and discarding them.
+    # The shape is in the name as well as the ladder. Two sweeps that differ
+    # only in prefix length are exactly the comparison worth making, and naming
+    # them by concurrency alone means the second silently overwrites the first.
+    out = os.environ.get(
+        "SWEEP_OUT",
+        f"/tmp/sweep_{INPUT_LEN + PREFIX_LEN}in-{OUTPUT_LEN}out"
+        f"-{PREFIX_LEN}shared"
+        f"_{'-'.join(str(r['concurrency']) for r in rows)}.json")
+    with open(out, "w") as fh:
+        json.dump(rows, fh, indent=2)
+    print(f"\n  full results: {out}")
+
+    if len(rows) < 2:
+        print("  single level: no trend to analyse, compare against other runs")
+        return
+
+    analyze(rows)
+
+
+def analyze(rows):
+    """Turn sweep rows into a verdict. Separate so saved results can be
+    re-read with --analyze without paying for another sweep."""
+    print(f"\n{BOLD}{CYA}Analysis{RST}")
+
+    best = max(rows, key=lambda r: r["output_throughput"])
+    print(f"  peak measured throughput  {BOLD}{best['output_throughput']:.1f} "
+          f"output tok/s{RST} at concurrency {best['concurrency']}")
+
+    # Two limits matter and they are not the same number. Reporting only the
+    # first queueing event understates capacity badly: throughput can keep
+    # climbing well past the point where a few requests start waiting.
+    #
+    #   capacity ceiling - concurrency where output throughput stops improving
+    #   latency knee     - highest concurrency still free of queueing
+    capacity = rows[0]
+    for prev, cur in zip(rows, rows[1:]):
+        if prev["output_throughput"] <= 0:
+            continue
+        gain = (cur["output_throughput"] - prev["output_throughput"]) \
+            / prev["output_throughput"] * 100
+        if gain < PLATEAU_PCT:
+            capacity = prev
+            break
+        capacity = cur
+
+    clean = [r for r in rows if r["peak_waiting"] == 0]
+    knee = clean[-1] if clean else None
+
+    print(f"  {BOLD}capacity ceiling{RST}          concurrency "
+          f"{capacity['concurrency']} at "
+          f"{capacity['output_throughput']:.0f} output tok/s "
+          f"{DIM}(throughput stops improving past here){RST}")
+    if knee:
+        print(f"  {BOLD}latency-clean ceiling{RST}     concurrency "
+              f"{knee['concurrency']} at {knee['output_throughput']:.0f} "
+              f"output tok/s, p99 TTFT {knee['p99_ttft_ms']:.0f}ms "
+              f"{DIM}(no queueing at all){RST}")
+    else:
+        print(f"  {YLW}every level queued{RST} - the clean ceiling is below "
+              f"concurrency {rows[0]['concurrency']}")
+
+    # What is actually binding? Distinguish a scheduler cap from real hardware
+    # limits, because the fix is completely different.
+    print(f"\n{BOLD}{CYA}What is the binding constraint?{RST}")
+    saturated = [r for r in rows if r["concurrency"] >= capacity["concurrency"]]
+    max_running = max(r["peak_running"] for r in rows)
+    plateaued_running = [r for r in saturated
+                         if abs(r["peak_running"] - max_running) < 1]
+    queued_beyond = [r for r in rows
+                     if r["concurrency"] > max_running and r["peak_waiting"] > 0]
+    peak_kv_overall = max(r["peak_kv"] for r in rows)
+    any_preempt = any(r["preempted"] > 0 for r in rows)
+
+    if len(plateaued_running) >= 2 and queued_beyond and not any_preempt \
+            and peak_kv_overall < 0.85:
+        print(f"  {YLW}SCHEDULER CAP{RST}, not hardware.")
+        print(f"    Requests in flight never exceeded {max_running:.0f} no "
+              f"matter how much load was offered, while the queue grew to "
+              f"{max(r['peak_waiting'] for r in rows):.0f}.")
+        print(f"    That is max_num_seqs={max_running:.0f} holding the batch "
+              f"size down.")
+        print(f"    Meanwhile KV cache peaked at only "
+              f"{peak_kv_overall * 100:.1f}% and there were zero preemptions,")
+        print(f"    so there is memory headroom to raise it.")
+        print(f"    {BOLD}Try MAX_NUM_SEQS={int(max_running) * 4} and re-run "
+              f"this sweep.{RST}")
+    elif any_preempt:
+        print(f"  {RED}KV CACHE / MEMORY{RST}. The scheduler had to preempt "
+              f"running requests.")
+        print(f"    Lower MAX_MODEL_LEN or raise GPU_MEM_UTIL to grow the "
+              f"cache.")
+    elif peak_kv_overall > 0.85:
+        print(f"  {YLW}KV CACHE{RST}. Usage peaked at "
+              f"{peak_kv_overall * 100:.1f}% without preemption - close to the "
+              f"edge.")
+        print(f"    Lower MAX_MODEL_LEN to fit more concurrent sequences.")
+    elif capacity["concurrency"] == rows[-1]["concurrency"]:
+        print(f"  {GRN}NOT YET FOUND{RST}. Throughput was still climbing at "
+              f"the top of the ladder.")
+        print(f"    Re-run higher: ./bench.sh sweep "
+              f"{rows[-1]['concurrency'] * 2},{rows[-1]['concurrency'] * 4}")
+    else:
+        print(f"  {BOLD}COMPUTE{RST}. Throughput plateaued with KV cache at "
+              f"only {peak_kv_overall * 100:.1f}% and no preemption,")
+        print(f"    so the GPUs are the limit rather than memory or the "
+              f"scheduler.")
+        print(f"    A tuned fused-MoE kernel config or enabling MTP is the "
+              f"lever here, not more concurrency.")
+
+    # Latency cost of concurrency, which is the real operational tradeoff.
+    first, last = rows[0], rows[-1]
+    print(f"\n{BOLD}{CYA}Cost of pushing past the ceiling{RST}")
+    print(f"  p99 TTFT   {first['p99_ttft_ms']:>9.0f}ms at conc "
+          f"{first['concurrency']:<4} -> {last['p99_ttft_ms']:>9.0f}ms at conc "
+          f"{last['concurrency']}   {DIM}queueing shows up here first{RST}")
+    print(f"  p99 TPOT   {first['p99_tpot_ms']:>9.1f}ms at conc "
+          f"{first['concurrency']:<4} -> {last['p99_tpot_ms']:>9.1f}ms at conc "
+          f"{last['concurrency']}   {DIM}per-token speed once running{RST}")
+    if first["output_throughput"] > 0:
+        print(f"  batching gain: "
+              f"{last['output_throughput'] / first['output_throughput']:.1f}x "
+              f"throughput, conc {first['concurrency']} -> "
+              f"{last['concurrency']}")
+    if last["p99_ttft_ms"] > 3 * (knee or last)["p99_ttft_ms"] and knee:
+        print(f"  {DIM}TTFT inflating while TPOT stays flat is the signature of "
+              f"queueing, not slow decode.{RST}")
+
+
+def print_table(rows):
+    hdr = (f"{'conc':>5} {'reqs':>5} {'out tok/s':>10} {'tot tok/s':>10} "
+           f"{'req/s':>7} {'TTFT p99':>9} {'TPOT p99':>9} "
+           f"{'peak run':>9} {'peak wait':>10} {'peak KV':>8} {'preempt':>8}")
+    print(f"{BOLD}{hdr}{RST}")
+    print(DIM + "-" * len(hdr) + RST)
+    for row in rows:
+        warn = RED if row["preempted"] > 0 else (
+            YLW if row["peak_waiting"] > 0 or row["peak_kv"] > 0.9 else "")
+        print(f"{warn}{row['concurrency']:>5} {row['completed']:>5} "
+              f"{row['output_throughput']:>10.1f} "
+              f"{row['total_token_throughput']:>10.1f} "
+              f"{row['request_throughput']:>7.2f} "
+              f"{row['p99_ttft_ms']:>8.0f}m {row['p99_tpot_ms']:>8.1f}m "
+              f"{row['peak_running']:>9.0f} {row['peak_waiting']:>10.0f} "
+              f"{row['peak_kv'] * 100:>7.1f}% {row['preempted']:>8.0f}{RST}")
+
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) > 2 and sys.argv[1] == "--analyze":
+            with open(sys.argv[2]) as fh:
+                saved = json.load(fh)
+            print(f"{BOLD}Re-analysis of {sys.argv[2]}{RST}\n")
+            print_table(saved)
+            analyze(saved)
+        else:
+            main()
+    except KeyboardInterrupt:
+        print("\ninterrupted")

--- a/benchmarks/shopper_study.py
+++ b/benchmarks/shopper_study.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""How many shoppers can this deployment serve at once, and what stops it.
+
+journey_load.py holds each concurrency level for a fixed number of minutes, so
+different levels finish different amounts of work and their latencies are not
+strictly comparable. This fixes the work instead: N shoppers each play one
+complete journey, and the run ends when the last of them finishes. Every level
+does exactly N x (turns per journey), so completion time, latency and
+throughput can be read against each other directly.
+
+It reports **time to first token** as the headline latency. A turn keeps
+working long after the shopper starts reading -- tools, the grounding pass, the
+cart read -- so total turn time measures the system's effort while first-token
+measures the wait. Sizing a streaming UI against total turn time buys hardware
+nobody needed.
+
+    # the model's ceiling: shoppers who never pause, all starting together
+    python3 benchmarks/shopper_study.py --levels 1,2,4,8,16,32 --think 0
+
+    # what real shoppers look like: they read, and they do not arrive in step
+    python3 benchmarks/shopper_study.py --levels 1,2,4,8,16,32 --think 20 --stagger 30
+
+    # honest prefix-cache number: different conversations, not N copies of one
+    python3 benchmarks/shopper_study.py --levels 8 --mixed
+
+Nothing is judged and nothing is asserted; correctness is replay.py's job.
+Checking answers costs further model calls, which is the resource under test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import threading
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tests.evaluation.src.config import load_eval_config  # noqa: E402
+from tests.evaluation.src.replay import (  # noqa: E402
+    SCRIPTS_ROOT,
+    Assistant,
+    load_scenarios,
+)
+
+#: Far outside any real shopper id, with its own range per level so no two
+#: levels ever share a conversation or a cart.
+STUDY_USER_BASE = 820_000_000
+
+PROM = "http://localhost:9090"
+
+#: Probed directly, not through the agent. The agent answers a dead model with
+#: an apology, and an apology has a first-token time like any other reply.
+MODEL = "http://localhost:8000"
+
+#: What the chain server says when a model call fails. These are ordinary
+#: replies as far as the harness is concerned -- they stream, they have a
+#: first-token time, and they raise nothing -- so without matching them a run
+#: against a dead model reports full throughput and no errors. One did.
+FALLBACKS = (
+    "i could not complete that shopping request",
+    "something went wrong",
+    "please try again",
+    "temporarily unavailable",
+    "is unavailable",
+)
+
+
+def model_alive(timeout: float = 10.0) -> bool:
+    """Is the model server itself answering?
+
+    A hang here does not look like a crash: the container stays up, the
+    weights stay resident, and the process list looks healthy, while every
+    request sits until something upstream times out.
+    """
+    try:
+        with urllib.request.urlopen(f"{MODEL}/health", timeout=timeout) as response:
+            return response.status == 200
+    except Exception:
+        return False
+
+
+@dataclass
+class Turn:
+    shopper: int
+    index: int
+    ttft: float | None
+    seconds: float
+    #: A reply the agent produced without the model. Counted, not raised.
+    fallback: bool = False
+
+
+@dataclass
+class Level:
+    concurrency: int
+    turns: list[Turn] = field(default_factory=list)
+    errors: int = 0
+    first_error: str | None = None
+    seconds: float = 0.0
+    started_at: float = 0.0
+    ended_at: float = 0.0
+    resources: dict = field(default_factory=dict)
+    model_ok_before: bool = True
+    model_ok_after: bool = True
+    #: Why the level is not a measurement, or None if it is one.
+    invalid: str | None = None
+
+    @property
+    def fallbacks(self) -> int:
+        return sum(1 for t in self.turns if t.fallback)
+
+    def pct(self, values: list[float], p: float) -> float:
+        if not values:
+            return 0.0
+        ordered = sorted(values)
+        return ordered[min(int(len(ordered) * p), len(ordered) - 1)]
+
+    @property
+    def ttfts(self) -> list[float]:
+        return [t.ttft for t in self.turns if t.ttft is not None]
+
+    @property
+    def walls(self) -> list[float]:
+        return [t.seconds for t in self.turns]
+
+    @property
+    def turns_per_minute(self) -> float:
+        return len(self.turns) / self.seconds * 60 if self.seconds else 0.0
+
+
+def prom_range(expr: str, start: float, end: float, step: int = 5) -> list[float]:
+    """Every sample of expr across the window, flattened across series."""
+    url = f"{PROM}/api/v1/query_range?" + urllib.parse.urlencode(
+        {"query": expr, "start": f"{start:.0f}", "end": f"{end:.0f}", "step": step})
+    try:
+        with urllib.request.urlopen(url, timeout=20) as resp:
+            result = json.load(resp)["data"]["result"]
+    except Exception:
+        return []
+    return [float(v) for s in result for _, v in s["values"]]
+
+
+def prom_delta(expr: str, start: float, end: float) -> float:
+    """How much a counter advanced across the window.
+
+    Two instant reads rather than increase(), which extrapolates over its
+    lookback and would bleed the previous level into this one.
+    """
+    def at(when: float) -> float | None:
+        url = f"{PROM}/api/v1/query?" + urllib.parse.urlencode(
+            {"query": expr, "time": f"{when:.0f}"})
+        try:
+            with urllib.request.urlopen(url, timeout=20) as resp:
+                result = json.load(resp)["data"]["result"]
+        except Exception:
+            return None
+        return float(result[0]["value"][1]) if result else None
+
+    a, b = at(start), at(end)
+    return 0.0 if a is None or b is None else b - a
+
+
+#: Everything outside the model server. Named rather than matched loosely, so a
+#: new observability container does not quietly get counted as application load.
+APP_SERVICES = ("chain-server|catalog-retriever|memory-retriever|milvus|rails|"
+                "etcd|minio|nginx|frontend|otel-collector|phoenix")
+
+
+def capture_resources(start: float, end: float) -> dict:
+    """What the machine was doing, from Prometheus rather than a local sampler.
+
+    Reading the same store the dashboard reads means a number here and a panel
+    there cannot disagree, and it covers every service rather than only the
+    ones this script thought to watch.
+    """
+    gpu = prom_range("DCGM_FI_DEV_GPU_UTIL", start, end)
+    kv = prom_range("vllm:kv_cache_usage_perc", start, end)
+    app_cpu = prom_range(
+        f'sum(container_cpu_percent{{service=~"{APP_SERVICES}"}})', start, end)
+    nim_cpu = prom_range(
+        'container_cpu_percent{service="nemotron"}', start, end)
+    app_mem = prom_range(
+        f'sum(container_memory_mib{{service=~"{APP_SERVICES}"}})', start, end)
+    queries = prom_delta("vllm:prefix_cache_queries_total", start, end)
+    hits = prom_delta("vllm:prefix_cache_hits_total", start, end)
+    return {
+        "gpu_mean_pct": round(sum(gpu) / len(gpu), 1) if gpu else None,
+        "gpu_peak_pct": round(max(gpu), 1) if gpu else None,
+        "kv_peak_pct": round(max(kv) * 100, 2) if kv else None,
+        "app_cpu_peak_cores": round(max(app_cpu) / 100, 2) if app_cpu else None,
+        "app_mem_peak_mib": round(max(app_mem)) if app_mem else None,
+        "nim_cpu_peak_cores": round(max(nim_cpu) / 100, 2) if nim_cpu else None,
+        "prompt_tokens": round(prom_delta("vllm:prompt_tokens_total", start, end)),
+        "output_tokens": round(prom_delta("vllm:generation_tokens_total", start, end)),
+        "cache_hit_pct": round(hits / queries * 100, 1) if queries else None,
+    }
+
+
+def play(assistant, scenario, identity, level, shopper, think, lock,
+         stop) -> None:
+    """One shopper, one complete journey, every turn in order."""
+    for index, step in enumerate(scenario.get("turns") or [], start=1):
+        if stop.is_set():
+            return
+        attachment = None
+        if step.get("attach"):
+            attachment = SCRIPTS_ROOT / "assets" / str(step["attach"])
+        started = time.monotonic()
+        try:
+            answer = assistant.say(identity, str(step["say"]), attachment)
+        except Exception as exc:
+            with lock:
+                level.errors += 1
+                if level.first_error is None:
+                    level.first_error = f"{type(exc).__name__}: {exc}"[:140]
+            return
+        reply = str(answer.get("reply") or "").strip().lower()
+        with lock:
+            level.turns.append(Turn(
+                shopper=shopper, index=index,
+                ttft=answer.get("ttft"),
+                seconds=time.monotonic() - started,
+                fallback=not reply or any(m in reply for m in FALLBACKS)))
+        if think and index < len(scenario.get("turns") or []):
+            # Jittered, because a fixed pause would march every shopper in
+            # lockstep for the whole journey -- which is the arrival pattern
+            # this option exists to avoid.
+            time.sleep(random.uniform(think * 0.5, think * 1.5))
+
+
+def run_level(assistants, scenarios, concurrency: int, think: float,
+              stagger: float, settle: float) -> Level:
+    level = Level(concurrency=concurrency)
+    lock = threading.Lock()
+    stop = threading.Event()
+
+    def worker(slot: int) -> None:
+        if stagger:
+            time.sleep(stagger * slot / max(concurrency - 1, 1))
+        assistant = assistants[slot % len(assistants)]
+        scenario = scenarios[slot % len(scenarios)]
+        marker = f"study-{concurrency}-{slot}-{int(time.time())}"
+        identity = {
+            "user_id": STUDY_USER_BASE + concurrency * 1000 + slot,
+            "session_id": marker,
+            "conversation_id": marker,
+            "cart_id": marker,
+        }
+        play(assistant, scenario, identity, level, slot, think, lock, stop)
+
+    level.model_ok_before = model_alive()
+    if not level.model_ok_before:
+        level.invalid = "model was not answering before the level started"
+        return level
+
+    level.started_at = time.time()
+    begin = time.monotonic()
+    threads = [threading.Thread(target=worker, args=(i,))
+               for i in range(concurrency)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    level.seconds = time.monotonic() - begin
+    level.ended_at = time.time()
+
+    # Prometheus scrapes on its own schedule, so the tail of the run is not in
+    # the store yet when the last thread returns.
+    time.sleep(settle)
+    level.resources = capture_resources(level.started_at, level.ended_at)
+    level.model_ok_after = model_alive()
+
+    # Three independent ways to catch a level that ran against a model which
+    # was not serving. Any one of them alone has a blind spot: the probe can
+    # pass either side of a hang that happened in between, the counter can
+    # move because a handful of early turns got through, and the fallback
+    # count can stay low if the agent happens to answer from cache.
+    prompt_tokens = level.resources.get("prompt_tokens") or 0
+    share = level.fallbacks / len(level.turns) if level.turns else 0.0
+    if not level.model_ok_after:
+        level.invalid = "model stopped answering during the level"
+    elif level.turns and not prompt_tokens:
+        level.invalid = "model processed no prompt tokens during the level"
+    elif share > 0.2:
+        level.invalid = f"{share:.0%} of replies were the agent's failure text"
+    return level
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--levels", default="1,2,4,8,16,32")
+    parser.add_argument("--journey", default="J01",
+                        help="journey every shopper plays (default J01)")
+    parser.add_argument("--mixed", action="store_true",
+                        help="rotate through every journey instead of N copies "
+                             "of one. N copies share every word, which is the "
+                             "best case prefix caching will ever see and not "
+                             "what real shoppers do.")
+    parser.add_argument("--think", type=float, default=0.0,
+                        help="seconds a shopper spends reading between turns, "
+                             "jittered +/-50%%. 0 is back to back, a worst case.")
+    parser.add_argument("--stagger", type=float, default=0.0,
+                        help="spread the start of the N shoppers over this many "
+                             "seconds. 0 starts them together, which makes every "
+                             "request miss the prefix cache at once.")
+    parser.add_argument("--text-only", action="store_true",
+                        help="skip journeys that attach an image or video. "
+                             "Without an image embedding service deployed "
+                             "those turns exercise a fallback, so including "
+                             "them measures the fallback and not the product.")
+    parser.add_argument("--settle", type=float, default=10.0)
+    parser.add_argument("--out", default=None)
+    args = parser.parse_args()
+
+    config = load_eval_config()
+    assistant = Assistant(config)
+    assistants = [assistant]
+
+    scenarios = load_scenarios(None if args.mixed else args.journey)
+    scenarios = [s for s in scenarios if s["id"].startswith("J")]
+    if args.text_only:
+        withheld = [s["id"] for s in scenarios
+                    if any(t.get("attach") for t in (s.get("turns") or []))]
+        scenarios = [s for s in scenarios
+                     if not any(t.get("attach") for t in (s.get("turns") or []))]
+        if withheld:
+            print(f"  text only   skipping {len(withheld)} journey(s) that "
+                  f"attach media: {', '.join(withheld)}")
+    if not scenarios:
+        raise SystemExit(f"no journey matched {args.journey!r}")
+    turns_each = len(scenarios[0].get("turns") or [])
+
+    levels = [int(v) for v in args.levels.split(",") if v.strip()]
+    label = ("mixed journeys" if args.mixed
+             else f"{scenarios[0]['id']} x N ({turns_each} turns each)")
+    print(f"shopper study: {label}")
+    print(f"  think time {args.think:g}s between turns"
+          + (", jittered" if args.think else " (back to back)"))
+    print(f"  start       "
+          + (f"spread over {args.stagger:g}s" if args.stagger else "all together"))
+    print(f"  levels      {', '.join(map(str, levels))}\n")
+
+    header = (f"{'shoppers':>8} {'turns':>6} {'wall s':>7} {'turns/min':>10} "
+              f"{'TTFT p50':>9} {'TTFT p95':>9} {'turn p95':>9} "
+              f"{'GPU%':>5} {'app cores':>10} {'KV%':>6} {'cache%':>7} {'err':>4}")
+    print(header)
+    print("-" * len(header))
+
+    results = []
+    for concurrency in levels:
+        level = run_level(assistants, scenarios, concurrency, args.think,
+                          args.stagger, args.settle)
+        r = level.resources
+        print(f"{concurrency:8d} {len(level.turns):6d} {level.seconds:7.0f} "
+              f"{level.turns_per_minute:10.1f} "
+              f"{level.pct(level.ttfts, 0.50):9.2f} "
+              f"{level.pct(level.ttfts, 0.95):9.2f} "
+              f"{level.pct(level.walls, 0.95):9.1f} "
+              f"{r.get('gpu_mean_pct') or 0:5.0f} "
+              f"{r.get('app_cpu_peak_cores') or 0:10.2f} "
+              f"{r.get('kv_peak_pct') or 0:6.1f} "
+              f"{r.get('cache_hit_pct') or 0:7.1f} "
+              f"{level.errors:4d}"
+              + (f"   <-- DISCARD: {level.invalid}" if level.invalid else ""))
+        results.append({
+            "invalid": level.invalid,
+            "fallback_replies": level.fallbacks,
+            "model_ok_before": level.model_ok_before,
+            "model_ok_after": level.model_ok_after,
+            "concurrency": concurrency,
+            "turns": len(level.turns),
+            "seconds": round(level.seconds, 1),
+            "turns_per_minute": round(level.turns_per_minute, 2),
+            "ttft_p50": round(level.pct(level.ttfts, 0.50), 3),
+            "ttft_p95": round(level.pct(level.ttfts, 0.95), 3),
+            "ttft_mean": round(statistics.fmean(level.ttfts), 3) if level.ttfts else None,
+            "turn_p95": round(level.pct(level.walls, 0.95), 2),
+            "errors": level.errors,
+            "first_error": level.first_error,
+            "started_at": level.started_at,
+            "ended_at": level.ended_at,
+            **level.resources,
+        })
+
+        # Every later level would run against the same dead server and report
+        # the same confident nonsense, only louder.
+        if level.invalid:
+            print(f"\n  stopping: {level.invalid}.")
+            print("  Levels above this one were not attempted. Restart the "
+                  "model server before rerunning.")
+            break
+
+    out = Path(args.out or (
+        f"/tmp/shopper_study_{'mixed' if args.mixed else args.journey}"
+        f"_think{args.think:g}_stagger{args.stagger:g}.json"))
+    out.write_text(json.dumps({
+        "journey": "mixed" if args.mixed else scenarios[0]["id"],
+        "journeys_played": [s["id"] for s in scenarios],
+        "text_only": args.text_only,
+        "turns_per_journey": turns_each,
+        "think_seconds": args.think,
+        "stagger_seconds": args.stagger,
+        "levels": results,
+    }, indent=1))
+    print(f"\n  written {out}")
+
+    usable = [r for r in results if not r["invalid"]]
+    if not usable:
+        raise SystemExit("  no level produced a usable measurement")
+    best = max(usable, key=lambda r: r["turns_per_minute"])
+    print(f"  peak {best['turns_per_minute']:.1f} turns/min at "
+          f"{best['concurrency']} shoppers")
+    cores = best.get("app_cpu_peak_cores") or 0
+    if cores and best["concurrency"]:
+        per = cores / best["concurrency"]
+        print(f"  application tier used {cores:.2f} cores at that point, "
+              f"{per:.3f} per shopper")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/turn_profile.py
+++ b/benchmarks/turn_profile.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Profile where time goes inside a single agent turn.
+
+Answers "what is the agent actually waiting on" by measuring one turn from three
+vantage points at once and reconciling them:
+
+  app      chain-server's own /query/timing response: per-phase timings, tokens,
+           and which model roles were called
+  engine   the NIM's Prometheus counters, sampled either side of the turn, which
+           give the LLM's true prefill/decode/queue split and KV peak
+  spans    Phoenix/OTel, which is the only source with per-LLM-call and
+           per-tool-call granularity
+
+No single source is sufficient. The app's `timings` buckets overlap each other
+(`deepagents` contains `catalog_search` and the safety checks), so they cannot be
+summed. The engine only sees its own requests, so it cannot see retrieval or the
+remote embedding hop. Spans see structure but attribute their own overhead.
+Reading all three together is what makes the residual - the time that belongs to
+no component - visible and trustworthy.
+
+Usage:
+    ./turn_profile.py                       # default query set
+    ./turn_profile.py --out /tmp/p1.json
+    ./turn_profile.py --only greeting,filtered_search
+"""
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+
+CHAIN = os.environ.get("CHAIN_BASE", "http://localhost:8009")
+NIM = os.environ.get("NIM_BASE", "http://127.0.0.1:8000")
+PHOENIX = os.environ.get("PHOENIX_BASE", "http://localhost:6006")
+
+# Counters read either side of a turn. Deltas over a single turn are exact
+# because the profiler runs one turn at a time against an otherwise idle engine.
+COUNTERS = [
+    "vllm:prompt_tokens_total",
+    "vllm:generation_tokens_total",
+    "vllm:time_to_first_token_seconds_sum",
+    "vllm:time_to_first_token_seconds_count",
+    "vllm:request_prefill_time_seconds_sum",
+    "vllm:request_decode_time_seconds_sum",
+    "vllm:request_queue_time_seconds_sum",
+    "vllm:request_inference_time_seconds_sum",
+    "vllm:inter_token_latency_seconds_sum",
+    "vllm:inter_token_latency_seconds_count",
+    "vllm:num_preemptions_total",
+    "vllm:prefix_cache_queries_total",
+    "vllm:prefix_cache_hits_total",
+]
+
+# Independent single-turn probes. Each runs in its own session so that a growing
+# history does not silently inflate the next one. `greeting` is the control: it
+# should need no catalog search, so whatever it costs is the fixed price of a
+# turn before any retrieval or tool work happens.
+PROBES = [
+    ("greeting", "Hello"),
+    ("filtered_search", "Show me black dresses under $100"),
+    ("simple_search", "I need a red handbag"),
+    ("broad_search", "What do you have in shoes?"),
+    ("cart_read", "What is in my cart?"),
+]
+
+# One multi-turn session, kept in order, to expose how prompt size and cost grow
+# with conversation depth. Single-turn probes cannot show this.
+CONVERSATION = [
+    ("convo_t1", "Show me summer dresses"),
+    ("convo_t2", "Only the ones under $80"),
+    ("convo_t3", "Add the first one to my cart"),
+]
+
+
+def _get_json(url, timeout=15):
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return json.loads(r.read().decode())
+
+
+def read_counters():
+    """Scrape the NIM's metrics, summing across label sets per metric name."""
+    try:
+        with urllib.request.urlopen(f"{NIM}/metrics", timeout=15) as r:
+            text = r.read().decode()
+    except Exception:
+        return {}
+    out = {}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        try:
+            key, val = line.rsplit(" ", 1)
+            name = key.split("{", 1)[0]
+        except ValueError:
+            continue
+        if name in COUNTERS or name == "vllm:kv_cache_usage_perc":
+            out[name] = out.get(name, 0.0) + float(val)
+    return out
+
+
+class KVSampler(threading.Thread):
+    """Track peak KV usage and in-flight requests while a turn runs.
+
+    kv_cache_usage_perc is a gauge, so it reads zero at idle and is only
+    meaningful sampled during the request.
+    """
+
+    def __init__(self, interval=0.25):
+        super().__init__(daemon=True)
+        self.interval = interval
+        self.stop_flag = threading.Event()
+        self.peak_kv = 0.0
+        self.peak_running = 0.0
+
+    def run(self):
+        while not self.stop_flag.is_set():
+            m = read_counters()
+            self.peak_kv = max(self.peak_kv, m.get("vllm:kv_cache_usage_perc", 0.0))
+            try:
+                with urllib.request.urlopen(f"{NIM}/metrics", timeout=10) as r:
+                    for line in r.read().decode().splitlines():
+                        if line.startswith("vllm:num_requests_running"):
+                            self.peak_running = max(
+                                self.peak_running, float(line.rsplit(" ", 1)[1])
+                            )
+            except Exception:
+                pass
+            time.sleep(self.interval)
+
+
+def run_turn(label, query, session_id, user_id=1):
+    """Run one turn and reconcile app, engine, and wall-clock views of it."""
+    before = read_counters()
+    sampler = KVSampler()
+    sampler.start()
+
+    payload = json.dumps(
+        {"user_id": user_id, "query": query, "session_id": session_id}
+    ).encode()
+    req = urllib.request.Request(
+        f"{CHAIN}/query/timing",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+
+    t0 = time.monotonic()
+    error = None
+    body = {}
+    try:
+        with urllib.request.urlopen(req, timeout=600) as r:
+            body = json.loads(r.read().decode())
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+    wall = time.monotonic() - t0
+
+    sampler.stop_flag.set()
+    sampler.join(timeout=2)
+    after = read_counters()
+
+    engine = {}
+    for name in COUNTERS:
+        if name in before and name in after:
+            engine[name.replace("vllm:", "")] = round(after[name] - before[name], 6)
+
+    timings = body.get("timings", {}) or {}
+    # chain-server sets timings["total"] from its own monotonic clock around the
+    # runtime call, so it is real wall time and safe to use, unlike the streaming
+    # endpoint's total_seconds which sums overlapping buckets.
+    app_total = timings.get("total")
+
+    prefill = engine.get("request_prefill_time_seconds_sum", 0.0)
+    decode = engine.get("request_decode_time_seconds_sum", 0.0)
+    ttft = engine.get("time_to_first_token_seconds_sum", 0.0)
+    calls = engine.get("time_to_first_token_seconds_count", 0.0)
+
+    return {
+        "label": label,
+        "query": query,
+        "session_id": session_id,
+        "error": error,
+        "wall_seconds": round(wall, 3),
+        "app_total_seconds": round(app_total, 3) if app_total is not None else None,
+        "app_timings": {k: round(v, 3) for k, v in timings.items()
+                        if isinstance(v, (int, float))},
+        "token_usage": body.get("token_usage", {}),
+        "model_usage": body.get("model_usage", {}),
+        "tool_calls": [
+            t.get("tool_name")
+            for t in (body.get("agent_diagnostics", {}) or {}).get("tool_calls", [])
+            if isinstance(t, dict)
+        ],
+        "engine": engine,
+        "engine_llm_calls": calls,
+        "engine_compute_seconds": round(prefill + decode, 3),
+        "engine_lifecycle_seconds": round(ttft + decode, 3),
+        # What no component claims. This is the number Phase 1 exists to find.
+        "non_llm_seconds": round(wall - (ttft + decode), 3),
+        "peak_kv_usage_perc": round(sampler.peak_kv * 100, 2),
+        "peak_requests_running": sampler.peak_running,
+        "response_chars": len(body.get("response", "") or ""),
+    }
+
+
+def fetch_spans(session_ids):
+    """Pull per-LLM-call and per-tool-call spans for the sessions just run."""
+    wanted = set(session_ids)
+    collected = []
+    cursor = None
+    for _ in range(40):  # bounded paging; the profiler only just created these
+        url = f"{PHOENIX}/v1/projects/default/spans?limit=200"
+        if cursor:
+            url += f"&cursor={cursor}"
+        try:
+            page = _get_json(url, timeout=20)
+        except Exception:
+            break
+        for span in page.get("data", []):
+            attrs = span.get("attributes", {}) or {}
+            sid = attrs.get("session.id") or attrs.get("session_id")
+            if sid in wanted:
+                collected.append({
+                    "session_id": sid,
+                    "name": span.get("name"),
+                    "kind": span.get("span_kind"),
+                    "parent_id": span.get("parent_id"),
+                    "span_id": (span.get("context") or {}).get("span_id"),
+                    "start": span.get("start_time"),
+                    "end": span.get("end_time"),
+                })
+        cursor = page.get("next_cursor")
+        if not cursor:
+            break
+    return collected
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="/tmp/turn_profile.json")
+    ap.add_argument("--only", default="", help="comma-separated probe labels")
+    ap.add_argument("--skip-conversation", action="store_true")
+    args = ap.parse_args()
+
+    try:
+        urllib.request.urlopen(f"{CHAIN}/ready", timeout=10).read()
+    except Exception as exc:
+        sys.exit(f"chain-server not ready at {CHAIN}: {exc}")
+
+    wanted = {s for s in args.only.split(",") if s}
+    stamp = int(time.time())
+    plan = [(lbl, q, f"prof-{stamp}-{lbl}") for lbl, q in PROBES
+            if not wanted or lbl in wanted]
+    if not args.skip_conversation and not wanted:
+        convo_session = f"prof-{stamp}-convo"
+        plan += [(lbl, q, convo_session) for lbl, q in CONVERSATION]
+
+    if not plan:
+        sys.exit("no probes selected")
+
+    print(f"profiling {len(plan)} turns against {CHAIN} / {NIM}\n")
+    hdr = f"{'probe':<18} {'wall':>7} {'engine':>7} {'non-LLM':>8} {'calls':>6} {'in tok':>8} {'peak KV':>8}"
+    print(hdr)
+    print("-" * len(hdr))
+
+    results = []
+    for label, query, session in plan:
+        row = run_turn(label, query, session)
+        results.append(row)
+        if row["error"]:
+            print(f"{label:<18} FAILED  {row['error'][:60]}")
+            continue
+        tu = row["token_usage"] or {}
+        print(f"{label:<18} {row['wall_seconds']:>6.1f}s "
+              f"{row['engine_lifecycle_seconds']:>6.1f}s "
+              f"{row['non_llm_seconds']:>7.1f}s "
+              f"{int(row['engine_llm_calls']):>6} "
+              f"{tu.get('input_tokens', 0):>8} "
+              f"{row['peak_kv_usage_perc']:>7.1f}%")
+
+    print("\nfetching spans from Phoenix...")
+    time.sleep(6)  # OTel batch export needs a moment to flush
+    spans = fetch_spans([s for _, _, s in plan])
+    print(f"  {len(spans)} spans matched")
+
+    ok = [r for r in results if not r["error"]]
+    payload = {
+        "collected_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "chain_base": CHAIN,
+        "nim_base": NIM,
+        "turns": results,
+        "spans": spans,
+    }
+    with open(args.out, "w") as fh:
+        json.dump(payload, fh, indent=2)
+
+    if ok:
+        tot_wall = sum(r["wall_seconds"] for r in ok)
+        tot_engine = sum(r["engine_lifecycle_seconds"] for r in ok)
+        print(f"\nacross {len(ok)} turns: {tot_wall:.1f}s wall, "
+              f"{tot_engine:.1f}s in the LLM "
+              f"({tot_engine / tot_wall * 100:.0f}%), "
+              f"{tot_wall - tot_engine:.1f}s elsewhere")
+    print(f"written: {args.out}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\ninterrupted")

--- a/docker-compose.scale.yaml
+++ b/docker-compose.scale.yaml
@@ -17,7 +17,7 @@
 # unchanged -- `docker compose up` still gives one chain-server on 8009, which
 # is what every script and document expects.
 #
-# Replicas get ephemeral host ports. `scripts/journey_load.py` finds them, so
+# Replicas get ephemeral host ports. `benchmarks/journey_load.py` finds them, so
 # there is nothing to configure; `docker compose port chain-server 8009 --index 2`
 # is how to find one by hand.
 #

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -180,6 +180,13 @@ Six steps. Each one answers a question the next step assumes you have answered.
 | 5 | Where does it saturate at *my* workload shape? | `benchmarks/bench.sh sweep` + `SWEEP_*` |
 | 6 | How many concurrent shoppers, end to end? | `benchmarks/shopper_study.py` |
 
+Steps 4 and 5 need two things the rest of the ladder does not: vLLM's benchmark
+CLI and a tokenizer on disk. Both are sizeable downloads and neither is a
+dependency of this repo, so fetch them before you begin — the commands are under
+step 4, and in [`benchmarks/README.md`](../benchmarks/README.md). Steps 1, 2, 3
+and 6 need nothing beyond this repo and a running deployment, which is worth
+knowing because step 6 is the one that answers the capacity question.
+
 ### Step 1 — Prove the instruments work
 
 ```bash

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,663 @@
+# Performance
+
+How to measure this application, in the order that makes each step
+interpretable, and how to read what comes back.
+
+Written for someone who has not done performance work before. It follows a
+ladder: each rung tells you something the next one needs. Skipping to the bottom
+rung — "how many users can we serve" — produces a number you cannot defend,
+because you will not know what limited it.
+
+This document deliberately contains **no measured results**. Throughput and
+latency depend on the GPU, the model profile, the catalog and the env profile in
+use, so a figure recorded here would be read as a target on hardware it never
+described. Where a number appears, it is illustrating the *shape* of an output,
+not reporting a finding. Measure your own, on the deployment you are actually
+asking about.
+
+Everything here needs the app LLM to be a **local NIM**
+([`docker-compose-nim-local.yaml`](../docker-compose-nim-local.yaml), configured
+by [`.env.local-llm.example`](../.env.local-llm.example)). A hosted endpoint
+publishes no metrics and rate-limits sustained load, so there is nothing to
+measure and no way to measure it.
+
+---
+
+## Contents
+
+- [Where things live](#where-things-live)
+- [The vocabulary](#the-vocabulary)
+- [Before you measure anything](#before-you-measure-anything)
+- [The measurement ladder](#the-measurement-ladder) — six steps, in order
+- [The scripts, one by one](#the-scripts-one-by-one)
+- [Pitfalls that produce confident, wrong numbers](#pitfalls-that-produce-confident-wrong-numbers)
+
+---
+
+## Where things live
+
+Two directories, split by what they do.
+
+| | Directory | Entry point |
+|---|---|---|
+| Collecting metrics | [`monitoring/`](../monitoring/README.md) | `./dashboard.sh up` |
+| Generating load and measuring | [`benchmarks/`](../benchmarks/README.md) | `./bench.sh` |
+
+They are separate because standing up a scraper and driving traffic through the
+system are different jobs, and conflating them made it easy to benchmark a
+deployment nobody had verified. Each entry point will redirect you if you ask it
+for the other's subcommands.
+
+```
+monitoring/                    benchmarks/
+  dashboard.sh   up/down/         bench.sh          load/sweep/top
+                 status/urls/     loadgen.py
+                 logs             saturate.py
+  docker-compose.yaml            metrics_top.py
+  prometheus.yaml                turn_profile.py
+  grafana/                       shopper_study.py
+  docker_stats_exporter.py       journey_load.py
+                                 concurrent_shoppers.py
+```
+
+---
+
+## The vocabulary
+
+**Latency** is how long one shopper waits. **Throughput** is how many you finish
+per second. They pull against each other: running 32 requests at once instead of
+4 finishes more work per second, but each request now shares the GPU, so each
+takes longer. Capacity planning is choosing a point on that curve — which means
+**a capacity number is meaningless without a latency target attached.**
+
+**Time to first token (TTFT)** is how long the shopper stares at nothing. It
+dominates perceived speed: a reply that starts in 300 ms and runs for 8 s feels
+faster than one that starts after 5 s and finishes in 6. For a streaming UI this
+is the number to size against, not total turn time.
+
+**Time per output token (TPOT)** is typing speed once words start.
+
+**Prefill vs decode** explains most of this system. A request first *reads* the
+whole prompt, all tokens in parallel, limited by compute. It then *writes* the
+answer one token at a time, consulting the whole model for each, limited by
+memory bandwidth. They saturate for different reasons and respond to different
+fixes.
+
+**Concurrency** is how many requests are in flight at once — the dial a sweep
+turns. Not the same as requests per second.
+
+**Percentiles.** p50 is typical, p95/p99 is the bad case. Always look at the
+tail; a mean hides the shopper who waited three times as long.
+
+**Prefix caching** lets the engine skip re-reading a prompt prefix it has
+already processed. It matters more here than in most applications, for a reason
+worth understanding before you measure it — see
+[step 6](#step-6--how-many-concurrent-shoppers-end-to-end).
+
+### Why the workload shape matters here
+
+A shopper turn is **heavily prefill-dominated**: it sends a very large prompt and
+gets a short reply, several times over. Every model call carries the system
+instructions, all tool definitions, the conversation so far, and any catalog
+results, while the reply is a few sentences.
+
+Published LLM benchmarks typically use a 1:1 input:output ratio. Those numbers
+will not predict this application. A workload that reads far more than it writes
+reaches its limits somewhere completely different.
+
+So do not sweep at a tool's default shape. Take the real ratio from your own
+deployment first (step 2), then feed it into the sweep (step 5). A sweep at the
+wrong shape produces confident numbers describing a workload you do not run, and
+the gap between the two is routinely a multiple, not a few percent.
+
+---
+
+## Before you measure anything
+
+Measuring the wrong thing is worse than not measuring. Every wrong conclusion in
+this area starts with a deployment that was not doing what the measurer assumed.
+Confirm all six.
+
+```bash
+# 1. The NIM is serving, at the precision you expect
+curl -s http://localhost:8000/v1/models | python3 -m json.tool
+docker logs retail-shopping-assistant-nemotron-1 2>&1 | grep -iE "Precision:|quant_algo"
+#    want: Precision: fp8   /   quant_algo=FP8
+
+# 2. The catalog is indexed -- an empty one yields confident nonsense
+curl -s http://localhost:8010/ready
+#    want: {"status":"ready","catalog_id":"fashion_products","products":<n>}
+
+# 3. The app is really using the local NIM. Count requests either side of a
+#    query and check the delta equals the reported model_calls.
+before=$(docker logs retail-shopping-assistant-nemotron-1 2>&1 | grep -c "POST /v1/chat/completions")
+curl -s -X POST http://localhost:8009/query/timing -H 'Content-Type: application/json' \
+  -d '{"user_id":1,"query":"Show me black dresses under $100","session_id":"smoke-1"}' \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['token_usage'])"
+after=$(docker logs retail-shopping-assistant-nemotron-1 2>&1 | grep -c "POST /v1/chat/completions")
+echo "local LLM calls: $((after-before))"
+
+# 4. Monitoring is scraping all three jobs, not just Prometheus itself
+cd monitoring && ./dashboard.sh status
+#    want: vllm, dcgm and containers all healthy
+```
+
+Step 3 is the one people skip, and it is the one that catches a hosted endpoint
+quietly serving your "local" benchmark.
+
+Two more checks are specific to this model, and each has silently invalidated
+whole days of measurement:
+
+```bash
+# 5. Tool calling actually works. If the parser cannot read this model's
+#    output, vLLM returns the tool call as plain text, the agent answers
+#    without ever searching, and every latency number describes a
+#    different, much cheaper application.
+curl -s http://localhost:8009/query/timing -X POST -H 'Content-Type: application/json' \
+  -d '{"user_id":1,"query":"Show me black dresses under $100","session_id":"tool-1"}' \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print('tools called:', d.get('agent_diagnostics',{}).get('tool_calls'))"
+#    want: a non-empty list including a catalog search
+
+# 6. Prefix caching resolved the way you asked. Unset does not mean default-on;
+#    vLLM disables it for hybrid attention models unless told otherwise.
+curl -s localhost:8000/metrics | grep -o 'enable_prefix_caching="[^"]*"'
+curl -s localhost:8000/metrics | grep -o 'mamba_block_size="[^"]*"'
+#    want: "True", and a small mamba_block_size, not the full context length
+```
+
+---
+
+## The measurement ladder
+
+Six steps. Each one answers a question the next step assumes you have answered.
+
+| Step | Question it answers | Command |
+|---|---|---|
+| 1 | Are my instruments telling the truth? | `monitoring/dashboard.sh up`, `benchmarks/bench.sh load` |
+| 2 | What does one turn cost, and in what shape? | `benchmarks/turn_profile.py` |
+| 3 | What moves when I add concurrency? | `benchmarks/bench.sh load` at rising levels |
+| 4 | Where does the *model* saturate, generically? | `benchmarks/bench.sh sweep` |
+| 5 | Where does it saturate at *my* workload shape? | `benchmarks/bench.sh sweep` + `SWEEP_*` |
+| 6 | How many concurrent shoppers, end to end? | `benchmarks/shopper_study.py` |
+
+### Step 1 — Prove the instruments work
+
+```bash
+cd monitoring
+./dashboard.sh up
+```
+
+This checks the NIM is healthy and exposing metrics, starts Prometheus, Grafana
+and the exporters, waits for the scrape target to come up and the dashboards to
+provision, then prints URLs.
+
+| Service | URL |
+|---|---|
+| Grafana | http://localhost:6005 |
+| Prometheus | http://localhost:9090 |
+| Phoenix (agent traces) | http://localhost:6006 |
+| Raw NIM metrics | http://localhost:8000/metrics |
+
+Grafana is on **6005** because the app's nginx owns 3000 and Phoenix owns 6006.
+Both Prometheus and Grafana bind loopback only; reach them remotely with:
+
+```bash
+ssh -N -L 6005:localhost:6005 -L 9090:localhost:9090 <user>@<host>
+```
+
+**An idle dashboard looks exactly like a broken one.** Do not conclude anything
+until you have driven traffic and seen the panels move:
+
+```bash
+cd ../benchmarks
+./bench.sh load 8 32      # 32 requests, 8 at a time
+```
+
+Then confirm every data source is being collected, not just Prometheus itself.
+`dashboard.sh status` lists all three jobs, or query it directly:
+
+```bash
+curl -s 'http://localhost:9090/api/v1/targets?state=active' \
+  | python3 -c "
+import json,sys
+for t in json.load(sys.stdin)['data']['activeTargets']:
+    print(t['labels'].get('job'), t['health'], t.get('lastError',''))"
+#    want: vllm up, dcgm up, containers up
+```
+
+If a job is `down`, fix it now. A missing exporter does not announce itself
+later; it shows up as a panel reading zero, which is indistinguishable from a
+real zero.
+
+### Step 2 — Profile one turn, and learn your workload shape
+
+```bash
+python3 benchmarks/turn_profile.py --out /tmp/profile.json
+```
+
+This is the highest-value single measurement in the ladder, because it produces
+the numbers steps 4 and 5 need as inputs. **Do it before any sweep.**
+
+It measures the same turn from three vantage points and reconciles them, because
+no single one is sufficient. The app's `/query/timing` gives per-phase timings
+and which model roles were called; the NIM's counters give the true
+prefill/decode/queue split; Phoenix spans give per-LLM-call and per-tool-call
+granularity. The app cannot see inside the model, the model cannot see
+retrieval, and reconciling all three is what makes the unattributed remainder
+visible.
+
+What to take away from it:
+
+- **Input and output tokens per call.** Divide per-turn totals by `model_calls`.
+  These become `SWEEP_INPUT_LEN` and `SWEEP_OUTPUT_LEN` in step 5.
+- **How many model calls a turn makes.** Likely more than you expect, and each
+  one re-sends the shared prompt.
+- **How much of the prompt never changes** — system instructions plus tool
+  schemas. That is your `SWEEP_PREFIX_LEN`, and it predicts what prefix caching
+  can win.
+- **Where non-model time goes** — catalog search, memory, guardrails.
+
+Two cautions. Set `EXPOSE_AGENT_DIAGNOSTICS=true` first or the tool-call
+breakdown comes back empty. And the streaming endpoint's `total_seconds` is the
+**sum of overlapping buckets** (`deepagents` already contains `catalog_search`
+and the safety checks), so it over-counts and is not wall clock;
+`/query/timing` reports a true wall-clock `timings.total`.
+
+### Step 3 — Add concurrency and watch what moves
+
+```bash
+cd benchmarks
+./bench.sh load 1 20
+./bench.sh load 4 40
+./bench.sh load 16 80
+./bench.sh load 64 160
+```
+
+You are not after a number here, you are building intuition about which panels
+respond to load and which do not. Watch, in Grafana or via `./bench.sh top`:
+
+- **running vs waiting** requests — the scheduler's own view
+- **KV cache usage** — does it climb linearly with concurrency?
+- **preemptions** — should be zero; any non-zero means eviction and recompute
+- **GPU utilisation** — note how early it saturates, and distrust it after that
+
+The lesson this step teaches is that GPU utilisation is nearly useless as a
+capacity signal. It reports that at least one SM had work scheduled during the
+sampling window, not that the GPU delivered anything near peak, so it can read
+high while the machine still has several times more work to give.
+
+### Step 4 — Find the model's saturation point, generically
+
+```bash
+./bench.sh sweep 1,2,4,8,16,32,64
+```
+
+Load comes from vLLM's own benchmark, so throughput and latency are the figures
+vLLM's maintainers publish rather than a homegrown approximation. While each
+level runs, the script separately polls `/metrics` twice a second to capture what
+the benchmark cannot see from outside: peak queue depth, peak KV usage, and
+whether the scheduler had to **preempt**.
+
+It calls saturation on four signals in order of severity — preemption, then
+queueing, then KV pressure above 90%, then a throughput plateau. They are
+distinguished because the fixes differ completely: queueing can mean a scheduler
+setting is too low, a one-line change, while preemption means you genuinely ran
+out of memory. Reporting "saturated" without saying *why* leads to buying
+hardware when a config edit would have done.
+
+The sweep needs two things nothing else here does. `./bench.sh sweep` explains
+both if they are missing:
+
+```bash
+# vLLM's benchmark CLI (large download)
+python3 -m venv ~/vllm-bench && ~/vllm-bench/bin/pip install vllm==0.17.1
+VLLM_BIN=~/vllm-bench/bin ./bench.sh sweep
+
+# a tokenizer -- the benchmark counts tokens locally (a few MB, not the weights)
+hf download <your-model-repo> \
+  --include 'tokenizer*' 'config.json' --local-dir ~/model-tokenizer
+TOKENIZER=~/model-tokenizer ./bench.sh sweep
+```
+
+**Reading a sweep table.** The columns, with illustrative values to show the
+format rather than to report a result:
+
+```
+ conc  reqs  out tok/s  tot tok/s   req/s  TTFT p99  TPOT p99  peak run  peak wait  peak KV  preempt
+    8    24      200.0    16000.0    1.75     3200m     34.0m         8          5     4.0%        0
+```
+
+At concurrency 8: 24 requests completed, 200 output tokens/sec (16,000 including
+prompt processing), 1.75 req/sec, 99% of requests began replying within
+3,200 ms, tokens then arrived every 34 ms, 8 running at peak, **5 waiting in a
+queue**, cache peaked 4% full, nothing evicted.
+
+Scan the **peak wait** and **preempt** columns. While both are zero you have
+headroom. The first level where `peak wait` leaves zero is where requests start
+waiting for a slot rather than for the model.
+
+**Read total tok/s, not output tok/s, for this workload.** Output looks feeble
+because each call writes a couple of hundred tokens while reading many
+thousands. Judging a prefill-heavy workload by output rate badly understates the
+machine.
+
+### Step 5 — Sweep again at your own workload shape
+
+Step 4's defaults are a generic benchmark shape. Now use what step 2 measured:
+
+```bash
+SWEEP_INPUT_LEN=<your per-call input tokens> \
+SWEEP_OUTPUT_LEN=<your per-call output tokens> \
+SWEEP_PREFIX_LEN=<the shared, unchanging part of the prompt> \
+  ./bench.sh sweep 1,8,32,64,128
+```
+
+`bench.sh` warns if you sweep without these, because the default shape answers a
+different question.
+
+`SWEEP_PREFIX_LEN` passes `--random-prefix-len` to the benchmark, giving every
+generated prompt the same fixed prefix. Without it the benchmark sends
+independent random prompts, which share nothing, so **prefix caching cannot
+engage and the sweep measures substantially more prefill work than your
+application actually does.**
+
+Expect this step to disagree sharply with step 4. That disagreement is the single
+most important reason not to size a deployment from published benchmarks.
+
+**A warning about what this step cannot tell you.** Even with a shared prefix,
+this is a *closed-loop* benchmark: it launches a synchronised burst and holds
+concurrency fixed. Real shoppers arrive independently. A synchronised burst can
+make every request miss the cache simultaneously, so the sweep may fail to
+measure caching at all at the concurrencies you care about. Treat step 5's
+throughput as a **floor**, and get your caching answer from step 6.
+
+### Step 6 — How many concurrent shoppers, end to end
+
+```bash
+# the model's ceiling: nobody pauses, everybody starts together
+python3 benchmarks/shopper_study.py --levels 1,2,4,8,16,32 --think 0
+
+# the honest caching number: different conversations, not N copies of one
+python3 benchmarks/shopper_study.py --mixed --text-only --levels 4,8,16,32
+
+# closer to real people: they read, and they do not arrive in step
+python3 benchmarks/shopper_study.py --levels 8,16,32 --think 20 --stagger 30
+```
+
+This drives whole journeys through the real application — agent, tools,
+retrieval, cart — and reports **TTFT as the headline latency**, because that is
+what a shopper waits for.
+
+It fixes the *work* rather than the time: N shoppers each play one complete
+journey and the level ends when the last finishes, so every level does exactly
+N × (turns per journey) and the levels are directly comparable. This is the
+difference from [`journey_load.py`](../benchmarks/journey_load.py), which holds
+each level for a fixed duration.
+
+Read the output like this:
+
+- **Find where p95 TTFT crosses your target.** That crossing, not any maximum,
+  is your capacity number. State the target alongside it, always.
+- **Check `cache%`.** This is where you learn what prefix caching is really
+  worth, because unlike step 5 the arrivals are realistic.
+- **Check `app cores`.** If the application tier is cheap, scaling it is wasted
+  money. If it is not, you have found a different problem.
+- **Any level marked `<-- DISCARD` is not a measurement.** See below.
+
+**Interpreting the cache hit rate.** Two different things can produce one, and
+they have opposite consequences for capacity planning. *Lateral* reuse is
+shoppers sharing text with each other; if that is what you are seeing, capacity
+depends on your users resembling one another. *Longitudinal* reuse is a single
+conversation reusing its own earlier work — a turn makes several model calls that
+each re-send the system prompt, tool schemas and history, and turn N+1's prompt
+contains turn N's prompt as a prefix. To tell them apart, run at **concurrency
+1**, where lateral sharing is physically impossible, and compare. Predict the
+longitudinal share ahead of time by dividing the unchanging boilerplate from
+step 2 by the per-call input length.
+
+**Why `--text-only` exists.** Some journeys attach an image or video. Without an
+image embedding service deployed, those turns exercise a fallback path, so
+including them measures the fallback rather than the product. The flag skips them
+and says which.
+
+**Why the liveness checks exist.** This is the most important thing in this
+document. When a model call fails, the application returns canned text — "I
+could not complete that shopping request." That text *streams like any other
+reply*: it has a first-token time and raises no exception. A harness measuring
+latency and counting exceptions cannot tell it from a real answer, and will
+cheerfully report a full sweep of completed turns with zero errors against a
+model that answered none of them.
+
+`shopper_study.py` therefore applies three independent checks per level — probe
+the model server directly before and after, confirm `vllm:prompt_tokens_total`
+advanced, and match the application's failure strings in the replies — and
+aborts the sweep rather than climbing into levels that would produce the same
+confident nonsense. Any harness you point at this stack needs the equivalent.
+
+The tells to recognise in your own data, if you ever suspect it:
+
+- A cache hit rate of **exactly** zero, which is what a missing metric looks like
+  rather than a real effect.
+- Latencies **clustered on a constant** across different load levels. Real
+  latency does not do that; a timeout does.
+- Throughput **rising** at the highest level while latency stays flat, which no
+  saturated system does.
+
+---
+
+## The scripts, one by one
+
+### `monitoring/dashboard.sh`
+
+Manages the observability stack: `up`, `down`, `status`, `urls`, `logs`. Checks
+the NIM is healthy and exposing `vllm:` series *before* standing up a scraper,
+then waits for the target to go healthy and the dashboards to provision rather
+than returning optimistically. `status` lists all three scrape jobs, because a
+missing exporter shows up as a panel reading zero rather than as an error.
+
+### `monitoring/docker_stats_exporter.py`
+
+Exports per-container CPU and memory in Prometheus format, reading the Docker
+Engine API over its socket.
+
+This exists because cAdvisor, the usual choice, could not resolve container
+metadata on a host using the `overlayfs` storage driver — it reported container
+IDs instead of service names across three versions. Without per-container
+figures, a run limited by Milvus, the chain server or the retriever is
+indistinguishable from one limited by the GPUs, and those call for opposite
+responses. It needs no privileged container and mounts nothing but the socket.
+
+### `benchmarks/bench.sh`
+
+Entry point for the three subcommands that need environment plumbing —
+resolving the served model name, locating the `vllm` CLI, finding a tokenizer on
+disk.
+
+| Command | What it does | Needs |
+|---|---|---|
+| `load [conc] [n]` | Drive concurrent traffic at the NIM directly | — |
+| `sweep [levels]` | Concurrency sweep to find saturation | `vllm` CLI + tokenizer |
+| `top [secs]` | Live metrics in the terminal, no browser | — |
+
+Run `top` in a real terminal, not inside a tool session — it is a full-screen
+TUI and will wedge a non-interactive shell.
+
+### `benchmarks/loadgen.py`
+
+Concurrent request generator against the NIM's OpenAI-compatible endpoint.
+Standard library only, so it runs anywhere. Discovers the served model name from
+`/v1/models` rather than hardcoding it, which matters because the name differs
+between a hand-built vLLM server and a NIM, and a stale name yields HTTP 404 for
+every request. Behind `bench.sh load`.
+
+### `benchmarks/saturate.py`
+
+The sweep. Wraps `vllm bench serve` for load generation while polling `/metrics`
+twice a second for what the benchmark cannot see from outside — queue depth, KV
+usage, preemptions. Resolves the served model name and passes it explicitly, and
+honours `SWEEP_INPUT_LEN`, `SWEEP_OUTPUT_LEN` and `SWEEP_PREFIX_LEN`. Writes
+results named by shape as well as concurrency, so runs at different shapes do not
+overwrite each other. Behind `bench.sh sweep`.
+
+### `benchmarks/metrics_top.py`
+
+Terminal dashboard for the NIM's metrics, for when you have no browser or no port
+forward. Behind `bench.sh top`.
+
+### `benchmarks/turn_profile.py`
+
+Per-turn latency budget through the whole app, reconciling app timings, engine
+counters and Phoenix spans. Step 2's tool, and the one that produces the token
+shape every later step depends on. **Set `EXPOSE_AGENT_DIAGNOSTICS=true` first**
+or the tool-call breakdown — most of the value — comes back empty. The script
+warns when it does.
+
+### `benchmarks/shopper_study.py`
+
+The capacity harness. Step 6's tool. Fixed work per level, TTFT headline,
+optional think time and staggered arrivals, `--mixed` for independent
+conversations, `--text-only` to skip media journeys, and the three liveness
+checks described above. Captures GPU, KV, cache hit rate and per-container CPU
+from Prometheus for each level, and writes a JSON file per run.
+
+```
+usage: shopper_study.py [--levels 1,2,4] [--journey J01] [--mixed]
+                        [--think N] [--stagger N] [--text-only]
+                        [--settle N] [--out PATH]
+```
+
+### `benchmarks/journey_load.py`
+
+Drives real journeys at rising concurrency for a **fixed duration** per level,
+and names the limiting factor it hit. Useful for a quick "what breaks first"
+answer. Prefer `shopper_study.py` when you need levels to be comparable to each
+other, since fixed-duration levels finish different amounts of work.
+
+### `benchmarks/concurrent_shoppers.py`
+
+A narrower question: do concurrent shoppers queue behind each other end to end?
+Good for catching application-level serialisation that a model-level sweep cannot
+see.
+
+### `tests/evaluation/src/replay.py`
+
+The **correctness** harness, which also records a stopwatch and TTFT.
+
+```bash
+python -m tests.evaluation.src.replay --label perf-check     # all, sequentially
+python -m tests.evaluation.src.replay --only J01,J13 --label spot
+```
+
+Use it to confirm behaviour stayed correct and turns stayed roughly as quick. Do
+**not** use it to find a capacity ceiling: concurrency is capped, and every turn
+runs different content, so a slow turn may simply have been a harder one. It
+saves full transcripts under `tests/evaluation/results/val/<label>/`, which is
+the fastest way to see whether the assistant is actually answering or quietly
+apologising.
+
+Note the evaluation harness uses a hosted model as its judge, so journey runs are
+exposed to the per-IP rate limit described below, independently of where the app
+LLM runs.
+
+---
+
+## Pitfalls that produce confident, wrong numbers
+
+Every one of these has invalidated real measurements on this stack.
+
+**A dead model looks like a fast one.** Covered in step 6, and the single most
+expensive mistake available here.
+
+**The tool-call parser silently dropping calls.** `pythonic` cannot read this
+model's XML-form tool calls, so vLLM returns them as plain assistant text with no
+`tool_calls` and the agent answers without ever searching. Every latency number
+measured in that state describes a much cheaper application that never used its
+tools. Check `agent_diagnostics.tool_calls` is non-empty before believing
+anything. Use `qwen3_coder`.
+
+**Sampling slower than the thing you measure.** `dcgm-exporter` defaults to a
+30-second collection interval, longer than many runs and far longer than a
+prefill burst, so the same stale idle sample is scraped repeatedly and
+utilisation reads zero through work that plainly happened. It is set to 1 second
+in `monitoring/docker-compose.yaml`.
+
+**Benchmarks that replay themselves.** `vllm bench serve` defaults to `--seed 0`,
+so every level generates byte-identical prompts. Those exact repeats produce
+prefix cache hits that have nothing to do with the prefix under test, which is
+enough to invalidate an entire prefix-caching experiment.
+
+**Closed-loop load is not how users arrive.** A fixed-concurrency burst can make
+every request miss the cache simultaneously. A load generator can be wrong not
+only about the size of the work but about its *arrival pattern*, and the second
+is much easier to miss.
+
+**Gauges read zero at idle.** `vllm:kv_cache_usage_perc` is a gauge and means
+nothing unless sampled during load. The sweep polls it twice a second for that
+reason.
+
+**Panel windows hide bursts.** A 5-minute average includes the idle time either
+side of a burst, so a short burst at a high rate can display as a small fraction
+of it. Both figures are correct; check what window a panel averages before
+comparing it to anything.
+
+**Env profiles blend rather than switch.** Every `.env.*` profile is a sourced
+shell file using `${VAR:-default}`, so an already-exported value wins over the
+file's default. Sourcing two profiles in one shell silently mixes them, with
+whichever came first winning on overlapping names. Two that bite:
+`CATALOG_IMAGE_EMBEDDING_ENABLED` leaking in as `true` changes indexing time and
+per-turn latency, so runs you meant to compare are not comparable; and
+`TEXT_EMBED_BASE_URL` unset falls back to `integrate.api.nvidia.com`, which fails
+with `401` on every batch if your key is scoped elsewhere. Deploy from a clean
+shell:
+
+```bash
+env -i HOME="$HOME" PATH="$PATH" bash -c 'set -a; . ./.env.local-llm; set +a; docker compose up -d'
+```
+
+**Hosted endpoints rate-limit by IP.** Even with the LLM local, catalog search
+embeds every query through a hosted endpoint (`TEXT_EMBED_BASE_URL`), and
+guardrails add more hosted calls per turn when enabled. Sustained concurrency
+trips a per-IP limit and returns HTTP 429, which surfaces as mass application
+failure rather than as a rate limit. If load testing suddenly fails everywhere,
+suspect that before your code.
+
+**One remote hop stays on the critical path.** The same hosted embedding call
+means a fully local deployment would be faster than what you measure here, so
+your figures are a floor rather than a best case. `docker-compose-nim-local.yaml`
+defines local NIMs for the embedding and safety models, but a 2-GPU box running a
+120B model has no room left for them; everything local needs more GPUs.
+
+**The model profile can change under you.** Left unset, the NIM selects a profile
+by reading *free* GPU memory at startup, and this image also offers a BF16 profile
+it considers runnable — so precision, and therefore every performance number, can
+vary run to run depending on what happened to be resident. Pin it for the
+duration of any measurement you intend to compare:
+
+```bash
+# `list-model-profiles` in the image shows the available set
+NIM_MODEL_PROFILE=<id> docker compose -f docker-compose-nim-local.yaml up -d nemotron
+```
+
+**A deployment can wedge without anything noticing.** Under sustained concurrency
+the NIM can stop dispatching while the container stays up, the process tree stays
+intact and the weights stay resident — every endpoint including `/health` timing
+out, with no crash, no OOM and no restart. The image ships **no `HEALTHCHECK`**,
+so `docker inspect` reports `current health: not tracked`. If you run this under
+load, add a healthcheck against `/health` and a restart policy, or a wedged
+server will quietly absorb an entire test run.
+
+**An empty dashboard has two causes that look identical.** Either no traffic
+(counters are cumulative, panels show rates, idle reads zero) or the `model_name`
+filter points at a model that no longer produces data — which happens whenever
+you switch between a hand-built vLLM server and a NIM. Check the dropdown before
+debugging anything else.
+
+---
+
+## Related documentation
+
+- [`benchmarks/README.md`](../benchmarks/README.md) — a map of the measurement tools
+- [`monitoring/README.md`](../monitoring/README.md) — the observability stack itself
+- [`docs/OBSERVABILITY.md`](OBSERVABILITY.md) — OpenTelemetry and Phoenix span model
+- [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) — deploying the stack, health checks
+- [`docs/API.md`](API.md) — the `metrics` stream event, `/query/timing`, token and model usage fields

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 - **[Catalog Schema and Filters](CATALOG_FILTERS.md)** - Declaring JSONL field roles without static catalog values
 - **[Catalog Architecture](CATALOG_REFACTOR_PLAN.md)** - Start here for JSONL ingestion, advertised capabilities, agent discovery, and validated retrieval
 - **[Commerce Contracts](COMMERCE_CONTRACTS.md)** - Internal product, cart, and commerce tool contracts
-- **[Observability](OBSERVABILITY.md)** - Study a shopper's session, and dig into why a turn did what it did
+  - **[Observability](OBSERVABILITY.md)** - Study a shopper's session, and dig into why a turn did what it did
+  - **[Performance](PERFORMANCE.md)** - Measure where a turn spends its time, find the saturation point, and size a deployment
 - **[Shopper Agent Architecture](SHOPPER_AGENT_ARCHITECTURE.md)** - Published catalog, turn flow, skill-to-tool mapping, and memory boundaries
 - **[Shopper Agent Leadership Note](SHOPPER_AGENT_LEADERSHIP_NOTE.md)** - Executive request flow, memory ownership, worked example, and prioritized next steps
 - **[Shopper Agent Tool Registry](SHOPPER_AGENT_TOOL_REGISTRY.md)** - Registered Deep Agents tools for the shopper-serving agent
@@ -48,6 +49,7 @@ Welcome to the Retail Shopping Assistant documentation! This hub provides compre
 | [Catalog Architecture](CATALOG_REFACTOR_PLAN.md) | Understand the end-to-end ingest, capability advertisement, agent discovery, and validated retrieval flow | Developers, architects |
 | [Commerce Contracts](COMMERCE_CONTRACTS.md) | Internal product, cart, and commerce tool contracts | Developers, architects |
 | [Observability](OBSERVABILITY.md) | Read a conversation turn by turn, open one turn's trace, and find what the model was told | Developers, operators, evaluators |
+| [Performance](PERFORMANCE.md) | Measure the latency budget of a turn, sweep the LLM to saturation, and size concurrent shoppers on given hardware | Developers, operators, architects |
 | [Shopper Agent Architecture](SHOPPER_AGENT_ARCHITECTURE.md) | Understand the published catalog, turn flow, skill-to-tool mapping, and memory boundaries | Developers, architects |
 | [Shopper Agent Leadership Note](SHOPPER_AGENT_LEADERSHIP_NOTE.md) | Understand the executive flow, state ownership, worked example, and next architecture priorities | Senior leaders, architects, product owners |
 | [Shopper Agent Tool Registry](SHOPPER_AGENT_TOOL_REGISTRY.md) | Registered Deep Agents tools, risk classes, and skill access boundaries for the shopper-serving agent | Developers, architects, evaluators |

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,105 @@
+# Monitoring
+
+Prometheus + Grafana for the local LLM NIM, plus a per-container resource
+exporter. This directory is the **observability stack** only — the tools that
+generate load and take measurements live in
+[`benchmarks/`](../benchmarks/README.md).
+
+See [`docs/PERFORMANCE.md`](../docs/PERFORMANCE.md) for how to measure this
+application and how to read what comes back. This file covers only how the
+pieces here fit together.
+
+## Prerequisites
+
+The app must be running with a **local NIM**
+(`docker-compose-nim-local.yaml`), since these tools read metrics that a NIM
+exposes and a hosted endpoint does not.
+
+## Usage
+
+```bash
+./dashboard.sh up        # start the stack, wait for a healthy scrape, print URLs
+./dashboard.sh status    # containers, scrape target health, live metric sample
+./dashboard.sh urls      # URLs plus the SSH tunnel command for remote access
+./dashboard.sh logs      # follow Prometheus and Grafana logs
+./dashboard.sh down      # stop (add --volumes to discard history)
+```
+
+Needs nothing beyond Python 3 and Docker.
+
+To put traffic through the system so the panels have something to show, see
+[`benchmarks/`](../benchmarks/README.md) — `bench.sh load` is the quickest.
+
+## How it is wired
+
+Both containers join the app's `shopping-network` as an external network rather
+than using host networking. That lets Prometheus scrape the NIM by service name
+at `nemotron:8000` with no host ports involved, and avoids the port collisions
+host networking caused (the app's nginx owns 3000, Phoenix owns 6006).
+
+Host bindings are loopback-only, and Grafana defaults to **6005** to stay clear
+of both:
+
+| | Port | Override |
+|---|---|---|
+| Grafana | 6005 | `GRAFANA_PORT` |
+| Prometheus | 9090 | — |
+
+Grafana provisions its datasource and dashboards from `grafana/provisioning/`,
+so there is nothing to configure by hand and no state worth preserving;
+deleting the volumes loses only Prometheus history.
+
+## What gets scraped
+
+| Job | Source | Why it is separate |
+|---|---|---|
+| `vllm` | the NIM's `/metrics` | engine counters: tokens, queue depth, KV usage, preemptions |
+| `dcgm` | `dcgm-exporter` | GPU utilisation, memory, temperature, power |
+| `containers` | `docker_stats_exporter.py` | per-container CPU and memory |
+
+The third exists because a run limited by Milvus, the chain server or the
+retriever is otherwise indistinguishable from one limited by the GPUs, and
+those call for opposite responses.
+
+`dcgm-exporter` is pinned to a **1-second** collection interval. Its 30-second
+default is longer than many benchmark runs and far longer than a prefill burst,
+so the same stale idle sample gets scraped repeatedly and utilisation reads zero
+through work that plainly happened.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `dashboard.sh` | Entry point for the stack: `up`, `down`, `status`, `urls`, `logs` |
+| `docker-compose.yaml` | Prometheus, Grafana and the exporters, joined to `shopping-network` |
+| `prometheus.yaml` | Scrape config for the three jobs above |
+| `grafana/dashboards/vllm-official.json` | vLLM's published dashboard, extended with CPU, GPU and prefix-cache panels |
+| `grafana/provisioning/` | Datasource and dashboard auto-provisioning |
+| `docker_stats_exporter.py` | Per-container CPU and memory, read from the Docker Engine API |
+
+### Why a custom exporter rather than cAdvisor
+
+cAdvisor is the usual choice and was tried first. On a host using the
+`overlayfs` storage driver it could not resolve container metadata, reporting
+container IDs instead of service names across three versions — which makes the
+per-container series unusable for attributing a bottleneck to a service.
+`docker_stats_exporter.py` reads the Engine API directly, needs no privileged
+container, and mounts nothing but the socket.
+
+## Gotchas
+
+**An idle dashboard is indistinguishable from a broken one.** Panels show rates
+over cumulative counters, so with no traffic everything reads zero. Put some
+load through it before concluding anything is wrong.
+
+**The dashboard filters on `model_name`.** Serve a different model and the saved
+filter can point at a name that produces no data, leaving every panel silently
+blank. Check the dropdown at the top.
+
+**`vllm:kv_cache_usage_perc` is a gauge, not a counter.** It reads 0 at idle and
+is only meaningful when sampled during load, which is why the sweep in
+`benchmarks/` polls it twice a second rather than reading it afterwards.
+
+**A missing exporter looks like a real zero.** If a job is `down`, the panels it
+feeds draw nothing rather than erroring. Check `./dashboard.sh status` lists all
+three targets as healthy before trusting a measurement.

--- a/monitoring/dashboard.sh
+++ b/monitoring/dashboard.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# The observability stack for the locally deployed LLM NIM.
+#
+# Only meaningful when the app LLM is a local NIM (docker-compose-nim-local.yaml).
+# A hosted endpoint publishes no metrics, so there would be nothing to scrape.
+#
+# Stack is Prometheus + Grafana running vLLM's official dashboard, adapted from
+#   https://github.com/vllm-project/vllm/blob/v0.17.1/examples/online_serving/prometheus_grafana/
+#
+# This script manages the stack. To generate load or take measurements, see
+# ../benchmarks/bench.sh -- kept separate because standing up a scraper and
+# driving traffic through the system are different jobs, and conflating them
+# made it easy to benchmark a deployment nobody had verified.
+#
+# Usage: ./dashboard.sh {up|down|status|urls|logs}
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The NIM as seen from this host. Prometheus itself reaches it as nemotron:8000
+# over the compose network; these are only for this script's health checks.
+VLLM_HOST="${VLLM_HOST:-127.0.0.1}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+PROM_PORT="${PROM_PORT:-9090}"
+# 3000 is deliberately avoided: the app's nginx front end claims it, and 6006 is
+# Phoenix.
+GRAFANA_PORT="${GRAFANA_PORT:-6005}"
+PY="${PYTHON:-python3}"
+
+# docker-compose.yaml reads GRAFANA_PORT too, so both sides stay in agreement
+# whether the port is overridden or left at the default.
+export GRAFANA_PORT
+
+RED=$'\033[31m'; GRN=$'\033[32m'; YLW=$'\033[33m'; BLU=$'\033[34m'
+BOLD=$'\033[1m'; RST=$'\033[0m'
+log()  { printf '%s[%s]%s %s\n' "$BLU" "$(date +%H:%M:%S)" "$RST" "$*"; }
+ok()   { printf '%s  ok%s %s\n' "$GRN" "$RST" "$*"; }
+warn() { printf '%s warn%s %s\n' "$YLW" "$RST" "$*"; }
+die()  { printf '%sfail%s %s\n' "$RED" "$RST" "$*" >&2; exit 1; }
+
+compose() { docker compose -f "$HERE/docker-compose.yaml" "$@"; }
+
+stage_up() {
+  curl -sf --max-time 5 "http://$VLLM_HOST:$VLLM_PORT/health" >/dev/null \
+    || die "vLLM is not responding on $VLLM_HOST:$VLLM_PORT - start it first"
+  ok "vLLM endpoint healthy"
+
+  # Confirm the server actually exposes /metrics before standing up a scraper.
+  curl -sf --max-time 5 "http://$VLLM_HOST:$VLLM_PORT/metrics" \
+    | grep -q '^vllm:' || die "/metrics is not exposing vllm: series"
+  ok "/metrics exposes vllm: series"
+
+  log "Starting Prometheus + Grafana"
+  compose up -d
+
+  log "Waiting for Prometheus to report the vllm target as up"
+  local waited=0 state=""
+  while (( waited < 120 )); do
+    state=$(curl -sf --max-time 3 \
+      "http://127.0.0.1:$PROM_PORT/api/v1/targets?state=active" 2>/dev/null \
+      | "$PY" -c '
+import json, sys
+try:
+    t = json.load(sys.stdin)["data"]["activeTargets"]
+except Exception:
+    sys.exit()
+for x in t:
+    if x["labels"].get("job") == "vllm":
+        print(x["health"]); break
+' 2>/dev/null || true)
+    [[ "$state" == "up" ]] && break
+    sleep 3; waited=$((waited + 3))
+  done
+  [[ "$state" == "up" ]] \
+    && ok "Prometheus is scraping vllm (target healthy after ${waited}s)" \
+    || warn "target state is '${state:-unknown}' after ${waited}s - check '$0 logs'"
+
+  log "Waiting for Grafana to provision the dashboard"
+  waited=0
+  local uid=""
+  while (( waited < 120 )); do
+    uid=$(curl -sf --max-time 3 \
+      "http://127.0.0.1:$GRAFANA_PORT/api/search?query=vLLM&type=dash-db" 2>/dev/null \
+      | "$PY" -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit()
+if d: print(d[0]["uid"])
+' 2>/dev/null || true)
+    [[ -n "$uid" ]] && break
+    sleep 3; waited=$((waited + 3))
+  done
+  [[ -n "$uid" ]] \
+    && ok "dashboard provisioned (uid $uid)" \
+    || warn "dashboard not visible yet - check '$0 logs'"
+
+  printf '\n'
+  stage_urls
+
+  # An idle dashboard looks exactly like a broken one, so say so here rather
+  # than letting someone conclude the stack is broken when it is merely bored.
+  printf '\n%sNo traffic yet, so every panel reads zero.%s Drive some:\n' "$BOLD" "$RST"
+  printf '  ../benchmarks/bench.sh load 8 32\n'
+}
+
+stage_down() {
+  log "Stopping monitoring stack"
+  compose down
+  ok "stopped (metric history is kept in the docker volumes)"
+}
+
+stage_urls() {
+  local dash
+  dash=$(curl -sf --max-time 3 \
+    "http://127.0.0.1:$GRAFANA_PORT/api/search?query=vLLM&type=dash-db" 2>/dev/null \
+    | "$PY" -c 'import json,sys
+d=json.load(sys.stdin)
+print(d[0]["url"] if d else "")' 2>/dev/null || true)
+
+  printf '%sDashboard%s\n' "$BOLD" "$RST"
+  printf '  Grafana     http://localhost:%s%s\n' "$GRAFANA_PORT" "${dash:-}"
+  printf '  Prometheus  http://localhost:%s\n' "$PROM_PORT"
+  printf '  raw metrics http://%s:%s/metrics\n' "$VLLM_HOST" "$VLLM_PORT"
+  printf '\n%sBoth are bound to loopback. To reach them from your laptop:%s\n' "$BOLD" "$RST"
+  printf '  ssh -N -L %s:localhost:%s -L %s:localhost:%s %s@<this-host>\n' \
+    "$GRAFANA_PORT" "$GRAFANA_PORT" "$PROM_PORT" "$PROM_PORT" "$(whoami)"
+  printf '  then open http://localhost:%s\n' "$GRAFANA_PORT"
+}
+
+stage_status() {
+  compose ps
+  printf '\n'
+  if curl -sf --max-time 3 "http://127.0.0.1:$PROM_PORT/-/healthy" >/dev/null 2>&1; then
+    ok "Prometheus healthy"
+    # All three targets are listed, not just vllm. A missing exporter does not
+    # error later -- it shows up as a panel reading zero, which is
+    # indistinguishable from a real zero, so it has to be caught here.
+    curl -sf "http://127.0.0.1:$PROM_PORT/api/v1/targets?state=active" \
+      | "$PY" -c '
+import json, sys
+for t in json.load(sys.stdin)["data"]["activeTargets"]:
+    print(f"     target {t[\"labels\"].get(\"job\")}: {t[\"health\"]}"
+          f"  last scrape {t.get(\"lastScrape\",\"?\")[:19]}")
+    if t.get("lastError"): print("       error:", t["lastError"])
+' 2>/dev/null || true
+  else
+    warn "Prometheus not responding on $PROM_PORT"
+  fi
+  curl -sf --max-time 3 "http://127.0.0.1:$GRAFANA_PORT/api/health" >/dev/null 2>&1 \
+    && ok "Grafana healthy" || warn "Grafana not responding on $GRAFANA_PORT"
+}
+
+stage_logs() { compose logs --tail "${1:-40}"; }
+
+case "${1:-up}" in
+  up)     stage_up ;;
+  down)   stage_down ;;
+  status) stage_status ;;
+  urls)   stage_urls ;;
+  logs)   shift || true; stage_logs "$@" ;;
+  top|load|sweep)
+    die "'$1' moved to ../benchmarks/bench.sh
+
+  This script manages the monitoring stack. Load generation and measurement
+  live next door:
+    ../benchmarks/bench.sh $1 ${2:-}" ;;
+  *)      die "usage: $0 {up|down|status|urls|logs}
+
+  up             start Prometheus + Grafana + exporters, wait until scraping
+  down           stop the stack (history preserved in volumes)
+  status         container, target and scrape health for all three jobs
+  urls           dashboard URLs and the SSH tunnel command
+  logs [n]       container logs
+
+  To generate load or take measurements, see ../benchmarks/bench.sh" ;;
+esac

--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -1,0 +1,118 @@
+# Prometheus + Grafana for a locally deployed LLM NIM.
+#
+# Only useful when the app is served by a local NIM (docker-compose-nim-local.yaml).
+# A hosted endpoint exposes no metrics to scrape, so there is nothing to show.
+#
+# Dashboard is vLLM's official one, adapted from
+#   https://github.com/vllm-project/vllm/blob/v0.17.1/examples/online_serving/prometheus_grafana/
+#
+# Two things differ from that upstream example:
+#
+#  1. Both services join the application's existing compose network rather than
+#     using host networking, so Prometheus reaches the NIM as `nemotron:8000` by
+#     service name. That keeps this portable: nothing depends on which host port
+#     the NIM happens to publish, or on the NIM publishing one at all.
+#
+#  2. The datasource and dashboard are provisioned from files, so the stack comes
+#     up with panels already working instead of needing a manual import.
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: nim-prometheus
+    restart: unless-stopped
+    ports:
+      # Loopback only. These are unauthenticated and should not be reachable
+      # from the network; use an SSH tunnel to view them remotely.
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      # Enough history for a tuning session without growing the volume much.
+      - '--storage.tsdb.retention.time=15d'
+    networks:
+      - shopping-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: nim-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    ports:
+      # 6005 rather than Grafana's usual 3000: the app's nginx front end owns
+      # 3000 and Phoenix owns 6006. Override with GRAFANA_PORT.
+      - "127.0.0.1:${GRAFANA_PORT:-6005}:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    environment:
+      # Local-only dashboard on a developer box: skipping the login wall makes it
+      # usable over a tunnel without credential juggling. Remove these three
+      # lines before exposing Grafana anywhere beyond localhost.
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_USERS_DEFAULT_THEME=dark
+    networks:
+      - shopping-network
+
+  # Per-container CPU and memory. Without it, a run limited by Milvus, the
+  # chain server or the retriever is indistinguishable from one limited by the
+  # GPUs -- and those call for opposite responses.
+  #
+  # cAdvisor is the usual choice and does not work on this host; see the header
+  # of docker_stats_exporter.py. This reads the same figures straight from the
+  # Docker API, needs no privileged container, and mounts nothing but the socket.
+  container-stats:
+    image: python:3.12-slim
+    container_name: nim-container-stats
+    restart: unless-stopped
+    command: ["python", "-u", "/app/docker_stats_exporter.py"]
+    volumes:
+      - ./docker_stats_exporter.py:/app/docker_stats_exporter.py:ro
+      # Writable: connecting to a Unix socket needs write permission, so a
+      # read-only mount here fails at connect time rather than at startup.
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - shopping-network
+
+  # GPU utilisation, memory, power and clocks. Distinguishes "the GPUs are
+  # saturated" from "the GPUs are idle and something upstream is the limit" --
+  # a distinction no vLLM metric can make, since the engine only reports on work
+  # that already reached it.
+  dcgm:
+    image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.5-3.4.0-ubuntu22.04
+    container_name: nim-dcgm
+    restart: unless-stopped
+    # Collect every second. The default is 30s, which is longer than many of
+    # the runs here and far longer than a prefill burst -- so the same stale
+    # sample gets scraped repeatedly and utilisation reads zero through work
+    # that plainly happened. Sampling has to be faster than the thing measured.
+    command: ["-c", "1000"]
+    cap_add:
+      - SYS_ADMIN
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu, utility]
+    networks:
+      - shopping-network
+
+networks:
+  # Created by the application's docker-compose.yaml, which pins this name.
+  # Start the app (and the NIM) before starting this stack.
+  shopping-network:
+    external: true
+    name: retail-shopping-assistant_shopping-network
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/monitoring/docker_stats_exporter.py
+++ b/monitoring/docker_stats_exporter.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-container CPU and memory for Prometheus, read from the Docker API.
+
+cAdvisor is the usual answer and does not work here. Docker on this host uses
+the newer `overlayfs` storage driver, and cAdvisor cannot find a container's
+read-write layer under it. That lookup happens while it registers the container,
+so the failure takes CPU and memory down with it: every container falls back to
+a raw cgroup handler keyed by id, with no compose labels, which is unreadable.
+Disabling its disk metrics does not help, because registration still needs them.
+
+So this asks Docker directly, which is where `docker stats` gets its numbers.
+Roughly forty lines against a stable API, versus a tool that has to infer the
+same facts from the filesystem.
+
+Why it is needed at all: the engine's own metrics describe the engine. They
+cannot distinguish a run limited by the GPUs from one limited by the chain
+server, the retriever or Milvus -- and those call for opposite responses. A
+ceiling with the application near idle means the model is the limit; the same
+ceiling with a service pinned at 100% of a core means it is not.
+
+Serves Prometheus text format on :9105/metrics.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SOCKET = os.environ.get("DOCKER_SOCKET", "/var/run/docker.sock")
+PORT = int(os.environ.get("EXPORTER_PORT", "9105"))
+INTERVAL = float(os.environ.get("SAMPLE_INTERVAL", "5"))
+
+
+class _UnixConnection(http.client.HTTPConnection):
+    """http.client over a unix socket, so no third-party dependency is needed."""
+
+    def __init__(self, path: str) -> None:
+        super().__init__("localhost")
+        self._path = path
+
+    def connect(self) -> None:
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.settimeout(30)
+        self.sock.connect(self._path)
+
+
+def _get(path: str):
+    conn = _UnixConnection(SOCKET)
+    try:
+        conn.request("GET", path)
+        return json.loads(conn.getresponse().read())
+    finally:
+        conn.close()
+
+
+def _cpu_percent(stats: dict) -> float:
+    """Percent of one core, matching what `docker stats` prints.
+
+    Expressed against a single core rather than the whole machine, so 250%
+    means two and a half cores. Absolute cores are what capacity planning
+    needs; a percentage of a 128-core host would round everything to zero.
+    """
+
+    cpu, pre = stats.get("cpu_stats", {}), stats.get("precpu_stats", {})
+    used = cpu.get("cpu_usage", {}).get("total_usage", 0) - \
+        pre.get("cpu_usage", {}).get("total_usage", 0)
+    elapsed = cpu.get("system_cpu_usage", 0) - pre.get("system_cpu_usage", 0)
+    cores = cpu.get("online_cpus") or 1
+    return (used / elapsed) * cores * 100 if elapsed > 0 and used > 0 else 0.0
+
+
+def _memory_mib(stats: dict) -> float:
+    """Working set, not raw usage.
+
+    Raw usage counts page cache, which makes an idle container that once read a
+    large file look busy. Subtracting inactive_file is what `docker stats` does
+    and what makes the figure mean "memory this container actually needs".
+    """
+
+    mem = stats.get("memory_stats", {})
+    usage = mem.get("usage", 0)
+    inactive = (mem.get("stats") or {}).get("inactive_file", 0)
+    return max(usage - inactive, 0) / 2**20
+
+
+class Collector(threading.Thread):
+    def __init__(self) -> None:
+        super().__init__(daemon=True)
+        self.lines: list[str] = []
+
+    def sample(self) -> list[str]:
+        out = [
+            "# HELP container_cpu_percent CPU as a percentage of one core.",
+            "# TYPE container_cpu_percent gauge",
+            "# HELP container_memory_mib Working set memory in MiB.",
+            "# TYPE container_memory_mib gauge",
+        ]
+        try:
+            containers = _get("/containers/json")
+        except Exception:
+            return out
+
+        for entry in containers:
+            labels = entry.get("Labels") or {}
+            service = labels.get("com.docker.compose.service")
+            name = (entry.get("Names") or ["?"])[0].lstrip("/")
+            if not service:
+                # Anything not started by compose -- including this host's
+                # Kubernetes pods -- is not part of the system under test and
+                # would only add noise.
+                continue
+            project = labels.get("com.docker.compose.project", "")
+            try:
+                stats = _get(f"/containers/{entry['Id']}/stats?stream=false")
+            except Exception:
+                continue
+            tags = f'service="{service}",project="{project}",name="{name}"'
+            out.append(f"container_cpu_percent{{{tags}}} {_cpu_percent(stats):.2f}")
+            out.append(f"container_memory_mib{{{tags}}} {_memory_mib(stats):.1f}")
+        return out
+
+    def run(self) -> None:
+        while True:
+            started = time.monotonic()
+            self.lines = self.sample()
+            # Each stats call blocks about a second server-side, so a busy host
+            # can take longer to walk than the interval. Sleeping on what is
+            # left, rather than a fixed interval, keeps it from falling behind.
+            time.sleep(max(1.0, INTERVAL - (time.monotonic() - started)))
+
+
+class Handler(BaseHTTPRequestHandler):
+    collector: Collector
+
+    def do_GET(self) -> None:
+        body = ("\n".join(self.collector.lines) + "\n").encode()
+        self.send_response(200 if self.path == "/metrics" else 404)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args) -> None:
+        return
+
+
+def main() -> None:
+    collector = Collector()
+    collector.start()
+    Handler.collector = collector
+    print(f"docker stats exporter on :{PORT}/metrics, every {INTERVAL}s",
+          flush=True)
+    HTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/grafana/dashboards/vllm-official.json
+++ b/monitoring/grafana/dashboards/vllm-official.json
@@ -1,0 +1,2137 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Monitoring vLLM Inference Server",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "End to end request latency measured in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:e2e_request_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:e2e_request_latency_seconds_sum{model_name=\"$model_name\"}[$__rate_interval])\n/\nrate(vllm:e2e_request_latency_seconds_count{model_name=\"$model_name\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Average",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "E2E Request Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of tokens processed per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(vllm:prompt_tokens_total{model_name=\"$model_name\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "Prompt Tokens/Sec",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(vllm:generation_tokens_total{model_name=\"$model_name\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "Generation Tokens/Sec",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Token Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Inter token latency in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:inter_token_latency_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:inter_token_latency_seconds_sum{model_name=\"$model_name\"}[$__rate_interval])\n/\nrate(vllm:inter_token_latency_seconds_count{model_name=\"$model_name\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Mean",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Inter Token Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of requests in RUNNING, WAITING, and SWAPPED state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "vllm:num_requests_running{model_name=\"$model_name\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Num Running",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "vllm:num_requests_waiting{model_name=\"$model_name\"}",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Num Waiting",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        }
+      ],
+      "title": "Scheduler State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "P50, P90, P95, and P99 TTFT latency in seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.9, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "C",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(vllm:time_to_first_token_seconds_bucket{model_name=\"$model_name\"}[$__rate_interval])))",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:time_to_first_token_seconds_sum{model_name=\"$model_name\"}[$__rate_interval])\n/\nrate(vllm:time_to_first_token_seconds_count{model_name=\"$model_name\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Average",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Time To First Token Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Occupancy, not reuse. Fraction of the KV pool held by sequences that are live right now. Blocks retained for prefix reuse count as free here, so this can sit near zero while reuse is working well -- see Prefix Cache Reuse. On this hybrid model a sequence costs a fixed ~0.4% whatever its length, so this tracks concurrency far more than it tracks tokens.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vllm:kv_cache_usage_perc{model_name=\"$model_name\"}",
+          "instant": false,
+          "legendFormat": "GPU Cache Usage",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Heatmap of request prompt length",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 12,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "none"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "min": 0,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto",
+          "value": "Request count"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Prompt Length",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "none"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(le) (increase(vllm:request_prompt_tokens_bucket{model_name=\"$model_name\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Request Prompt Length",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Heatmap of request generation length",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 13,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "cellValues": {
+          "unit": "none"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "min": 0,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto",
+          "value": "Request count"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisLabel": "Generation Length",
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "none"
+        }
+      },
+      "pluginVersion": "11.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(le) (increase(vllm:request_generation_tokens_bucket{model_name=\"$model_name\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Request Generation Length",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of finished requests by their finish reason: either an EOS token was generated or the max sequence length was reached.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "sum by(finished_reason) (increase(vllm:request_success_total{model_name=\"$model_name\"}[$__rate_interval]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Finish Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:request_queue_time_seconds_sum{model_name=\"$model_name\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Queue Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:request_prefill_time_seconds_sum{model_name=\"$model_name\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Prefill",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:request_decode_time_seconds_sum{model_name=\"$model_name\"}[$__rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Decode",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Requests Prefill and Decode Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "default": false,
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "rate(vllm:request_max_num_generation_tokens_sum{model_name=\"$model_name\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Tokens",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Max Generation Token in Sequence Group",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Share of prompt blocks answered from cache instead of prefilled again. This is the metric that says whether reuse is working; Cache Utilization cannot show it. Prefix matching runs from the start of the prompt and stops at the first difference, so anything variable placed early (a date, a session id, history ahead of the tool schemas) makes every token after it a miss however identical it is.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:prefix_cache_hits_total{model_name=\"$model_name\"}[1m]) / clamp_min(rate(vllm:prefix_cache_queries_total{model_name=\"$model_name\"}[1m]), 1)",
+          "instant": false,
+          "legendFormat": "hit rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Prefix Cache Reuse",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The same fact in tokens per second, which is what it costs. The lower band is work the GPUs did not have to repeat; the upper band is prompt text prefilled from scratch. Widening the lower band is usually the cheapest throughput win available on an agent workload, because most of every prompt is text the engine processed moments earlier.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:prompt_tokens_cached_total{model_name=\"$model_name\"}[1m])",
+          "instant": false,
+          "legendFormat": "served from cache",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(vllm:prompt_tokens_total{model_name=\"$model_name\"}[1m]) - rate(vllm:prompt_tokens_cached_total{model_name=\"$model_name\"}[1m])",
+          "instant": false,
+          "legendFormat": "prefilled again",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Prompt Tokens: cached vs prefilled",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Whether the GPUs are the limit. The engine's own metrics only describe work that already reached it, so they cannot tell a saturated GPU from an idle one waiting on something upstream. Sustained high here with throughput flat means the hardware is the ceiling; low here with throughput flat means it is not, and adding GPUs would change nothing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent",
+          "max": 100,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "DCGM_FI_DEV_GPU_UTIL",
+          "instant": false,
+          "legendFormat": "GPU {{gpu}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Utilisation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Weights plus KV cache plus activations. Nearly constant in normal operation, because the engine reserves its pool at startup rather than growing into it -- so this is a sanity check that the expected model is resident, not a live pressure gauge. KV pressure is Cache Utilization.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 56
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "DCGM_FI_DEV_FB_USED",
+          "instant": false,
+          "legendFormat": "GPU {{gpu}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Percent of ONE core, so 250 means two and a half cores. This is how a ceiling gets attributed: if throughput stops rising while every service sits low, the model is the limit and more application replicas buy nothing. If a service is pinned near 100, that service is the limit and replicating it is the fix. Watch chain-server and milvus first.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 40,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "container_cpu_percent{service!~\"grafana|prometheus|dcgm|container-stats|cadvisor\"}",
+          "instant": false,
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Application CPU by service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Working set, excluding page cache. Mostly a leak and sizing check: it should be flat under sustained load. A service climbing steadily through a long run is retaining something per request, which shows up as degradation long before it shows up as a failure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 64
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "container_memory_mib{service!~\"grafana|prometheus|dcgm|container-stats|cadvisor\"}",
+          "instant": false,
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Application memory by service",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "edx8memhpd9tsa"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "nvidia/nemotron-3-super-120b-a12b",
+          "value": "nvidia/nemotron-3-super-120b-a12b"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(model_name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "model_name",
+        "multi": false,
+        "name": "model_name",
+        "options": [],
+        "query": {
+          "query": "label_values(model_name)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "vLLM - Nemotron 3 Super (2x H100 NVL, FP8)",
+  "uid": "b281712d-8bff-41ef-9f3f-71ad43c05e9b",
+  "version": 8,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yaml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: vllm
+    orgId: 1
+    folder: vLLM
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yaml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+datasources:
+  - name: prometheus
+    type: prometheus
+    access: proxy
+    # Service name, not localhost: Grafana queries Prometheus from inside its
+    # own container, and both join the application's shopping-network. The host
+    # port published for Prometheus is for humans and SSH tunnels, and is not
+    # reachable from in here -- localhost would resolve to Grafana itself.
+    url: http://prometheus:9090
+    isDefault: true
+    # This uid is not arbitrary. vLLM's official dashboard ships with its
+    # DS_PROMETHEUS template variable defaulting to uid "edx8memhpd9tsa".
+    # Provisioning the datasource under that uid lets the dashboard load
+    # unmodified, instead of opening with "datasource not found" until someone
+    # picks it by hand.
+    uid: edx8memhpd9tsa
+    editable: false

--- a/monitoring/prometheus.yaml
+++ b/monitoring/prometheus.yaml
@@ -1,0 +1,36 @@
+# Scrape config for a locally deployed LLM NIM.
+#
+# The target is the compose service name, not a host port. Prometheus runs on the
+# application's network, so `nemotron:8000` resolves regardless of whether the NIM
+# publishes a host port -- and keeps working if that published port changes.
+#
+# If you serve the app LLM from a different local NIM service, change the target
+# to match its service name in docker-compose-nim-local.yaml.
+
+global:
+  scrape_interval: 5s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: vllm
+    static_configs:
+      - targets:
+          - 'nemotron:8000'
+
+  # Per-container CPU and memory for every service in the stack, so a ceiling can
+  # be attributed to the component that caused it rather than assumed to be the
+  # GPU. Scraped more slowly than the engine: these move on the scale of seconds,
+  # not milliseconds, and cAdvisor is comparatively expensive to scrape.
+  - job_name: containers
+    scrape_interval: 10s
+    static_configs:
+      - targets:
+          - 'container-stats:9105'
+
+  # GPU-side truth. Needed to tell a saturated GPU apart from an idle one waiting
+  # on something upstream.
+  - job_name: dcgm
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+          - 'dcgm:9400'

--- a/tests/evaluation/src/replay.py
+++ b/tests/evaluation/src/replay.py
@@ -149,6 +149,7 @@ class Assistant:
                 payload["image_bool"] = True
 
         started = time.monotonic()
+        first_token: float | None = None
         reply, products, diagnostics = "", [], {}
         with requests.post(
             self._url, json=payload, timeout=self._timeout, stream=True
@@ -161,6 +162,15 @@ class Assistant:
                 event = json.loads(line[6:])
                 body = event.get("payload")
                 if event.get("type") == "content":
+                    # First words on screen, which is what a shopper waiting at
+                    # the page actually experiences. The turn keeps running long
+                    # after this -- tools, the grounding pass, the cart -- so
+                    # total seconds describes the system's work and this
+                    # describes the wait. Under load they diverge sharply, and
+                    # sizing against the wrong one either wastes hardware or
+                    # promises a page that sits blank.
+                    if first_token is None and body:
+                        first_token = time.monotonic() - started
                     reply = body or ""
                 elif event.get("type") == "products" and isinstance(body, list):
                     products = body
@@ -188,6 +198,9 @@ class Assistant:
                 for scope in ((call.get("arguments") or {}).get("scopes") or [])
             ],
             "seconds": round(time.monotonic() - started, 1),
+            # None if the turn produced no content at all, which is a failure
+            # worth telling apart from a fast one rather than recording as 0.
+            "ttft": round(first_token, 2) if first_token is not None else None,
         }
 
     def cart(self, user_id: int) -> list[dict[str, Any]]:


### PR DESCRIPTION
Rebased onto latest `staging`, so this is linear commits with no merge commit.

**This branch changes no NIM configuration.** It is measurement tooling and
documentation only. `docker-compose-nim-local.yaml` is byte-for-byte identical
to `staging` — the engine arguments are already correct there, and #217 owns the
one remaining config change, so nothing here competes for that file.

**It deliberately carries no measured results.** Throughput and latency depend on
the GPU, the model profile, the catalog and the env profile, so a number recorded
here would be read as a target on hardware it never described. The guide teaches
you to produce your own.

## What this adds

**An observability stack** (`monitoring/`). Prometheus and Grafana against the
NIM's own metrics, DCGM for the GPUs, and a small exporter for per-container CPU
and memory. The last one matters because a run limited by Milvus, the chain
server or the retriever is otherwise indistinguishable from one limited by the
GPUs, and those call for opposite responses.

**Benchmarking tools** (`benchmarks/`), kept separate from the stack that
collects the results. Load generators and a concurrency sweep that polls the
engine's own counters for what a load generator cannot see from outside — queue
depth, KV usage, preemptions — plus a per-turn profiler that reconciles app
timings, engine counters and Phoenix spans, and three harnesses that drive whole
journeys under concurrency.

**A guide that leads a developer through it** — [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md).
Six preflight checks, then a ladder of six steps in the order that makes each one
interpretable, then a walkthrough of every script, then the pitfalls. The bottom
rung — how many users can we serve — is not defensible without the rungs above it.

## Why the order is the point

The guide's main claim is that these measurements are only meaningful in sequence,
and two steps in particular cannot be skipped.

**Take the token shape from your own deployment before sweeping.** This
application reads far more than it writes. A sweep at a benchmark's default 1:1
shape answers a question about a workload nobody runs, and on our hardware the
two shapes differed by roughly 8× on identical silicon.

**Verify tool calling and prefix caching resolved as asked before believing any
figure.** Both fail silently and both change what you are measuring rather than
stopping it. If the parser cannot read the model's output, vLLM returns the tool
call as plain text, the agent answers without ever searching the catalog, and
every latency number describes a much cheaper application than the one we ship.
Prefix caching being unset does not mean default-on; vLLM disables it for hybrid
attention models unless told otherwise.

## The measurement that measured nothing

Worth reading even if you skip the rest, because it is the reason
`shopper_study.py` looks the way it does. An earlier harness reported **1,216
completed turns with zero errors against a model that answered none of them.**

When a model call fails, the application returns canned text — "I could not
complete that shopping request." That text streams like any other reply: it has a
first-token time and raises no exception. A harness timing first tokens and
counting exceptions cannot tell a dead server from a working one.

`shopper_study.py` now applies three independent checks per level — probe the
model server before and after, confirm `vllm:prompt_tokens_total` advanced, and
match the application's failure strings in the replies — and aborts rather than
climbing into levels that would repeat it.

## Corrections to the existing guide

The document previously claimed **under 8% of a shopper's wait was the model
doing arithmetic**, from a 61-second turn. That turn was measured while the
tool-call parser could not read this model's output, so the agent answered
without ever searching the catalog. The old figure pointed optimisation effort at
the wrong 40 seconds. The claim is removed rather than replaced with a new
number, for the reason given above.

It also said prefix caching was off and that no CPU monitoring existed. Both have
since been fixed, and the guidance now reflects that.

## Reviewing this

Start with [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md); the ladder and "Pitfalls
that produce confident, wrong numbers" carry most of the value. The two README
files, [`benchmarks/`](benchmarks/README.md) and
[`monitoring/`](monitoring/README.md), are maps of what is in each directory.

Everything is additive apart from four one-line path updates in
`docker-compose.scale.yaml`, `.env.local-llm.example`, `docs/README.md` and
`README.md`, which follow the scripts that moved into `benchmarks/`.
