### PR TITLE
Ask for prefix caching on the local NIM instead of letting vLLM decide

### DIFF
--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -17,6 +17,25 @@ services:
       # array and object arguments; qwen3_xml returns them as raw strings, which
       # fails validation for every structured tool this app defines.
       - NIM_PASSTHROUGH_ARGS=${NIM_PASSTHROUGH_ARGS:---enable-auto-tool-choice --tool-call-parser qwen3_coder --max-num-seqs 256}
+      # Set explicitly, because unset does not mean "default on" -- it means vLLM
+      # chooses, and vLLM disables prefix caching for every model whose attention
+      # type is hybrid, calling the feature experimental. It does not consult the
+      # model, even though NemotronHForCausalLM declares SupportsMambaPrefixCaching.
+      # This model is hybrid, so it is caught by that blanket rule and the shared
+      # prefix of every agent call is prefilled again from scratch.
+      #
+      # Worth caring about here because an agent turn makes several model calls
+      # that each re-send the same system prompt, tool schemas and conversation,
+      # so most of each prompt is text the engine processed moments earlier.
+      #
+      # Confirm it took effect -- the engine publishes what it resolved, which is
+      # not always what was asked for:
+      #   curl -s localhost:8000/metrics | grep cache_config_info
+      # Expect enable_prefix_caching="True", and mamba_block_size to drop to the
+      # attention block size, which is what makes the recurrent state reusable.
+      #
+      # Set to 0 to compare against, or if a future image regresses here.
+      - NIM_ENABLE_KV_CACHE_REUSE=${NIM_ENABLE_KV_CACHE_REUSE:-1}
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
     user: "${NIM_UID:-1000}"

--- a/docker-compose-nim-local.yaml
+++ b/docker-compose-nim-local.yaml
@@ -36,6 +36,25 @@ services:
       #
       # Set to 0 to compare against, or if a future image regresses here.
       - NIM_ENABLE_KV_CACHE_REUSE=${NIM_ENABLE_KV_CACHE_REUSE:-1}
+      # Left to the NIM by default, because the right profile depends on the
+      # hardware it finds. Pin it when comparing measurements across runs:
+      # selection reads *free* GPU memory at startup, and this image also offers
+      # a BF16 profile it considers runnable, so precision -- and every number
+      # downstream of it -- can otherwise move between runs depending on what
+      # happened to be resident.
+      #
+      #   # FP8, tensor parallel 2, needs >=65GB on each of 2 GPUs
+      #   NIM_MODEL_PROFILE=57d42cc7d33914933427e7f8d8cb1773bc11e5c96826c92095820a8776e6a4f6 \
+      #     docker compose -f docker-compose-nim-local.yaml up -d nemotron
+      #
+      # `list-model-profiles` in the image shows what your hardware offers.
+      #
+      # Declared bare, with no `=`, so it is passed through only when set in the
+      # shell and omitted from the container otherwise. That distinction matters
+      # here: `${NIM_MODEL_PROFILE:-}` would hand the NIM an empty string, and
+      # the profile is looked up as `profile_id in manifest`, so "" reads as a
+      # profile that does not exist rather than as a request to choose one.
+      - NIM_MODEL_PROFILE
     volumes:
       - ${LOCAL_NIM_CACHE}:/opt/nim/.cache
     user: "${NIM_UID:-1000}"


### PR DESCRIPTION
## What

Sets `NIM_ENABLE_KV_CACHE_REUSE=1` for the local Nemotron NIM, overridable.

## Why

- Unset is not a default. The variable is three-state with no default, so vLLM chooses — and vLLM disables prefix caching for any model with hybrid attention, calling the feature experimental.
- It applies that rule without asking the model, even though `NemotronHForCausalLM` declares `SupportsMambaPrefixCaching` by name.
- Nemotron-3 Super is hybrid, so the running engine reported `enable_prefix_caching="False"` and never consulted the cache.
- Poor fit for this app: an agent turn makes several model calls that each re-send the same system prompt, tool schemas and conversation, so most of every prompt was processed moments earlier.

## Effect

Resolved engine config, via `curl -s localhost:8000/metrics | grep cache_config_info`:

| Label | Before | After |
|---|---|---|
| `enable_prefix_caching` | `False` | `True` |
| `mamba_block_size` | `262144` | `16` |

### What the second row means

It is the row that tells you the Mamba half of the model is actually participating, and it is worth understanding because it is *derived* rather than set.

