### PR TITLE
Fix tool calling on the local Nemotron NIM (wrong tool-call parser)

### DIFF
--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -9,7 +9,14 @@ services:
       - "8000:8000"
     environment:
       - NGC_API_KEY=${NGC_API_KEY}
-      - NIM_PASSTHROUGH_ARGS=--enable-auto-tool-choice --tool-call-parser pythonic --max-num-seqs 256
+      # qwen3_coder, not pythonic: this image emits XML-form tool calls
+      # (<tool_call><function=><parameter=>), which the pythonic parser cannot
+      # read at all -- vLLM then returns the call as ordinary text with no
+      # tool_calls, so the agent silently answers without ever calling a tool.
+      # Of the parsers that do read that form, only qwen3_coder json-decodes
+      # array and object arguments; qwen3_xml returns them as raw strings, which
+      # fails validation for every structured tool this app defines.
+      - NIM_PASSTHROUGH_ARGS=${NIM_PASSTHROUGH_ARGS:---enable-auto-tool-choice --tool-call-parser qwen3_coder --max-num-seqs 256}
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
     user: "${NIM_UID:-1000}"


### PR DESCRIPTION
The local-NIM profile starts the shopper LLM with `--tool-call-parser pythonic`. This NIM image does not emit pythonic tool calls, so no tool call is ever parsed and the agent answers every shopper request without searching the catalog. Switching to `qwen3_coder` fixes it.

- **Symptom:** every product query returns a plausible "I don't have any black dresses under $100" answer. The catalog is indexed and the retriever returns those products when called directly, so the failure looks like bad retrieval when it is not.
- **Cause:** the image emits `<tool_call><function=...><parameter=...>` XML. The pythonic parser cannot read that form, so vLLM returns the call as ordinary assistant text with `finish_reason: stop` and no `tool_calls`. Reproducible against the NIM directly, with no app involved.
- **Fix:** `--tool-call-parser qwen3_coder`, the parser this model's output matches and the one the standalone vLLM deployment of the same checkpoint already used. It is also the only parser reading that form that json-decodes `array` and `object` arguments; `qwen3_xml` returns them as raw strings, which fails validation for every structured tool this app defines.
- **Also:** `NIM_PASSTHROUGH_ARGS` is now overridable so the parser can be changed without editing the file.

No application code changes.

## Verification

Same stack, same catalog, only the parser changed.

| query | before | after |
|---|---|---|
| black dresses under $100 | no tool call, 0 products | `search_catalog_tool` completed, 3 products |
| red shoes | no tool call, 0 products | `search_catalog_tool` completed, 4 products |
| add first to cart | nothing to add | `resolve_conversation_products_tool` + `add_cart_items_tool` completed |

Cross-checked against the hosted endpoint, which parses tool calls server-side: it returned the same 3 dresses with `scopes` as a list, confirming the app was correct and only local NIM parsing was at fault.