### PR TITLE
Stop publishing milvus-etcd on host port 2379

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -223,8 +223,11 @@ services:
   etcd:
     container_name: milvus-etcd
     image: quay.io/coreos/etcd:v3.5.5
-    ports:
-      - "2379:2379"
+    # Deliberately not published to the host. milvus-standalone reaches this
+    # over the shopping-network as http://etcd:2379, so nothing outside the
+    # network needs it -- and 2379 is etcd's well-known port, so publishing it
+    # fails to start on any host already running one (a Kubernetes control
+    # plane, most commonly).
     environment:
       - ETCD_AUTO_COMPACTION_MODE=revision
       - ETCD_AUTO_COMPACTION_RETENTION=1000


### PR DESCRIPTION
`milvus-etcd` publishes container port 2379 to the host, but nothing outside the Compose network ever connects to it. On any host already running an etcd — a Kubernetes control plane being the common case — the bind fails and the stack cannot start.

- **Symptom:** `milvus-etcd` never starts, so `milvus-standalone` has no metadata store, the catalog cannot be indexed, and product search returns nothing. The visible failure is a shopping assistant that confidently reports no matching products.
- **Cause:** 2379 is etcd's well-known port and is frequently already bound. Docker cannot bind a host port twice.
- **Fix:** drop the `ports:` entry. `milvus-standalone` already reaches etcd over the shopping-network via `ETCD_ENDPOINTS: http://etcd:2379`, which is unaffected.

Verified no other reference to etcd on the host exists; the only `2379` occurrences are etcd's own listen address and Milvus's internal endpoint. `docker compose config` validates.

The only thing given up is host-side debugging via `curl localhost:2379`, still available through `docker compose exec`.