Attention layers cache per-token K/V, so prefix caching chunks tokens into blocks, hashes them, and reuses any block whose prefix matches. Mamba layers have no such structure. An SSM layer carries a single fixed-size recurrent state that it updates as it scans, so the state after token N is a summary of tokens 0..N, with nothing per-token to index into. Resuming mid-prefix therefore requires a *snapshot* of that recurrent state, taken at exactly the boundary you want to resume from. `mamba_block_size` is how often those snapshots are taken, in tokens.

At `262144` — which is `max_model_len` — the first snapshot boundary sits further out than the model's entire context window, so in practice no resume point ever exists. The attention half can match a prefix while the Mamba half has no state to resume from at that position, and the result is that nothing is reusable. At `16`, the attention block size, both halves checkpoint on the same boundaries, so a prefix boundary means the same thing throughout the layer stack.

Neither value is configured here. They are the two branches of one condition in `vllm/model_executor/models/config.py`:

```python
# When enabling prefix caching, we align mamba block size
# to the block size as the basic granularity for prefix caching.
if cache_config.mamba_block_size is None:
    cache_config.mamba_block_size = cache_config.block_size
else:
    ...
    if cache_config.mamba_block_size is None:
        cache_config.mamba_block_size = model_config.max_model_len
```

So `262144` → `16` is a consequence of `enable_prefix_caching` becoming `True`, not a second change. That makes it a useful check after any edit to this file: prefix caching reporting `True` while `mamba_block_size` is still at `max_model_len` would mean something overrode the alignment and the Mamba layers are not taking part.

The snapshots are not free — each one is the full conv and SSM state for every Mamba layer — which is what `mamba_cache_mode` governs. Once prefix caching is enabled it defaults to `align`, storing state at the last token of each scheduler step and when that lands on a block boundary, rather than `all`, which stores at every boundary. `align` requires chunked prefill, and the block size must be a multiple of 8 to satisfy the `causal_conv1d` kernel.

## Scope

**This is about the deployment being configured as intended, not about how much it wins.**

An earlier revision of this description reported that the cache was consulted but returned zero hits and no benefit. That observation came from a synthetic sweep, and as that same revision noted, random prompts share no prefix and so cannot show the effect either way. Measured since against real shopper journeys — which do re-send a system prompt, tool schemas and conversation history on every call — the cache is consulted and does return hits. The zero-hit claim is therefore withdrawn rather than restated.

Quantifying the benefit is deliberately not part of this PR. [`docs/PERFORMANCE.md`](docs/PERFORMANCE.md), merged in #213, describes how to measure it on your own hardware, which is the only figure worth acting on: the result depends on the GPU, the model profile and the workload's prompt structure.

**Correctness remains untested.** vLLM warns this path may produce incorrect outputs for hybrid models. The variable stays overridable so both cases can be compared without editing the file.

## Also: a way to pin the model profile

Rebased onto latest `staging`, and picks up one more knob for the same file, moved here out of #213 — that branch is measurement tooling and documentation, and had no business shipping NIM configuration. This PR now owns every config change to `docker-compose-nim-local.yaml`, so the two no longer compete for it.

Unset, the NIM picks a profile by reading *free* GPU memory at startup, and this image also offers a BF16 profile it will accept. So precision, and every measurement downstream of it, can move between runs depending on what happened to be resident. Anyone comparing two runs needs to hold that still.

**Default behaviour is unchanged** — the profile is still left to the NIM, because the right one depends on the hardware and this file should keep working on hardware that isn't two H100 NVLs.

It is declared **bare, with no `=`**, which is the part worth reviewing:

```yaml
- NIM_MODEL_PROFILE
```

That passes the variable through only when it is set in the shell, and omits it from the container otherwise. The obvious `${NIM_MODEL_PROFILE:-}` would instead hand the NIM an empty string on every normal startup, and the profile is resolved as `profile_id in manifest` (`nimlib/model_manifest.py:213`), so `""` reads as a profile that does not exist rather than as a request to choose one.

Verified rather than assumed, since compose's own docs are easy to misread here:

| `NIM_MODEL_PROFILE` in shell | In the container |
|---|---|
| unset | absent entirely |
| set | passed through |

## Test plan

- [ ] Confirm `cache_config_info` reports `enable_prefix_caching="True"` and `mamba_block_size` equal to the attention block size once the NIM is up
- [ ] Run a fixed set of shopper turns with the flag on and off, comparing tool calls chosen and products returned
- [ ] Start the NIM with `NIM_MODEL_PROFILE` unset and confirm it still auto-selects, then with it set and confirm the chosen profile in the startup logs
